### PR TITLE
Add luaL_error to emu.getaddress function to avoid crash

### DIFF
--- a/lua/modules/emu.h
+++ b/lua/modules/emu.h
@@ -310,6 +310,7 @@ namespace LuaCore::Emu
 				return 1;
 			}
 		}
+		luaL_error(L, "Invalid variable name. (%s)", s);
 		return 0;
 	}
 


### PR DESCRIPTION
The `emu.getaddress` function allows lua scripts to get the address of some internal variables (rdram for STROOP, etc.). If you passed a string that didn't correspond to any variables, mupen would crash. Adding a lua error avoides this crash.

I can change the verbiage if someone wants me to.