### PR TITLE
Fix "Queuecrush" bug

### DIFF
--- a/main/gui_gtk/main_gtk.c
+++ b/main/gui_gtk/main_gtk.c
@@ -324,32 +324,16 @@ ask_hack()
 }
 
 void
-warn_savestate_from_another_rom()
+warn_savestate(char* messageCaption, char* message)
 {
 
 	if (!g_GuiEnabled)
 	{
-		printf( "You're trying to load a save state from either another rom\n"
-		        "or another dump.\n" );
+		printf(message);
 		return;
 	}
 
-	messagebox(tr("Wrong save state"), MB_OK,
-		   tr("You're trying to load a save state from either another rom\n"
-		      "or another dump.") );
-}
-
-void
-warn_savestate_not_exist()
-{
-	if (!g_GuiEnabled)
-	{
-		printf( "The save state you're trying to load doesn't exist\n" );
-		return;
-	}
-
-	messagebox(tr("Save state not exist"), MB_OK,
-		   tr("The save state you're trying to load doesn't exist"));
+	messagebox(tr(messageCaption), MB_OK, tr(message));
 }
 
 void

--- a/main/guifuncs.h
+++ b/main/guifuncs.h
@@ -38,7 +38,6 @@ int ask_hack();
 void new_frame();
 void new_vi();
 
-void warn_savestate_not_exist();
-void warn_savestate_from_another_rom();
+void warn_savestate(char* messageCaption, char* message);
 
 void display_status(const char* status);

--- a/main/main.c
+++ b/main/main.c
@@ -128,15 +128,10 @@ int ask_hack()
      }
 }
 
-void warn_savestate_from_another_rom()
+void warn_savestate(char* messageCaption, char* message)
 {
-   printf("Error: You're trying to load a save state from either another rom\n");
-   printf("       or another dump.\n");
-}
-
-void warn_savestate_not_exist()
-{
-   printf("Error: The save state you're trying to load doesn't exist\n");
+	printf("%s\n", messageCaption);
+	printf("%s\n", message);
 }
 
 void new_frame()

--- a/main/main_gtk.c
+++ b/main/main_gtk.c
@@ -87,11 +87,7 @@ void display_MD5calculating_progress(int p)
 {
 }
 
-void warn_savestate_from_another_rom()
-{
-}
-
-void warn_savestate_not_exist()
+void warn_savestate()
 {
 }
 

--- a/main/savestates.c
+++ b/main/savestates.c
@@ -243,7 +243,7 @@ void savestates_load()
 		free(filename);
 		sprintf(str, "Savestate \"%s\" not found.\n", fname);
 		MessageBox(0, str, "Error", MB_ICONWARNING);
-		warn_savestate_not_exist();
+		warn_savestate("Savestate doesn't exist", "You have selected wrong save slot or save doesn't exist");
 		savestates_job_success = FALSE;
 		return;
 	}
@@ -252,7 +252,7 @@ void savestates_load()
 	gzread(f, buf, 32);
 	if (memcmp(buf, ROM_SETTINGS.MD5, 32))
 	{
-		warn_savestate_from_another_rom();
+		warn_savestate("Savestates Wrong Region", "This savestate is from another ROM or version");
 		gzclose(f);
 		savestates_job_success = FALSE;
 		return;
@@ -316,9 +316,10 @@ void savestates_load()
 		gzread(f, buf+len+4, 4);
 	}
 	if (len == BUFLEN) { // Exhausted the buffer and still no terminator. Prevents the buffer overflow "Queuecrush".
-	    fprintf(stderr, "Snapshot event queue terminator not reached.\n");
+		fprintf(stderr, "Snapshot event queue terminator not reached.\n");
 		savestates_job_success = FALSE;
-		goto failedLoad;
+		warn_savestate("Savestate error", "Event queue too long (Savestate corrupted?)");
+		return;
 	}
 	load_eventqueue_infos(buf);
       

--- a/main/savestates.c
+++ b/main/savestates.c
@@ -197,7 +197,8 @@ void savestates_save()
 
 void savestates_load()
 {
-	char *filename, buf[1024];
+#define BUFLEN 1024
+	char *filename, buf[BUFLEN];
 	gzFile f;
 	int len, i;
 	int filename_f = 0;
@@ -307,14 +308,17 @@ void savestates_load()
 	gzread(f, &next_vi, 4);
 	gzread(f, &vi_field, 4);
    
-	len = 0;
-	while(1)
+	for (len = 0; len < BUFLEN; len += 8)
 	{
 		gzread(f, buf+len, 4);
 		if (*((unsigned long*)&buf[len]) == 0xFFFFFFFF) 
 			break;
 		gzread(f, buf+len+4, 4);
-		len += 8;
+	}
+	if (len == BUFLEN) { // Exhausted the buffer and still no terminator. Prevents the buffer overflow "Queuecrush".
+	    fprintf(stderr, "Snapshot event queue terminator not reached.\n");
+		savestates_job_success = FALSE;
+		goto failedLoad;
 	}
 	load_eventqueue_infos(buf);
       
@@ -411,3 +415,4 @@ failedLoad:
 		last_addr = PC->addr;
 	}
 }
+#undef BUFLEN

--- a/main/win/guifuncs.c
+++ b/main/win/guifuncs.c
@@ -46,21 +46,14 @@ void display_loading_progress(int p)
    SendMessage( hStatusProgress, PBM_SETPOS, p+1, 0 );
 }
 
-void warn_savestate_not_exist()
+void warn_savestate(char* messageCaption, char* message)
 {
-   if (!Config.savesERRORS) return;
-   TranslateDefault("Savestates Wrong Slot","You have selected wrong save slot or save doesn't exist",TempMessage);
-   SendMessage( hStatus, SB_SETTEXT, 0, (LPARAM)TempMessage ); 
-  
-}
+    if (!Config.savesERRORS) return;
+    TranslateDefault(message, messageCaption, TempMessage);
 
-void warn_savestate_from_another_rom()
-{
-   if (!Config.savesERRORS) return;
-   TranslateDefault("Savestates Wrong Region","This savestate is from another ROM or version",TempMessage);
-   SendMessage( hStatus, SB_SETTEXT, 0, (LPARAM)TempMessage ); 
-   MessageBox(mainHWND, TempMessage, "Error", MB_ICONERROR);
-  
+    SendMessage(hStatus, SB_SETTEXT, 0, (LPARAM)TempMessage);
+    MessageBox(mainHWND, TempMessage, "Error", MB_ICONERROR);
+
 }
 
 void display_MD5calculating_progress(int p )


### PR DESCRIPTION
Queuecrush is a buffer overflow that results from a .st file encoding more than 1024 event queues. Video about the vulnerability coming soon.