### PR TITLE
fix(LuaRenderer): run rendering heartbeat on a separate thread

### DIFF
--- a/src/Views.Win32/CMakeLists.txt
+++ b/src/Views.Win32/CMakeLists.txt
@@ -184,6 +184,7 @@ target_link_libraries(Mupen64RR.Views.Win32 PRIVATE
     Dcomp
     D3D11
     DXGI
+    Dwmapi
     d3dcompiler
     Winhttp
 )

--- a/src/Views.Win32/Main.cpp
+++ b/src/Views.Win32/Main.cpp
@@ -740,8 +740,9 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 
         return TRUE;
     case WM_DESTROY:
-        Config::save();
         timeKillEvent(g_ui_timer);
+        Config::save();
+        LuaRenderer::stop();
         Gdiplus::GdiplusShutdown(gdi_plus_token);
         PostQuitMessage(0);
         break;

--- a/src/Views.Win32/lua/LuaRenderer.cpp
+++ b/src/Views.Win32/lua/LuaRenderer.cpp
@@ -7,6 +7,7 @@
 #include <lua/presenters/GDIPresenter.h>
 #include <lua/presenters/Presenter.h>
 #include <lua/LuaCallbacks.h>
+#include "LuaRenderer.h"
 
 const auto D2D_OVERLAY_CLASS = L"lua_d2d_overlay";
 const auto GDI_OVERLAY_CLASS = L"lua_gdi_overlay";
@@ -14,32 +15,31 @@ const auto CTX_PROP = L"lua_ctx";
 
 static bool d2d_drawing = false;
 static HBRUSH g_alpha_mask_brush;
+static MMRESULT render_timer{};
 
