### PR TITLE
Implement Wii VC Round-to-Zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ commit.txt
 /tasinput_plugin/src/UpgradeLog.htm
 /tasinput_plugin/src/stdout.txt
 /tasinput_plugin/src/config.aps
-/.vs/TASInputDragfix/v16
-/.vs/VSWorkspaceState.json
-/.vs/slnx.sqlite
-/.vs/ProjectSettings.json
+.vs/
+plugins/
+winproject/save
+winproject/plugin

--- a/main/win/Config.c
+++ b/main/win/Config.c
@@ -33,6 +33,7 @@
 
 extern int no_audio_delay;
 extern int no_compiled_jump;
+extern int round_to_zero;
 
 ////////////////////// Service functions and structures ////////////////////////
 
@@ -170,7 +171,7 @@ void LoadConfig()
     Config.GuiToolbar = ReadCfgInt("Advanced", "Use Toolbar", 0);
     Config.GuiStatusbar = ReadCfgInt("Advanced", "Use Statusbar", 1);
     Config.AutoIncSaveSlot = ReadCfgInt("Advanced", "Auto Increment Save Slot", 0);
-    Config.RoundToZero = ReadCfgInt("Advanced", "Round To Zero", 0);
+    round_to_zero = ReadCfgInt("Advanced", "Round To Zero", 0);
     
     //Compatibility Settings
     no_audio_delay = ReadCfgInt("Compatibility","No Audio Delay", 0);
@@ -328,7 +329,7 @@ void SaveConfig()
     WriteCfgInt( "Advanced", "Use Toolbar", Config.GuiToolbar);
     WriteCfgInt( "Advanced", "Use Statusbar", Config.GuiStatusbar);
     WriteCfgInt( "Advanced", "Auto Increment Save Slot", Config.AutoIncSaveSlot);
-    WriteCfgInt( "Advanced", "Round To Zero", Config.RoundToZero);
+    WriteCfgInt( "Advanced", "Round To Zero", round_to_zero);
     
     WriteCfgInt( "CPU", "Core", Config.guiDynacore);
     

--- a/main/win/Config.c
+++ b/main/win/Config.c
@@ -164,12 +164,13 @@ void LoadConfig()
     
     
     //Advanced vars
-    Config.StartFullScreen = ReadCfgInt("Advanced","Start Full Screen",0);
-    Config.PauseWhenNotActive = ReadCfgInt("Advanced","Pause when not active",1);
-    Config.OverwritePluginSettings = ReadCfgInt("Advanced","Overwrite Plugins Settings ",0);
-    Config.GuiToolbar = ReadCfgInt( "Advanced", "Use Toolbar", 0);
-    Config.GuiStatusbar = ReadCfgInt( "Advanced", "Use Statusbar", 1);
-    Config.AutoIncSaveSlot = ReadCfgInt( "Advanced", "Auto Increment Save Slot", 0);
+    Config.StartFullScreen = ReadCfgInt("Advanced", "Start Full Screen", 0);
+    Config.PauseWhenNotActive = ReadCfgInt("Advanced", "Pause when not active", 1);
+    Config.OverwritePluginSettings = ReadCfgInt("Advanced", "Overwrite Plugins Settings", 0);
+    Config.GuiToolbar = ReadCfgInt("Advanced", "Use Toolbar", 0);
+    Config.GuiStatusbar = ReadCfgInt("Advanced", "Use Statusbar", 1);
+    Config.AutoIncSaveSlot = ReadCfgInt("Advanced", "Auto Increment Save Slot", 0);
+    Config.RoundToZero = ReadCfgInt("Advanced", "Round To Zero", 0);
     
     //Compatibility Settings
     no_audio_delay = ReadCfgInt("Compatibility","No Audio Delay", 0);
@@ -327,6 +328,7 @@ void SaveConfig()
     WriteCfgInt( "Advanced", "Use Toolbar", Config.GuiToolbar);
     WriteCfgInt( "Advanced", "Use Statusbar", Config.GuiStatusbar);
     WriteCfgInt( "Advanced", "Auto Increment Save Slot", Config.AutoIncSaveSlot);
+    WriteCfgInt( "Advanced", "Round To Zero", Config.RoundToZero);
     
     WriteCfgInt( "CPU", "Core", Config.guiDynacore);
     

