### PR TITLE
build!: re-add features that were available to the VS build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,6 @@ jobs:
       - name: "Upload x86-sse2 build"
         uses: actions/upload-artifact@v4
         with:
-          name: mupen-x86-sse2
+          name: mupen
           path: build/out
           retention-days: 14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # - enable the program to use pointers larger than 2GB
   # - disable the generation of a manifest file (since it's pulled in internally via the resource script)
   add_link_options(/DYNAMICBASE:NO /NXCOMPAT:NO /LARGEADDRESSAWARE /MANIFEST:NO)
+
+  # Include compile options to enable AVX2 on x64 builds
+  if ("${VCPKG_TARGET_TRIPLET}" MATCHES "^x64")
+    add_compile_options(/arch:AVX2)
+  endif()
 endif()
 if (WIN32)
   # Use UTF-16 versions of functions

--- a/src/Views.Win32/CMakeLists.txt
+++ b/src/Views.Win32/CMakeLists.txt
@@ -10,7 +10,6 @@ add_library(Mupen64RR.Views.Win32.Headers INTERFACE
 set_target_properties(Mupen64RR.Views.Win32.Headers PROPERTIES
     CXX_STANDARD 23
     CXX_STANDARD_REQUIRED ON
-    OUTPUT_NAME mupen64
 )
 target_include_directories(Mupen64RR.Views.Win32.Headers INTERFACE "include")
 


### PR DESCRIPTION
This PR should:
- make the CI work again
- enable version suffixes to be supplied via environment variable
- allow architectures to be specified (on x86, x86-64)
