### PR TITLE
Fix recent rom menu being disabled

### DIFF
--- a/main/win/rombrowser.c
+++ b/main/win/rombrowser.c
@@ -1230,11 +1230,8 @@ void RunRecentRom(int id) {
 }
 
 void DisableRecentRoms(HMENU hMenu, BOOL disable) {
-    // this is cool but why
-    if (!Config.RecentRomsFreeze) return; // only disable rom loading if freeze enabled
     for (int i = 0; i < MAX_RECENT_ROMS; i++)
-        EnableMenuItem(hMenu, ID_RECENTROMS_FIRST + i, (disable ? MF_ENABLED : MF_DISABLED));
-
+        EnableMenuItem(hMenu, ID_RECENTROMS_FIRST + i, (disable ? MF_DISABLED : MF_ENABLED));
 }
 
 void FreezeRecentRoms(HWND hWnd, BOOL ChangeConfigVariable) {


### PR DESCRIPTION
Previously, if the freeze option was on on program startup, you couldn't select any recent rom (for some reason). This decouples that functionality, and also fixes the ternary to work properly.