### PR TITLE
feat(Capture): allow continuing capture across resets between ROMs with same VI/s

### DIFF
--- a/src/Views.Win32/capture/CaptureManager.cpp
+++ b/src/Views.Win32/capture/CaptureManager.cpp
@@ -506,6 +506,8 @@ bool is_capturing()
 
 void core_executing_changed(const std::any &data)
 {
+    std::lock_guard lock(m_mutex);
+
     auto value = std::any_cast<bool>(data);
 
     if (!value || !m_capturing) return;


### PR DESCRIPTION
Allows continuing capture across resets between ROMs with same VI/s.

We already handle sample rate changes by resampling, but we can't deal with FPS changes. That's too complex to consider anyway.