### PR TITLE
fix(cmake): fix build failure on case sensitive OSs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ find_package(nlohmann_json CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
 find_package(Catch2 CONFIG REQUIRED)
 find_package(glew CONFIG REQUIRED) 
-find_package(sdl3 CONFIG REQUIRED) 
+find_package(SDL3 CONFIG REQUIRED) 
 
 # Lua, because Lua sucks
 find_package(Lua REQUIRED)


### PR DESCRIPTION
Capitalize `SDL3` in dependencies so cmake is able to find the appropriate config module on OSs with case sensitive filesystems (Linux)

I spent 4 hours debugging this