### PR TITLE
AVI Fixes

### DIFF
--- a/main/vcr.h
+++ b/main/vcr.h
@@ -76,6 +76,7 @@ extern void VCR_aiLenChanged();
 
 extern BOOL VCR_isActive();
 extern BOOL VCR_isIdle(); // not the same as !isActive()
+extern BOOL VCR_isStartingAndJustRestarted();
 extern BOOL VCR_isPlaying();
 extern BOOL VCR_isRecording();
 extern BOOL VCR_isCapturing();

--- a/main/win/main_win.cpp
+++ b/main/win/main_win.cpp
@@ -2495,6 +2495,15 @@ static DWORD WINAPI ThreadFunc(LPVOID lpParam)
 	StartLuaScripts();
 	StartSavestate();
     AtResetCallback();
+    if (pauseAtFrame == 0 && VCR_isStartingAndJustRestarted())
+    {
+        emu_paused = 0;
+        while (emu_paused)
+        {
+            Sleep(10);
+        }
+        pauseAtFrame = -1;
+    }
     go();
     ShowInfo("Emu thread: Core stopped...");
 	ThreadFuncState = TFS_CLOSEINPUT;

--- a/main/win/main_win.cpp
+++ b/main/win/main_win.cpp
@@ -2497,7 +2497,7 @@ static DWORD WINAPI ThreadFunc(LPVOID lpParam)
     AtResetCallback();
     if (pauseAtFrame == 0 && VCR_isStartingAndJustRestarted())
     {
-        emu_paused = 0;
+        emu_paused = TRUE;
         while (emu_paused)
         {
             Sleep(10);


### PR DESCRIPTION
Fixes some potential rounding issues with audio frames and adds a hack to allow pausing before on frame "0" on movie playback (mainly for avi recording, as the current logic could miss a good chunk of a game intro or w/e due to lack of polling).