### PR TITLE
Fixes the slider allowing less than 5% speed

### DIFF
--- a/main/win/configdialog.c
+++ b/main/win/configdialog.c
@@ -836,7 +836,7 @@ BOOL CALLBACK GeneralCfg(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
                   EnableWindow( GetDlgItem(hwnd,IDC_PURE_INTERP), FALSE );
          }
          
-         CreateTrackbar(hwnd,1,200,Config.FPSmodifier,200, 30, 184, 300) ; 
+         CreateTrackbar(hwnd,5,200,Config.FPSmodifier,200, 30, 184, 300) ; 
          
          SwitchLimitFPS(hwnd);
          FillModifierValue( hwnd, Config.FPSmodifier);        


### PR DESCRIPTION
Anything below 5% isn't handled correctly, which makes emulation run way too fast when set. 5% is the lowest the hotkeys allow, so I thought it was a fine lowest value. If you want to go lower I think frame advance is fine :P 

This also allows realigning to the standard speed up and slow down windows fairly trivially, otherwise you were stuck at 1% higher than expected.