### PR TITLE
fix(Lua): use strings for callback keys instead of integers

### DIFF
--- a/src/Views.Win32/lua/LuaCallbacks.cpp
+++ b/src/Views.Win32/lua/LuaCallbacks.cpp
@@ -158,7 +158,7 @@ bool invoke_callbacks_with_key_impl(const t_lua_environment *lua, const std::fun
 
     lua_State *L = lua->L;
 
-    lua_rawgeti(L, LUA_REGISTRYINDEX, key);
+    lua_getfield(L, LUA_REGISTRYINDEX, key);
     if (lua_isnil(L, -1))
     {
         lua_pop(L, 1);
@@ -216,13 +216,13 @@ void LuaCallbacks::invoke_callbacks_with_key_on_all_instances(callback_key key)
 
 static int register_function(lua_State *L, LuaCallbacks::callback_key key)
 {
-    lua_rawgeti(L, LUA_REGISTRYINDEX, key);
+    lua_getfield(L, LUA_REGISTRYINDEX, key);
     if (lua_isnil(L, -1))
     {
         lua_pop(L, 1);
         lua_newtable(L);
-        lua_rawseti(L, LUA_REGISTRYINDEX, key);
-        lua_rawgeti(L, LUA_REGISTRYINDEX, key);
+        lua_setfield(L, LUA_REGISTRYINDEX, key);
+        lua_getfield(L, LUA_REGISTRYINDEX, key);
     }
     int i = luaL_len(L, -1) + 1;
     lua_pushinteger(L, i);
@@ -234,7 +234,7 @@ static int register_function(lua_State *L, LuaCallbacks::callback_key key)
 
 static void unregister_function(lua_State *L, LuaCallbacks::callback_key key)
 {
-    lua_rawgeti(L, LUA_REGISTRYINDEX, key);
+    lua_getfield(L, LUA_REGISTRYINDEX, key);
     if (lua_isnil(L, -1))
     {
         lua_pop(L, 1);

--- a/src/Views.Win32/lua/LuaCallbacks.h
+++ b/src/Views.Win32/lua/LuaCallbacks.h
@@ -11,26 +11,26 @@
  */
 namespace LuaCallbacks
 {
-using callback_key = uint8_t;
+using callback_key = const char*;
 
-constexpr callback_key REG_LUACLASS = 1;
-constexpr callback_key REG_ATUPDATESCREEN = 2;
-constexpr callback_key REG_ATDRAWD2D = 3;
-constexpr callback_key REG_ATVI = 4;
-constexpr callback_key REG_ATINPUT = 5;
-constexpr callback_key REG_ATSTOP = 6;
-constexpr callback_key REG_SYNCBREAK = 7;
-constexpr callback_key REG_READBREAK = 8;
-constexpr callback_key REG_WRITEBREAK = 9;
-constexpr callback_key REG_WINDOWMESSAGE = 10;
-constexpr callback_key REG_ATINTERVAL = 11;
-constexpr callback_key REG_ATPLAYMOVIE = 12;
-constexpr callback_key REG_ATSTOPMOVIE = 13;
-constexpr callback_key REG_ATLOADSTATE = 14;
-constexpr callback_key REG_ATSAVESTATE = 15;
-constexpr callback_key REG_ATRESET = 16;
-constexpr callback_key REG_ATSEEKCOMPLETED = 17;
-constexpr callback_key REG_ATWARPMODIFYSTATUSCHANGED = 18;
+constexpr callback_key REG_LUACLASS = "luaclass";
+constexpr callback_key REG_ATUPDATESCREEN = "atupdatescreen";
+constexpr callback_key REG_ATDRAWD2D = "atdrawd2d";
+constexpr callback_key REG_ATVI = "atvi";
+constexpr callback_key REG_ATINPUT = "atinput";
+constexpr callback_key REG_ATSTOP = "atstop";
+constexpr callback_key REG_SYNCBREAK = "syncbreak";
+constexpr callback_key REG_READBREAK = "readbreak";
+constexpr callback_key REG_WRITEBREAK = "writebreak";
+constexpr callback_key REG_WINDOWMESSAGE = "windowmessage";
+constexpr callback_key REG_ATINTERVAL = "atinterval";
+constexpr callback_key REG_ATPLAYMOVIE = "atplaymovie";
+constexpr callback_key REG_ATSTOPMOVIE = "atstopmovie";
+constexpr callback_key REG_ATLOADSTATE = "atloadstate";
+constexpr callback_key REG_ATSAVESTATE = "atsavestate";
+constexpr callback_key REG_ATRESET = "atreset";
+constexpr callback_key REG_ATSEEKCOMPLETED = "atseekcompleted";
+constexpr callback_key REG_ATWARPMODIFYSTATUSCHANGED = "atwarpmodifystatuschanged";
 
 /**
  * \brief Gets the last controller data for a controller index


### PR DESCRIPTION
From the [Lua Reference Manual](https://www.lua.org/manual/5.5/manual.html#4.3):

> The integer keys in the registry are used by the reference mechanism (see [luaL_ref](https://www.lua.org/manual/5.5/manual.html#luaL_ref)), with some predefined values. Therefore, integer keys in the registry must not be used for other purposes.

This replaces the integer callback keys with strings to prevent conflicts with Lua versions >5.1.