### PR TITLE
fixed two periods being shown in titlebar while avi capturing

### DIFF
--- a/main/vcr.cpp
+++ b/main/vcr.cpp
@@ -2038,9 +2038,9 @@ void UpdateTitleBarCapture(const char* filename) {
 		char m64[PATH_MAX];
 		strncpy(m64, m_filename, PATH_MAX);
 		_splitpath(m64, 0, 0, m64, 0);
-		sprintf(title, MUPEN_VERSION " - %s | %s.m64 | %s.%s", ROM_HEADER->nom, m64, avi, ext);
+		sprintf(title, MUPEN_VERSION " - %s | %s.m64 | %s%s", ROM_HEADER->nom, m64, avi, ext);
 	} else {
-		sprintf(title, MUPEN_VERSION " - %s | %s.%s", ROM_HEADER->nom, avi, ext);
+		sprintf(title, MUPEN_VERSION " - %s | %s%s", ROM_HEADER->nom, avi, ext);
 	}
 	printf("title %s\n", title);
 	SetWindowText(mainHWND, title);


### PR DESCRIPTION
maybe there's a cleaner way to fix this but idk what's going on in the _splitpath function so 🤷