-static LRESULT CALLBACK d2d_overlay_wndproc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
+static std::thread draw_thread;
+static std::atomic<bool> draw_thread_running{false};
+
+static void draw_lua()
 {
-    RT_ASSERT(is_on_gui_thread(), L"LuaRenderer::d2d_overlay_wndproc called from non-GUI thread");
+    const auto now = std::chrono::steady_clock::now();
 
-    switch (msg)
+    // TODO: Maybe UpdateLayeredWindow here directly?
+    for (const auto &lua : g_lua_environments)
     {
-    case WM_PAINT: {
-        // NOTE: Sometimes, this control receives a WM_PAINT message while execution is already in WM_PAINT, causing us
-        // to call begin_present twice in a row... Usually this shouldn't happen, but the shell file dialog API causes
-        // this by messing with the parent window's message loop.
-        if (d2d_drawing)
-        {
-            g_view_logger->warn("Tried to clobber a D2D drawing section!");
-            break;
-        }
+        RedrawWindow(lua->rctx.gdi_overlay_hwnd, nullptr, nullptr, RDW_INVALIDATE);
+    }
 
-        d2d_drawing = true;
+    std::vector<t_lua_environment *> to_destroy;
+    for (const auto &lua : g_lua_environments)
+    {
+        const auto time_since_last_render =
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - lua->rctx.last_render_time).count();
 
-        auto lua = (t_lua_environment *)GetProp(hwnd, CTX_PROP);
+        const auto fps = lua->rctx.target_fps.value_or(1000.0f);
+        const auto target_frame_time = 1000.0f / fps;
 
-        if (!lua)
-        {
-            d2d_drawing = false;
-            break;
-        }
+        if (time_since_last_render < target_frame_time) continue;
 
         bool success;
         if (!lua->rctx.presenter)
@@ -54,16 +54,45 @@ static LRESULT CALLBACK d2d_overlay_wndproc(HWND hwnd, UINT msg, WPARAM wparam, 
             lua->rctx.presenter->end_present();
         }
 
-        ValidateRect(hwnd, nullptr);
-        d2d_drawing = false;
+        lua->rctx.last_render_time = now;
 
-        if (!success)
-        {
-            LuaManager::destroy_environment(lua);
-        }
-
-        return 0;
+        if (!success) to_destroy.push_back(lua);
     }
+
+    for (const auto &lua : to_destroy)
+    {
+        LuaManager::destroy_environment(lua);
+    }
+}
+
+static void draw_clock_proc()
+{
+    while (draw_thread_running)
+    {
+        g_main_ctx.dispatcher->invoke([]() { draw_lua(); });
+
+        DwmFlush();
+    }
+}
+
+static void stop_draw_clock()
+{
+    draw_thread_running = false;
+    if (draw_thread.joinable()) draw_thread.join();
+}
+
+static void start_draw_clock()
+{
+    draw_thread_running = true;
+    draw_thread = std::thread(draw_clock_proc);
+}
+
+static LRESULT CALLBACK d2d_overlay_wndproc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
+{
+    RT_ASSERT(is_on_gui_thread(), L"LuaRenderer::d2d_overlay_wndproc called from non-GUI thread");
+
+    switch (msg)
+    {
     case WM_NCDESTROY:
         RemoveProp(hwnd, CTX_PROP);
         break;
@@ -126,6 +155,14 @@ void LuaRenderer::init()
     RegisterClass(&wndclass);
 
     g_alpha_mask_brush = CreateSolidBrush(LUA_GDI_COLOR_MASK);
+
+    start_draw_clock();
+}
+
+void LuaRenderer::stop()
+{
+    stop_draw_clock();
+    DeleteObject(g_alpha_mask_brush);
 }
 
 static void create_loadscreen(t_lua_rendering_context *ctx)
@@ -151,31 +188,6 @@ static void destroy_loadscreen(t_lua_rendering_context *ctx)
     DeleteDC(ctx->loadscreen_dc);
     DeleteObject(ctx->loadscreen_bmp);
     ctx->loadscreen_dc = nullptr;
-}
-
-static void CALLBACK invalidate_callback(UINT, UINT, DWORD_PTR user, DWORD_PTR, DWORD_PTR)
-{
-    const auto hwnd = (HWND)user;
-    if (IsWindow(hwnd)) RedrawWindow(hwnd, nullptr, nullptr, RDW_INVALIDATE);
-}
-
-static void stop_invalidation_timers(t_lua_rendering_context *ctx)
-{
-    timeKillEvent(ctx->d2d_timer);
-    timeKillEvent(ctx->gdi_timer);
-}
-
-static void restart_invalidation_timers(t_lua_rendering_context *ctx)
-{
-    stop_invalidation_timers(ctx);
-
-    const auto fps = ctx->target_fps.value_or(1000.0f);
-    const auto ms = (UINT)std::round(1000.0f / fps);
-
-    ctx->d2d_timer = timeSetEvent(ms, 1, invalidate_callback, (DWORD_PTR)ctx->d2d_overlay_hwnd,
-                                  TIME_PERIODIC | TIME_KILL_SYNCHRONOUS);
-    ctx->gdi_timer = timeSetEvent(ms, 1, invalidate_callback, (DWORD_PTR)ctx->gdi_overlay_hwnd,
-                                  TIME_PERIODIC | TIME_KILL_SYNCHRONOUS);
 }
 
 t_lua_rendering_context LuaRenderer::default_rendering_context()
