### PR TITLE
feat(VCR): Continue movie recording functionality

### DIFF
--- a/src/Core/Core.cpp
+++ b/src/Core/Core.cpp
@@ -109,6 +109,7 @@ core_result core_create(core_params *params, core_ctx **ctx)
     g_ctx.vcr_read_movie_inputs = vcr_read_movie_inputs;
     g_ctx.vcr_start_playback = vcr_start_playback;
     g_ctx.vcr_start_record = vcr_start_record;
+    g_ctx.vcr_continue_recording = vcr_continue_recording;
     g_ctx.vcr_replace_author_info = vcr_replace_author_info;
     g_ctx.vcr_get_seek_info = vcr_get_seek_info;
     g_ctx.vcr_begin_seek = vcr_begin_seek;

--- a/src/Core/include/core_api.h
+++ b/src/Core/include/core_api.h
@@ -176,8 +176,7 @@ extern "C"
          * the value specified by the user's preferences in the view. If the user has chosen to not show the dialog
          * again, this function will return the last choice.
          */
-        std::function<bool(const std::string &id, const char *str, const char *title, bool warning)>
-            show_ask_dialog;
+        std::function<bool(const std::string &id, const char *str, const char *title, bool warning)> show_ask_dialog;
 
         /**
          * \brief Shows the user a dialog.
@@ -469,6 +468,12 @@ extern "C"
                                   std::string description)>
             vcr_start_record;
 
+        /**
+         * \brief Continues recording a movie.
+         * \return The operation result
+         */
+        std::function<core_result()> vcr_continue_recording;
+        
         /**
          * \brief Replaces the author and description information of a movie
          * \param path The movie's path

--- a/src/Core/include/core_types.h
+++ b/src/Core/include/core_types.h
@@ -51,6 +51,8 @@ typedef enum
     VCR_InvalidExtendedVersion,
     // The operation requires a playback or recording task
     VCR_NeedsPlaybackOrRecording,
+    // The operation requires a playback task
+    VCR_NeedsPlayback,
     // The provided start type is invalid.
     VCR_InvalidStartType,
     // Another warp modify operation is already running

--- a/src/Core/r4300/vcr.h
+++ b/src/Core/r4300/vcr.h
@@ -75,6 +75,7 @@ core_result vcr_parse_header(std::filesystem::path path, core_vcr_movie_header *
 core_result vcr_read_movie_inputs(std::filesystem::path path, std::vector<core_buttons> &inputs);
 core_result vcr_start_playback(std::filesystem::path path);
 core_result vcr_start_record(std::filesystem::path path, uint16_t flags, std::string author, std::string description);
+core_result vcr_continue_recording();
 core_result vcr_replace_author_info(const std::filesystem::path &path, const std::string &author,
                                     const std::string &description);
 core_vcr_seek_info vcr_get_seek_info();

--- a/src/Views.Win32/Config.cpp
+++ b/src/Views.Win32/Config.cpp
@@ -519,6 +519,7 @@ static void migrate_config(t_config &config, const mINI::INIStructure &ini)
     migrate_hotkey("Toggle movie loop", AppActions::LOOP_MOVIE_PLAYBACK);
     migrate_hotkey("Start movie playback", AppActions::START_MOVIE_PLAYBACK);
     migrate_hotkey("Start movie recording", AppActions::START_MOVIE_RECORDING);
+    migrate_hotkey("Continue movie recording", AppActions::CONTINUE_MOVIE_RECORDING);
     migrate_hotkey("Stop movie", AppActions::STOP_MOVIE);
     migrate_hotkey("Create Movie Backup", AppActions::CREATE_MOVIE_BACKUP);
     migrate_hotkey("Take screenshot", AppActions::SCREENSHOT);

--- a/src/Views.Win32/Main.cpp
+++ b/src/Views.Win32/Main.cpp
@@ -234,6 +234,10 @@ bool show_error_dialog_for_result(const core_result result, void *hwnd)
         module = L"VCR";
         error = L"The operation requires a playback or recording task.";
         break;
+    case VCR_NeedsPlayback:
+        module = L"VCR";
+        error = L"The operation requires a playback task.";
+        break;
     case VCR_InvalidStartType:
         module = L"VCR";
         error = L"The provided start type is invalid.";

--- a/src/Views.Win32/components/AppActions.h
+++ b/src/Views.Win32/components/AppActions.h
@@ -56,7 +56,8 @@ const std::wstring STATUSBAR = APP + L"Options > Statusbar ---";
 const std::wstring SETTINGS = APP + L"Options > Settings";
 
 const std::wstring START_MOVIE_RECORDING = APP + L"Movie > Start Movie Recording";
-const std::wstring START_MOVIE_PLAYBACK = APP + L"Movie > Start Movie Playback ---";
+const std::wstring START_MOVIE_PLAYBACK = APP + L"Movie > Start Movie Playback";
+const std::wstring CONTINUE_MOVIE_RECORDING = APP + L"Movie > Continue Movie Recording ---";
 const std::wstring STOP_MOVIE = APP + L"Movie > Stop Movie";
 const std::wstring CREATE_MOVIE_BACKUP = APP + L"Movie > Create Movie Backup ---";
 const std::wstring RECENT_MOVIES = APP + L"Movie > Recent Movies ---";


### PR DESCRIPTION
This PR introduces a new "Continue Movie Recording" feature to the VCR and frontend, which simply engages recording mode if the VCR is currently in playback mode. 

It's functionally equivalent to saving+loading a savestate in read-write mode, but aimed at novice users.
