### PR TITLE
fix: `atkey` not being called when hotkeys are locked

### DIFF
--- a/src/Views.Win32/components/HotkeyTracker.cpp
+++ b/src/Views.Win32/components/HotkeyTracker.cpp
@@ -21,11 +21,11 @@ struct t_hotkey_tracker_context
     bool last_xmb2{};
 };
 
-static bool on_key(bool is_up, int32_t key)
+static std::optional<bool> on_key(bool is_up, int32_t key)
 {
     if (ActionManager::get_hotkeys_locked())
     {
-        return true;
+        return std::nullopt;
     }
 
     const bool shift = GetKeyState(VK_SHIFT) & 0x8000;
@@ -54,12 +54,7 @@ static bool on_key(bool is_up, int32_t key)
         }
     }
 
-    if (hit)
-    {
-        return true;
-    }
-
-    return false;
+    return hit;
 }
 
 static LRESULT CALLBACK action_menu_wnd_subclass_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, UINT_PTR sId,
@@ -130,10 +125,8 @@ static LRESULT CALLBACK action_menu_wnd_subclass_proc(HWND hwnd, UINT msg, WPARA
     case WM_KEYUP:
     case WM_SYSKEYDOWN:
     case WM_SYSKEYUP: {
-        if (on_key(msg == WM_KEYUP || msg == WM_SYSKEYUP, (int)wParam))
-        {
-            return 0;
-        }
+        const auto result = on_key(msg == WM_KEYUP || msg == WM_SYSKEYUP, (int)wParam);
+        if (result.has_value() && result.value()) return 0;
         break;
     }
     case WM_NOTIFY: {

--- a/test/lua/manual/atkey_received_when_hotkeys_locked.lua
+++ b/test/lua/manual/atkey_received_when_hotkeys_locked.lua
@@ -1,0 +1,24 @@
+--
+-- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
+-- Locks the hotkeys and ensures that atkey is still called for key press (not text type) keyboard events afterwards.
+-- Start the script and then:
+-- 1. Press a key.
+-- 2. If you see "Test passed!" in the console, the test is successful. If not, the test has failed.
+
+dofile(debug.getinfo(1).source:sub(2):gsub("\\[^\\]+\\[^\\]+$", "") .. '\\test_prelude.lua')
+
+action.lock_hotkeys(true)
+
+emu.atkey(function(args)
+    if args.keycode then
+        print("Test passed!")
+    end
+end)
+
+emu.atstop(function()
+    action.lock_hotkeys(false)
+end)


### PR DESCRIPTION
Fixes `emu.atkey` callback not being called with keycode events when hotkeys are locked using `action.lock_hotkeys`.

Sees test case.

changelog: skip