### PR TITLE
Add STROOP autoDetect parameter to Config.xml line

### DIFF
--- a/view/gui/Main.cpp
+++ b/view/gui/Main.cpp
@@ -1539,7 +1539,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 
                     char stroop_c[1024] = {0};
                     sprintf(stroop_c,
-                            "<Emulator name=\"Mupen 5.0 RR\" processName=\"%s\" ramStart=\"%s\" endianness=\"little\"/>",
+                            "<Emulator name=\"Mupen 5.0 RR\" processName=\"%s\" ramStart=\"%s\" endianness=\"little\" autoDetect=\"true\"/>",
                             proc_name, ram_start);
 
                     constexpr auto RAMSTART_MESSAGE = "The RAM start is {}.\r\nDo you want to copy the generated STROOP config line to your clipboard?";


### PR DESCRIPTION
Pannen's STROOP now has an autoDetect parameter in the Config file which lets STROOP try to auto-detect the RAM start if it doesn't match, most of the emulator entries have it set