### PR TITLE
added font style as parameter to wgui.d2d_draw_text

### DIFF
--- a/lua/LuaConsole.cpp
+++ b/lua/LuaConsole.cpp
@@ -2206,9 +2206,15 @@ namespace LuaEngine {
 		auto text = std::string(luaL_checkstring(L, 9));
 		auto font_name = std::string(luaL_checkstring(L, 10));
 		auto font_size = luaL_checknumber(L, 11);
-		auto horizontal_alignment = luaL_checkinteger(L, 12);
-		auto vertical_alignment = luaL_checkinteger(L, 13);
+		auto font_style_str = std::string(luaL_checkstring(L, 12));
+		auto horizontal_alignment = luaL_checkinteger(L, 13);
+		auto vertical_alignment = luaL_checkinteger(L, 14);
 		auto wide_text = widen(text);
+
+		enum DWRITE_FONT_WEIGHT font_weight = (font_style_str == "bold" || font_style_str == "bold-italic")
+											   ? DWRITE_FONT_WEIGHT_BOLD : DWRITE_FONT_WEIGHT_NORMAL;
+		enum DWRITE_FONT_STYLE font_style   = (font_style_str == "italic" || font_style_str == "bold-italic")
+											   ? DWRITE_FONT_STYLE_ITALIC : DWRITE_FONT_STYLE_NORMAL;
 
 		// FIXME: use DrawTextLayout
 		// i just whipped this up quickly for testing
@@ -2218,8 +2224,8 @@ namespace LuaEngine {
 		dw_factory->CreateTextFormat(
 			widen(font_name).c_str(),
 			NULL,
-			DWRITE_FONT_WEIGHT_NORMAL,
-			DWRITE_FONT_STYLE_NORMAL,
+			font_weight,
+			font_style,
 			DWRITE_FONT_STRETCH_NORMAL,
 			font_size,
 			L"",

--- a/lua/LuaConsole.cpp
+++ b/lua/LuaConsole.cpp
@@ -2206,15 +2206,16 @@ namespace LuaEngine {
 		auto text = std::string(luaL_checkstring(L, 9));
 		auto font_name = std::string(luaL_checkstring(L, 10));
 		auto font_size = luaL_checknumber(L, 11);
-		auto font_style_str = std::string(luaL_checkstring(L, 12));
+		auto font_opts = luaL_checkinteger(L, 12);
 		auto horizontal_alignment = luaL_checkinteger(L, 13);
 		auto vertical_alignment = luaL_checkinteger(L, 14);
 		auto wide_text = widen(text);
 
-		enum DWRITE_FONT_WEIGHT font_weight = (font_style_str == "bold" || font_style_str == "bold-italic")
-											   ? DWRITE_FONT_WEIGHT_BOLD : DWRITE_FONT_WEIGHT_NORMAL;
-		enum DWRITE_FONT_STYLE font_style   = (font_style_str == "italic" || font_style_str == "bold-italic")
-											   ? DWRITE_FONT_STYLE_ITALIC : DWRITE_FONT_STYLE_NORMAL;
+		// Checks if a given bit is set
+		#define CHECK_BIT(var, offset) (var >> offset) & 1
+		
+		enum DWRITE_FONT_WEIGHT font_weight = CHECK_BIT(font_opts, 0) ? DWRITE_FONT_WEIGHT_BOLD : DWRITE_FONT_WEIGHT_NORMAL;
+		enum DWRITE_FONT_STYLE font_style   = CHECK_BIT(font_opts, 1) ? DWRITE_FONT_STYLE_ITALIC : DWRITE_FONT_STYLE_NORMAL;
 
 		// FIXME: use DrawTextLayout
 		// i just whipped this up quickly for testing


### PR DESCRIPTION
an argument `fontstyle` is now passed to the `wgui.d2d_draw_text` lua function. the valid styles are:
- 0: normal
- 1: bold
- 2: italic
- 3: bold + italic