@@ -233,8 +245,8 @@ void LuaRenderer::create_renderer(t_lua_rendering_context *ctx, t_lua_environmen
     ReleaseDC(g_main_ctx.hwnd, gdi_dc);
 
     ctx->gdi_overlay_hwnd =
-        CreateWindowEx(WS_EX_LAYERED | WS_EX_TRANSPARENT, GDI_OVERLAY_CLASS, L"", WS_CHILD | WS_VISIBLE, 0, 0, ctx->dc_size.width,
-                       ctx->dc_size.height, g_main_ctx.hwnd, nullptr, g_main_ctx.hinst, nullptr);
+        CreateWindowEx(WS_EX_LAYERED | WS_EX_TRANSPARENT, GDI_OVERLAY_CLASS, L"", WS_CHILD | WS_VISIBLE, 0, 0,
+                       ctx->dc_size.width, ctx->dc_size.height, g_main_ctx.hwnd, nullptr, g_main_ctx.hinst, nullptr);
     SetLayeredWindowAttributes(ctx->gdi_overlay_hwnd, LUA_GDI_COLOR_MASK, 0, LWA_COLORKEY);
 
     ctx->gdi_front_dc = GetDC(ctx->gdi_overlay_hwnd);
@@ -243,8 +255,8 @@ void LuaRenderer::create_renderer(t_lua_rendering_context *ctx, t_lua_environmen
     FillRect(ctx->gdi_back_dc, &window_rect, g_alpha_mask_brush);
 
     ctx->d2d_overlay_hwnd =
-        CreateWindowEx(WS_EX_LAYERED | WS_EX_TRANSPARENT, D2D_OVERLAY_CLASS, L"", WS_CHILD | WS_VISIBLE, 0, 0, ctx->dc_size.width,
-                       ctx->dc_size.height, g_main_ctx.hwnd, nullptr, g_main_ctx.hinst, nullptr);
+        CreateWindowEx(WS_EX_LAYERED | WS_EX_TRANSPARENT, D2D_OVERLAY_CLASS, L"", WS_CHILD | WS_VISIBLE, 0, 0,
+                       ctx->dc_size.width, ctx->dc_size.height, g_main_ctx.hwnd, nullptr, g_main_ctx.hinst, nullptr);
 
     SetWindowPos(ctx->gdi_overlay_hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
     SetWindowPos(ctx->d2d_overlay_hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
@@ -259,7 +271,6 @@ void LuaRenderer::create_renderer(t_lua_rendering_context *ctx, t_lua_environmen
     }
 
     create_loadscreen(ctx);
-    restart_invalidation_timers(ctx);
 }
 
 void LuaRenderer::pre_destroy_renderer(t_lua_rendering_context *ctx)
@@ -268,7 +279,6 @@ void LuaRenderer::pre_destroy_renderer(t_lua_rendering_context *ctx)
     ctx->ignore_create_renderer = true;
     SetProp(ctx->gdi_overlay_hwnd, CTX_PROP, nullptr);
     SetProp(ctx->d2d_overlay_hwnd, CTX_PROP, nullptr);
-    stop_invalidation_timers(ctx);
 }
 
 void LuaRenderer::destroy_renderer(t_lua_rendering_context *ctx)
@@ -379,7 +389,6 @@ void LuaRenderer::set_target_fps(t_lua_rendering_context *rctx, std::optional<fl
     }
 
     rctx->target_fps = fps;
-    restart_invalidation_timers(rctx);
 }
 
 HBRUSH LuaRenderer::alpha_mask_brush()

--- a/src/Views.Win32/lua/LuaRenderer.h
+++ b/src/Views.Win32/lua/LuaRenderer.h
@@ -13,6 +13,11 @@ constexpr uint32_t LUA_GDI_COLOR_MASK = RGB(255, 0, 255);
 void init();
 
 /**
+ * \brief Stops the subsystem.
+ */
+void stop();
+
+/**
  * \brief Creates a new rendering context with the default values.
  */
 t_lua_rendering_context default_rendering_context();

--- a/src/Views.Win32/lua/LuaTypes.h
+++ b/src/Views.Win32/lua/LuaTypes.h
@@ -60,9 +60,7 @@ struct t_lua_rendering_context
     bool ignore_create_renderer{};
 
     std::optional<float> target_fps{};
-
-    MMRESULT d2d_timer{};
-    MMRESULT gdi_timer{};
+    std::chrono::steady_clock::time_point last_render_time{};
 
     HDC loadscreen_dc{};
     HBITMAP loadscreen_bmp{};

--- a/src/Views.Win32/stdafx.h
+++ b/src/Views.Win32/stdafx.h
@@ -49,6 +49,7 @@ extern "C"
 #include <d3dcompiler.h>
 #include <wrl/client.h>
 #include <dcomp.h>
+#include <dwmapi.h>
 #include <shlobj_core.h>
 #include <xxh64.h>
 #include <strsafe.h>


### PR DESCRIPTION
This fixes various **ABSURD** COM reentrancy issues such as file dialogs (or any other dialog box) nuking the application.

The performance impact is minimal. This new scheduling allows us to more easily improve performance in the future.

Closes #576 