--- a/main/win/configdialog.c
+++ b/main/win/configdialog.c
@@ -843,6 +843,7 @@ BOOL CALLBACK AdvancedSettingsProc(HWND hwnd, UINT Message, WPARAM wParam, LPARA
          WriteCheckBoxValue( hwnd, IDC_GUI_TOOLBAR, Config.GuiToolbar);
          WriteCheckBoxValue( hwnd, IDC_GUI_STATUSBAR, Config.GuiStatusbar);
          WriteCheckBoxValue( hwnd, IDC_AUTOINCSAVESLOT, Config.AutoIncSaveSlot);
+         WriteCheckBoxValue( hwnd, IDC_ROUNDTOZERO, Config.RoundToZero);
                   
          WriteCheckBoxValue( hwnd, IDC_NO_AUDIO_DELAY, no_audio_delay);
          WriteCheckBoxValue( hwnd, IDC_NO_COMPILED_JUMP, no_compiled_jump);
@@ -871,7 +872,8 @@ BOOL CALLBACK AdvancedSettingsProc(HWND hwnd, UINT Message, WPARAM wParam, LPARA
                 Config.OverwritePluginSettings =  ReadCheckBoxValue( hwnd, IDC_PLUGIN_OVERWRITE);
                 Config.GuiToolbar =  ReadCheckBoxValue( hwnd, IDC_GUI_TOOLBAR);
                 Config.GuiStatusbar = ReadCheckBoxValue( hwnd, IDC_GUI_STATUSBAR);
-	        Config.AutoIncSaveSlot = ReadCheckBoxValue( hwnd, IDC_AUTOINCSAVESLOT);
+	            Config.AutoIncSaveSlot = ReadCheckBoxValue( hwnd, IDC_AUTOINCSAVESLOT);
+                Config.RoundToZero = ReadCheckBoxValue( hwnd, IDC_ROUNDTOZERO);
                                                                                                
                 no_audio_delay = ReadCheckBoxValue( hwnd, IDC_NO_AUDIO_DELAY);
                 no_compiled_jump = ReadCheckBoxValue( hwnd, IDC_NO_COMPILED_JUMP);

--- a/main/win/configdialog.c
+++ b/main/win/configdialog.c
@@ -52,6 +52,7 @@ HWND hwndTrack ;
 
 extern int no_audio_delay;
 extern int no_compiled_jump;
+extern int round_to_zero;
 
 void WriteCheckBoxValue( HWND hwnd, int resourceID , int value)
 {
@@ -843,7 +844,7 @@ BOOL CALLBACK AdvancedSettingsProc(HWND hwnd, UINT Message, WPARAM wParam, LPARA
          WriteCheckBoxValue( hwnd, IDC_GUI_TOOLBAR, Config.GuiToolbar);
          WriteCheckBoxValue( hwnd, IDC_GUI_STATUSBAR, Config.GuiStatusbar);
          WriteCheckBoxValue( hwnd, IDC_AUTOINCSAVESLOT, Config.AutoIncSaveSlot);
-         WriteCheckBoxValue( hwnd, IDC_ROUNDTOZERO, Config.RoundToZero);
+         WriteCheckBoxValue( hwnd, IDC_ROUNDTOZERO, round_to_zero);
                   
          WriteCheckBoxValue( hwnd, IDC_NO_AUDIO_DELAY, no_audio_delay);
          WriteCheckBoxValue( hwnd, IDC_NO_COMPILED_JUMP, no_compiled_jump);
@@ -873,7 +874,7 @@ BOOL CALLBACK AdvancedSettingsProc(HWND hwnd, UINT Message, WPARAM wParam, LPARA
                 Config.GuiToolbar =  ReadCheckBoxValue( hwnd, IDC_GUI_TOOLBAR);
                 Config.GuiStatusbar = ReadCheckBoxValue( hwnd, IDC_GUI_STATUSBAR);
 	            Config.AutoIncSaveSlot = ReadCheckBoxValue( hwnd, IDC_AUTOINCSAVESLOT);
-                Config.RoundToZero = ReadCheckBoxValue( hwnd, IDC_ROUNDTOZERO);
+                round_to_zero = ReadCheckBoxValue( hwnd, IDC_ROUNDTOZERO);
                                                                                                
                 no_audio_delay = ReadCheckBoxValue( hwnd, IDC_NO_AUDIO_DELAY);
                 no_compiled_jump = ReadCheckBoxValue( hwnd, IDC_NO_COMPILED_JUMP);

--- a/main/win/main_win.h
+++ b/main/win/main_win.h
@@ -98,7 +98,7 @@ typedef struct _CONFIG {
     BOOL GuiToolbar;
     BOOL GuiStatusbar;
     BOOL AutoIncSaveSlot;
-    BOOL RoundToZero;
+    //BOOL RoundToZero;
     
     //Compatibility Options
     //BOOL NoAudioDelay;
@@ -142,6 +142,6 @@ typedef struct _CONFIG {
 		char LuaScriptPath[MAX_PATH];
 } CONFIG;
 
-extern CONFIG Config;
+extern "C" CONFIG Config;
 
 #endif

--- a/main/win/main_win.h
+++ b/main/win/main_win.h
@@ -98,6 +98,7 @@ typedef struct _CONFIG {
     BOOL GuiToolbar;
     BOOL GuiStatusbar;
     BOOL AutoIncSaveSlot;
+    BOOL RoundToZero;
     
     //Compatibility Options
     //BOOL NoAudioDelay;

--- a/main/win/translation.c
+++ b/main/win/translation.c
@@ -526,6 +526,9 @@ void TranslateAdvancedDialog(HWND hwnd)
     SetItemTranslatedString(hwnd,IDC_COLUMN_COMMENTS,"Comments");
     SetItemTranslatedString(hwnd,IDC_COLUMN_FILENAME,"File Name");
     SetItemTranslatedString(hwnd,IDC_COLUMN_MD5,"MD5");
+    
+    SetItemTranslatedString(hwnd, IDC_WIIVC_OPTIONS, "Wii VC Options");
+    SetItemTranslatedString(hwnd, IDC_ROUNDTOZERO, "Round To Zero");
          
 }
 

--- a/r4300/cop0.c
+++ b/r4300/cop0.c
@@ -144,7 +144,7 @@ void MTC0()
       case 15:  // PRevID
 	break;
       case 16:  // Config
-	Config = rrt;
+	Config_cop0 = rrt;
 	break;
       case 18:  // WatchLo
 	WatchLo = rrt & 0xFFFFFFFF;

--- a/r4300/cop1_d.c
+++ b/r4300/cop1_d.c
@@ -173,7 +173,11 @@ void FLOOR_W_D()
 void CVT_S_D()
 {
    if (check_cop1_unusable()) return;
-   set_rounding();
+   if (round_to_zero) {
+       set_trunc();
+   } else {
+       set_rounding();
+   }
    *reg_cop1_simple[cffd] = *reg_cop1_double[cffs];
    PC++;
 }

--- a/r4300/cop1_s.c
+++ b/r4300/cop1_s.c
@@ -172,7 +172,11 @@ void FLOOR_W_S()
 void CVT_D_S()
 {
    if (check_cop1_unusable()) return;
-   set_rounding();
+   if (round_to_zero) {
+       set_trunc();
+   } else {
+       set_rounding();
+   }
    *reg_cop1_double[cffd] = *reg_cop1_simple[cffs];
    PC++;
 }

--- a/r4300/macros.h
+++ b/r4300/macros.h
@@ -95,7 +95,7 @@ stop=1; \
 #define Cause reg_cop0[13]
 #define EPC reg_cop0[14]
 #define PRevID reg_cop0[15]
-#define Config reg_cop0[16]
+#define Config_cop0 reg_cop0[16]
 #define LLAddr reg_cop0[17]
 #define WatchLo reg_cop0[18]
 #define WatchHi reg_cop0[19]

--- a/r4300/pure_interp.c
+++ b/r4300/pure_interp.c
@@ -1114,7 +1114,7 @@ static void MTC0()
       case 15:  // PRevID
 	break;
       case 16:  // Config
-	Config = rrt;
+	Config_cop0 = rrt;
 	break;
       case 18:  // WatchLo
 	WatchLo = rrt & 0xFFFFFFFF;

--- a/r4300/pure_interp.c
+++ b/r4300/pure_interp.c
@@ -1402,7 +1402,11 @@ static void FLOOR_W_S()
 
 static void CVT_D_S()
 {
-   set_rounding();
+   if (round_to_zero) {
+       set_trunc();
+   } else {
+       set_rounding();
+   }
    *reg_cop1_double[cffd] = *reg_cop1_simple[cffs];
    interp_addr+=4;
 }
@@ -1728,7 +1732,11 @@ static void FLOOR_W_D()
 
 static void CVT_S_D()
 {
-   set_rounding();
+   if (round_to_zero) {
+       set_trunc();
+   } else {
+       set_rounding();
+   }
    *reg_cop1_simple[cffd] = *reg_cop1_double[cffs];
    interp_addr+=4;
 }

--- a/r4300/r4300.c
+++ b/r4300/r4300.c
@@ -1568,7 +1568,7 @@ void go()
    
    Random = 31;
    Status= 0x34000000;
-   Config= 0x6e463;
+   Config_cop0= 0x6e463;
    PRevID = 0xb00;
    Count = 0x5000;
    Cause = 0x5C;

--- a/r4300/r4300.c
+++ b/r4300/r4300.c
@@ -49,6 +49,7 @@ extern void update_debugger();
 unsigned long i, dynacore = 0, interpcore = 0;
 int no_audio_delay = 0;
 int no_compiled_jump = 0;
+int round_to_zero = 0;
 int stop, llbit;
 long long int reg[32], hi, lo;
 long long int local_rs, local_rt;

--- a/r4300/r4300.h
+++ b/r4300/r4300.h
@@ -63,6 +63,7 @@ extern char invalid_code[0x100000];
 extern unsigned long jump_to_address;
 extern int no_audio_delay;
 extern int no_compiled_jump;
+extern int round_to_zero;
 
 void go();
 void pure_interpreter();

--- a/r4300/x86/gcop1_d.c
+++ b/r4300/x86/gcop1_d.c
@@ -277,10 +277,16 @@ void gencvt_s_d()
    gencallinterp((unsigned long)CVT_S_D, 0);
 #else
    gencheck_cop1_unusable();
+   if (round_to_zero) {
+	   fldcw_m16((unsigned short*)&trunc_mode);
+   }
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_simple[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
+   if (round_to_zero) {
+	   fldcw_m16((unsigned short*)&rounding_mode);
+   }
 #endif
 }
 

--- a/r4300/x86/gcop1_s.c
+++ b/r4300/x86/gcop1_s.c
@@ -276,10 +276,16 @@ void gencvt_d_s()
    gencallinterp((unsigned long)CVT_D_S, 0);
 #else
    gencheck_cop1_unusable();
+   if (round_to_zero) {
+	   fldcw_m16((unsigned short*)&trunc_mode);
+   }
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
+   if (round_to_zero) {
+       fldcw_m16((unsigned short*)&rounding_mode);
+   }
 #endif
 }
 

--- a/winproject/debugview.ini
+++ b/winproject/debugview.ini
@@ -1,9 +1,9 @@
 
 [common]
-x                              = 1011
-y                              = 171
-width                          = 401
-height                         = 619
+x                              = 1542
+y                              = 140
+width                          = 487
+height                         = 206
 showtoolbar                    = 1
 showstatusbar                  = 1
 
@@ -17,7 +17,7 @@ transperency                   = 0
 alphalevel                     = 220
 column1width                   = 30
 column2width                   = 60
-column3width                   = 265
+column3width                   = 216
 filtering                      = 0
 
 [logfile]

--- a/winproject/mupen64/mupen64_2017.vcxproj
+++ b/winproject/mupen64/mupen64_2017.vcxproj
@@ -19,25 +19,25 @@
     <ProjectGuid>{83B5BB38-A6A7-432B-AF4D-2AE840F5621C}</ProjectGuid>
     <RootNamespace>mupen64</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/winproject/resource.h
+++ b/winproject/resource.h
@@ -227,6 +227,7 @@
 #define IDC_NO_COMPILED_JUMP            5516
 #define IDC_AUTOINCSAVESLOT             5517
 #define IDD_HOTKEY_CONFIG               5518
+#define IDC_WIIVC_OPTIONS               5519
 
 #define ID_RECENTROMS_RESET             6000
 #define ID_RECENTROMS_FREEZE            6001
@@ -399,7 +400,9 @@
 
 
 
-#define ID_LANG_ENGLISH            10000
+#define ID_LANG_ENGLISH                 10000
+
+#define IDC_ROUNDTOZERO                 10002
 
     
 

--- a/winproject/rsrc.rc
+++ b/winproject/rsrc.rc
@@ -191,24 +191,26 @@ IDD_ADVANCED_OPTIONS DIALOGEX 0, 0, 231, 262
 STYLE DS_MODALFRAME | DS_SETFONT | WS_POPUP
 FONT 8, "Tahoma", 0, 0, 0
 {
-    GROUPBOX        "Common Options", IDC_COMMON, 7, 7, 215, 105
-    AUTOCHECKBOX    "Start game in full screen", IDC_STARTFULLSCREEN, 16, 20, 200, 10
-    AUTOCHECKBOX    "Pause emulation when window is not active", IDC_PAUSENOTACTIVE, 16, 35, 200, 10
-    AUTOCHECKBOX    "Use global plugins settings", IDC_PLUGIN_OVERWRITE, 16, 50, 200, 10
-    AUTOCHECKBOX    "Show toolbar", IDC_GUI_TOOLBAR, 16, 65, 200, 10
-    AUTOCHECKBOX    "Show statusbar", IDC_GUI_STATUSBAR, 16, 80, 200, 10
-    AUTOCHECKBOX    "Auto Increment save slot", IDC_AUTOINCSAVESLOT, 16, 95, 200, 10
-    GROUPBOX        "Compatibility Options", IDC_COMPATIBILITY, 7, 116, 215, 56
-    AUTOCHECKBOX    "No audio delay (it can fix some compatibility issues but audio won't be synchronised with video)", IDC_NO_AUDIO_DELAY, 16, 129, 200, 18, BS_VCENTER | BS_MULTILINE
-    AUTOCHECKBOX    "No compiled jump (improves compatibility at the cost of some speed)", IDC_NO_COMPILED_JUMP, 16, 150, 200, 18, BS_VCENTER | BS_MULTILINE
-    GROUPBOX        "ROM Browser Columns", IDC_ROMBROWSERCOLUMNS, 7, 176, 215, 73
-    AUTOCHECKBOX    "Good Name", IDC_COLUMN_GOODNAME, 16, 189, 100, 10
-    AUTOCHECKBOX    "Internal Name", IDC_COLUMN_INTERNALNAME, 16, 203, 100, 10
-    AUTOCHECKBOX    "Country", IDC_COLUMN_COUNTRY, 16, 217, 100, 10
-    AUTOCHECKBOX    "Size", IDC_COLUMN_SIZE, 16, 231, 100, 10
-    AUTOCHECKBOX    "Comments", IDC_COLUMN_COMMENTS, 120, 189, 100, 10
-    AUTOCHECKBOX    "File Name", IDC_COLUMN_FILENAME, 120, 203, 100, 10
-    AUTOCHECKBOX    "MD5", IDC_COLUMN_MD5, 120, 217, 100, 10
+    GROUPBOX        "Common Options", IDC_COMMON, 7, 7, 215, 60
+    AUTOCHECKBOX    "Start game in full screen", IDC_STARTFULLSCREEN, 16, 20, 100, 10
+    AUTOCHECKBOX    "Pause emulation when window is not active", IDC_PAUSENOTACTIVE, 16, 35, 100, 10
+    AUTOCHECKBOX    "Use global plugins settings", IDC_PLUGIN_OVERWRITE, 16, 50, 100, 10
+    AUTOCHECKBOX    "Show toolbar", IDC_GUI_TOOLBAR, 120, 20, 100, 10
+    AUTOCHECKBOX    "Show statusbar", IDC_GUI_STATUSBAR, 120, 35, 100, 10
+    AUTOCHECKBOX    "Auto Increment save slot", IDC_AUTOINCSAVESLOT, 120, 50, 100, 10
+    GROUPBOX        "Compatibility Options", IDC_COMPATIBILITY, 7, 71, 215, 56
+    AUTOCHECKBOX    "No audio delay (it can fix some compatibility issues but audio won't be synchronised with video)", IDC_NO_AUDIO_DELAY, 16, 84, 200, 18, BS_VCENTER | BS_MULTILINE
+    AUTOCHECKBOX    "No compiled jump (improves compatibility at the cost of some speed)", IDC_NO_COMPILED_JUMP, 16, 105, 200, 18, BS_VCENTER | BS_MULTILINE
+    GROUPBOX        "ROM Browser Columns", IDC_ROMBROWSERCOLUMNS, 7, 131, 215, 73
+    AUTOCHECKBOX    "Good Name", IDC_COLUMN_GOODNAME, 16, 144, 100, 10
+    AUTOCHECKBOX    "Internal Name", IDC_COLUMN_INTERNALNAME, 16, 158, 100, 10
+    AUTOCHECKBOX    "Country", IDC_COLUMN_COUNTRY, 16, 172, 100, 10
+    AUTOCHECKBOX    "Size", IDC_COLUMN_SIZE, 16, 186, 100, 10
+    AUTOCHECKBOX    "Comments", IDC_COLUMN_COMMENTS, 120, 144, 100, 10
+    AUTOCHECKBOX    "File Name", IDC_COLUMN_FILENAME, 120, 158, 100, 10
+    AUTOCHECKBOX    "MD5", IDC_COLUMN_MD5, 120, 172, 100, 10
+    GROUPBOX        "Wii VC Options", IDC_WIIVC_OPTIONS, 7, 208, 215, 50
+    AUTOCHECKBOX    "Round To Zero", IDC_ROUNDTOZERO, 16, 221, 100, 10
 }
 
 


### PR DESCRIPTION
When the checkbox is checked, Mupen will round doubles toward 0, rather than toward the nearest single, when converted. Copy of the logic from SM64-TAS-ABC's RTZ branch, and only works on Dynamic Recompiler.