### PR TITLE
"Start from Existing Snapshot" movie compatibility, GUI fix

### DIFF
--- a/main/vcr.cpp
+++ b/main/vcr.cpp
@@ -1315,6 +1315,9 @@ VCR_startRecord( const char *filename, unsigned short flags, const char *authorU
 		savestates_select_filename(buf);
 		savestates_job |= LOADSTATE;
 
+		// set this to the normal snapshot flag to maintain compatibility
+		m_header.startFlags = MOVIE_START_FROM_SNAPSHOT;
+
 		m_task = StartRecordingFromExistingSnapshot;
 	}
 	else {

--- a/main/vcr.cpp
+++ b/main/vcr.cpp
@@ -1713,7 +1713,7 @@ startPlayback( const char *filename, const char *authorUTF8, const char *descrip
 
 		if (Config.movieBackupsLevel > 1) movieBackup();
 
-		if (m_header.startFlags & (MOVIE_START_FROM_SNAPSHOT ^ MOVIE_START_FROM_EXISTING_SNAPSHOT))
+		if (m_header.startFlags & MOVIE_START_FROM_SNAPSHOT)
 		{
 			// we cant wait for this function to return and then get check in emu(?) thread (savestates_load)
 

--- a/main/win/main_win.cpp
+++ b/main/win/main_win.cpp
@@ -1914,7 +1914,7 @@ ShowInfo("[VCR]:refreshing movie info...");
 
 //ShowInfo("refreshing movie start/frames...\n");
 
-    SetDlgItemText(hwnd, IDC_FROMSNAPSHOT_TEXT, (m_header.startFlags & (MOVIE_START_FROM_SNAPSHOT | MOVIE_START_FROM_EXISTING_SNAPSHOT)) ? "Savestate" : "Start");
+    SetDlgItemText(hwnd, IDC_FROMSNAPSHOT_TEXT, (m_header.startFlags & MOVIE_START_FROM_SNAPSHOT) ? "Savestate" : "Start");
     if (m_header.startFlags & MOVIE_START_FROM_EEPROM) {
         SetDlgItemTextA(hwnd, IDC_FROMSNAPSHOT_TEXT, "EEPROM");
     }

--- a/main/win/translation.c
+++ b/main/win/translation.c
@@ -306,7 +306,7 @@ void SetMenuAcceleratorsFromUser(HWND mainHWND)
     SetHotkeyMenuAccelerators(&Config.hotkey[12], GetSubMenu(GetMenu(mainHWND), 1), 4);  // load current slot
     SetHotkeyMenuAccelerators(&Config.hotkey[11], GetSubMenu(GetMenu(mainHWND), 1), 6);  // save current slot
 
-    SetHotkeyMenuAccelerators(&Config.hotkey[5], GetSubMenu(GetMenu(mainHWND), 3), 15); // toggle read-only
+    SetHotkeyMenuAccelerators(&Config.hotkey[5], GetSubMenu(GetMenu(mainHWND), 3), 13); // toggle read-only
     SetHotkeyMenuAccelerators(&Config.hotkey[6], GetSubMenu(GetMenu(mainHWND), 3), 3); // 
     SetHotkeyMenuAccelerators(&Config.hotkey[7], GetSubMenu(GetMenu(mainHWND), 3), 4);
     SetHotkeyMenuAccelerators(&Config.hotkey[8], GetSubMenu(GetMenu(mainHWND), 3), 0); // start recording


### PR DESCRIPTION
- `MOVIE_START_FROM_EXISTING_SNAPSHOT` no longer writes its unique flag to the m64 file, instead now using the regular `MOVIE_START_FROM_SNAPSHOT` flag.
- `Toggle Read-Only` GUI button once again displays its associated hotkey