### PR TITLE
fixed roms larger than 8,192kb failing to load

### DIFF
--- a/main/rom.c
+++ b/main/rom.c
@@ -221,7 +221,8 @@ int rom_read(const char *argv)
 
    printf ("file found\n");
 /*------------------------------------------------------------------------*/   
-   if (Config.manageBadRoms && findsize() > 64) goto killRom;
+   // 512 is what findsize returns for an extended sm64 rom (65,536kb)
+   if (Config.manageBadRoms && findsize() > 512) goto killRom;
 
    if (rom) free(rom);
    rom = (unsigned char*)malloc(taille_rom);


### PR DESCRIPTION
the removal of the "Alert Hacked ROMs" config option meant that there was no longer any handling for roms larger than 8,192kb, and such roms would simply fail to load. this fix allows roms up to 65,536kb in size to be loaded (the 512 magic constant is a result of the value returned by `findsize()` on a rom of this size).