### PR TITLE
Clear x87 stack on failed input check

### DIFF
--- a/r4300/x86/gcop1_d.c
+++ b/r4300/x86/gcop1_d.c
@@ -35,7 +35,7 @@
 #include "interpret.h"
 #include "gcop1_helpers.h"
 
-static void gencheck_eax_valid()
+static void gencheck_eax_valid(int stackBase)
 {
     if (!emulate_float_crashes)
         return;
@@ -43,7 +43,7 @@ static void gencheck_eax_valid()
     mov_reg32_imm32(EBX, (unsigned long)&largest_denormal_double);
     fld_preg32_qword(EBX);
     fld_preg32_qword(EAX);
-    gencheck_float_input_valid();
+    gencheck_float_input_valid(stackBase);
 }
 
 static void gencheck_result_valid()
@@ -73,10 +73,10 @@ void genadd_d()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.ft]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(1);
    fadd_preg32_qword(EAX);
    gencheck_result_valid();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
@@ -91,10 +91,10 @@ void gensub_d()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.ft]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(1);
    fsub_preg32_qword(EAX);
    gencheck_result_valid();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
@@ -109,10 +109,10 @@ void genmul_d()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.ft]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(1);
    fmul_preg32_qword(EAX);
    gencheck_result_valid();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
@@ -127,10 +127,10 @@ void gendiv_d()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.ft]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(1);
    fdiv_preg32_qword(EAX);
    gencheck_result_valid();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
@@ -145,7 +145,7 @@ void gensqrt_d()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_qword(EAX);
    fsqrt();
    gencheck_result_valid();
@@ -161,7 +161,7 @@ void genabs_d()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_qword(EAX);
    fabs_();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
@@ -191,7 +191,7 @@ void genneg_d()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_qword(EAX);
    fchs();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
@@ -207,7 +207,7 @@ void genround_l_d()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&round_mode);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fd]));
@@ -225,7 +225,7 @@ void gentrunc_l_d()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&trunc_mode);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fd]));
@@ -243,7 +243,7 @@ void genceil_l_d()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&ceil_mode);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fd]));
@@ -261,7 +261,7 @@ void genfloor_l_d()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&floor_mode);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fd]));
@@ -279,7 +279,7 @@ void genround_w_d()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&round_mode);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -297,7 +297,7 @@ void gentrunc_w_d()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&trunc_mode);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -315,7 +315,7 @@ void genceil_w_d()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&ceil_mode);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -333,7 +333,7 @@ void genfloor_w_d()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&floor_mode);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -353,7 +353,7 @@ void gencvt_s_d()
 	   fldcw_m16((unsigned short*)&trunc_mode);
    }
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_qword(EAX);
    gencheck_result_valid_s();
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -371,7 +371,7 @@ void gencvt_w_d()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -387,7 +387,7 @@ void gencvt_l_d()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_qword(EAX);
    mov_eax_memoffs32((unsigned long*)(&reg_cop1_double[dst->f.cf.fd]));

--- a/r4300/x86/gcop1_helpers.c
+++ b/r4300/x86/gcop1_helpers.c
@@ -25,9 +25,11 @@ static void gencall_noret(void (*fn)()) {
  * Given the fp stack:
  * ST(0) = x
  * ST(1) = largest denormal (float/double)
- * Assert that x is not denormal or nan, ending with a cleared stack.
+ * Assert that x is not denormal or nan, ending with ST(0) and ST(1) popped.
+ *
+ * If the assert fires, an additional 'stackBase' values are popped.
  */
-void gencheck_float_input_valid()
+void gencheck_float_input_valid(int stackBase)
 {
     // if abs(x) > largest denormal, goto A
     fabs_(); // ST(0) = abs(ST(0))
@@ -42,7 +44,8 @@ void gencheck_float_input_valid()
     je_rj(0);
     unsigned long jump2 = code_length;
 
-    fstp_fpreg(0); // pop
+    for (int i = 0; i < stackBase + 1; i++)
+        fstp_fpreg(0); // pop
     gencall_noret(fail_float_input);
 
     // A:

--- a/r4300/x86/gcop1_helpers.h
+++ b/r4300/x86/gcop1_helpers.h
@@ -1,7 +1,7 @@
 #ifndef GCOP1_HELPERS_H
 #define GCOP1_HELPERS_H
 
-void gencheck_float_input_valid();
+void gencheck_float_input_valid(int stackBase);
 void gencheck_float_output_valid();
 void gencheck_float_conversion_valid();
 

--- a/r4300/x86/gcop1_s.c
+++ b/r4300/x86/gcop1_s.c
@@ -36,7 +36,7 @@
 #include "interpret.h"
 #include "gcop1_helpers.h"
 
-static void gencheck_eax_valid()
+static void gencheck_eax_valid(int stackBase)
 {
     if (!emulate_float_crashes)
         return;
@@ -44,7 +44,7 @@ static void gencheck_eax_valid()
     mov_reg32_imm32(EBX, (unsigned long)&largest_denormal_float);
     fld_preg32_dword(EBX);
     fld_preg32_dword(EAX);
-    gencheck_float_input_valid();
+    gencheck_float_input_valid(stackBase);
 }
 
 static void gencheck_result_valid()
@@ -64,10 +64,10 @@ void genadd_s()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.ft]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(1);
    fadd_preg32_dword(EAX);
    gencheck_result_valid();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -82,10 +82,10 @@ void gensub_s()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.ft]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(1);
    fsub_preg32_dword(EAX);
    gencheck_result_valid();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -100,10 +100,10 @@ void genmul_s()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.ft]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(1);
    fmul_preg32_dword(EAX);
    gencheck_result_valid();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -118,10 +118,10 @@ void gendiv_s()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.ft]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(1);
    fdiv_preg32_dword(EAX);
    gencheck_result_valid();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -136,7 +136,7 @@ void gensqrt_s()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_dword(EAX);
    fsqrt();
    gencheck_result_valid();
@@ -152,7 +152,7 @@ void genabs_s()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(1);
    fld_preg32_dword(EAX);
    fabs_();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -180,7 +180,7 @@ void genneg_s()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    fchs();
@@ -197,7 +197,7 @@ void genround_l_s()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&round_mode);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
@@ -215,7 +215,7 @@ void gentrunc_l_s()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&trunc_mode);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
@@ -233,7 +233,7 @@ void genceil_l_s()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&ceil_mode);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
@@ -251,7 +251,7 @@ void genfloor_l_s()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&floor_mode);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
@@ -269,7 +269,7 @@ void genround_w_s()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&round_mode);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -287,7 +287,7 @@ void gentrunc_w_s()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&trunc_mode);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -305,7 +305,7 @@ void genceil_w_s()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&ceil_mode);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -323,7 +323,7 @@ void genfloor_w_s()
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&floor_mode);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -340,7 +340,7 @@ void gencvt_d_s()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
@@ -354,7 +354,7 @@ void gencvt_w_s()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fd]));
@@ -370,7 +370,7 @@ void gencvt_l_s()
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_simple[dst->f.cf.fs]));
-   gencheck_eax_valid();
+   gencheck_eax_valid(0);
    fclex();
    fld_preg32_dword(EAX);
    mov_eax_memoffs32((unsigned long *)(&reg_cop1_double[dst->f.cf.fd]));


### PR DESCRIPTION
Noticed I forgot to pop the x87 stack when handling errors. This causes x87 stack overflows and floating point weirdness to happen when a nan/denormal error for an input rhs occurs for the 6th or so time.

Untested but I feel pretty confident about it.