### PR TITLE
fix(Lua): crash when calling certain mupen functions in atstop callback after an error

### DIFF
--- a/src/Views.Win32/lua/LuaManager.cpp
+++ b/src/Views.Win32/lua/LuaManager.cpp
@@ -45,7 +45,6 @@ static void rebuild_lua_env_map()
     }
 }
 
-
 void LuaManager::init()
 {
     g_mupen_api_lua_code = load_resource_as_string(IDR_API_LUA_FILE, MAKEINTRESOURCE(TEXTFILE));
@@ -136,8 +135,6 @@ std::expected<void, std::wstring> LuaManager::start_environment(t_lua_environmen
 fail:
     if (has_error)
     {
-        g_lua_environments.pop_back();
-        rebuild_lua_env_map();
 
         const auto error = IOUtils::to_wide_string(lua_tostring(env->L, -1));
         destroy_environment(env);

--- a/test/lua/manual/env_usage_in_atstop_after_error.lua
+++ b/test/lua/manual/env_usage_in_atstop_after_error.lua
@@ -1,0 +1,17 @@
+--
+-- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
+-- Raises an error in the global scope and calls a function that uses the environment in an atstop callback.
+-- Start the script, and ensure that:
+-- 1. 'Test passed!' is printed to the console
+
+dofile(debug.getinfo(1).source:sub(2):gsub("\\[^\\]+\\[^\\]+$", "") .. '\\test_prelude.lua')
+
+emu.atstop(function()
+    print('Test passed!')
+end)
+
+error('test')


### PR DESCRIPTION
Fixes a crash when calling certain mupen functions in atstop callback after an error.

Test case is included.