### PR TITLE
Prevent unnecessary error when running at >1000 VIs and pressing frame advance

### DIFF
--- a/main/win/main_win.cpp
+++ b/main/win/main_win.cpp
@@ -3148,6 +3148,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
                     if (!manualFPSLimit) break;
 					extern int frame_advancing;
                     frame_advancing = 1;
+                    VIs = 0; // prevent old VI value from showing error if running at super fast speeds
                     resumeEmu(TRUE); // maybe multithreading unsafe
                 }
                 break;


### PR DESCRIPTION
This prevents [this](https://github.com/mkdasher/mupen64-rr-lua-/blob/dev/main/win/timers.cpp#L142) from triggering the instant that you press the frame advance key at high speeds.

Setting it to 0 avoids updating the bottom bar (due to [this check](https://github.com/mkdasher/mupen64-rr-lua-/blob/dev/main/win/timers.cpp#L238). Nothing else reads this variable, as it is only used internally to keep track of the status bar at the bottom and the error check mentioned above.