### PR TITLE
build!: Dynamically link all vcpkg dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,15 +16,17 @@ project(mupen64-rr
 
 # The dynamic recompiler will not work correctly on x86_64, so it is completely disabled for safety's sake.
 set(MUPEN64RR_ENABLE_DYNAREC ON CACHE BOOL "If on, enables the dynamic recompiler.")
-if (NOT "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "^(x86|i[346]86)$")
+
+if(NOT "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "^(x86|i[346]86)$")
   message(STATUS "Target processor ${CMAKE_SYSTEM_PROCESSOR} is incompatible with the dynamic recompiler, disabling...")
   set(MUPEN64RR_ENABLE_DYNAREC OFF CACHE BOOL "If on, enables the dynamic recompiler. (FORCE-DISABLED)" FORCE)
 endif()
 
-# The Windows view can, of course, only be compiled on Windows. 
+# The Windows view can, of course, only be compiled on Windows.
 # This is in place to allow future frontends to be written separately.
 set(MUPEN64RR_BUILD_WIN32 ON CACHE BOOL "If on, enables the Win32 view and plugins.")
-if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+
+if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   message(STATUS "Target system ${CMAKE_SYSTEM_NAME} is incompatible with the Win32 frontend, disabling...")
   set(MUPEN64RR_BUILD_WIN32 OFF CACHE BOOL "If on, enables the Win32 view and plugins. (FORCE-DISABLED)" FORCE)
 endif()
@@ -38,7 +40,7 @@ if(NOT WIN32)
 endif()
 
 # version suffix
-if (DEFINED ENV{VERSION_SUFFIX})
+if(DEFINED ENV{VERSION_SUFFIX})
   set(MUPEN64RR_VERSION_SUFFIX "$ENV{VERSION_SUFFIX}")
 else()
   set(MUPEN64RR_VERSION_SUFFIX "")
@@ -71,9 +73,9 @@ find_package(nlohmann_json CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
 find_package(Catch2 CONFIG REQUIRED)
 
-if (MUPEN64RR_BUILD_WIN32)
-  find_package(glew CONFIG REQUIRED) 
-  find_package(SDL3 CONFIG REQUIRED) 
+if(MUPEN64RR_BUILD_WIN32)
+  find_package(glew CONFIG REQUIRED)
+  find_package(SDL3 CONFIG REQUIRED)
 endif()
 
 # Lua, because Lua sucks
@@ -89,12 +91,31 @@ if(LUA_FOUND AND NOT TARGET Lua::Lua)
   )
 endif()
 
+#[=======================[
+Copies all vcpkg dependencies into the target's folder.
+]=======================]
+function(mupen64rr_copy_vcpkg_deps target)
+  if (MUPEN64RR_LINK_STATIC)
+    return()
+  endif()
+  if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Windows" AND DEFINED VCPKG_INSTALLED_DIR))
+    return()
+  endif()
+
+  add_custom_command(
+    TARGET "${target}" POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E copy_directory_if_newer 
+      "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin" "$<TARGET_FILE_DIR:${target}>"
+    VERBATIM
+  )
+endfunction()
+
 # CMake modules
 # =======================================
 include(CTest)
 include(Catch)
 
-if (WIN32)
+if(WIN32)
   # Include linker options to:
   # - disable Address-Space Layout Randomization (ASLR)
   # - disable Windows Data Execution Prevention (DEP)
@@ -103,10 +124,10 @@ if (WIN32)
   add_link_options(/DYNAMICBASE:NO /NXCOMPAT:NO /LARGEADDRESSAWARE /MANIFEST:NO)
 
   # Include compile options to enable AVX2 on x64 builds
-  if ("${VCPKG_TARGET_TRIPLET}" MATCHES "^x64")
+  if("${VCPKG_TARGET_TRIPLET}" MATCHES "^x64")
     add_compile_options(/arch:AVX2)
   endif()
-  
+
   # Enable UTF-8 in Windows-adjacent APIs where possible
   add_compile_options(/utf-8)
 
@@ -114,12 +135,8 @@ if (WIN32)
   add_compile_definitions(UNICODE _UNICODE)
 endif()
 
-
-
 # define _DEBUG for debug builds
 add_compile_definitions("$<$<CONFIG:Debug>:_DEBUG>")
-
-
 
 # Subdirectories
 # ===========================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ function(mupen64rr_copy_vcpkg_deps target)
 
   add_custom_command(
     TARGET "${target}" POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" -E copy_directory_if_newer 
+    COMMAND "${CMAKE_COMMAND}" -E copy_directory 
       "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin" "$<TARGET_FILE_DIR:${target}>"
     VERBATIM
   )

--- a/src/Plugins.Win32.TASVideo/CMakeLists.txt
+++ b/src/Plugins.Win32.TASVideo/CMakeLists.txt
@@ -97,6 +97,8 @@ target_link_libraries(Mupen64RR.Plugins.Win32.TASVideo PRIVATE
     glu32
     winmm
 )
-target_compile_definitions(Mupen64RR.Plugins.Win32.TASVideo PRIVATE 
-    "GLEW_STATIC"
-)
+if (MUPEN64RR_LINK_STATIC)
+    target_compile_definitions(Mupen64RR.Plugins.Win32.TASVideo PRIVATE 
+        "GLEW_STATIC"
+    )
+endif()

--- a/src/Views.Win32/CMakeLists.txt
+++ b/src/Views.Win32/CMakeLists.txt
@@ -141,6 +141,7 @@ set_target_properties(Mupen64RR.Views.Win32 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${MUPEN64RR_OUT_DIR}"
     PDB_OUTPUT_DIRECTORY "${MUPEN64RR_OUT_DIR}"
 )
+mupen64rr_copy_vcpkg_deps(Mupen64RR.Views.Win32)
 # Dependencies of the resource file. These are specified manually,
 # but it wouldn't be impossible to write a scanner to gather this info automagically.
 set_source_files_properties(

--- a/test/Core.Tests/CMakeLists.txt
+++ b/test/Core.Tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(Mupen64RR.Core.Tests
     "stdafx.h"
     "vcr_tests.cpp"
 )
+mupen64rr_copy_vcpkg_deps(Mupen64RR.Core.Tests)
 set_target_properties(Mupen64RR.Core.Tests PROPERTIES
     CXX_STANDARD 23
     CXX_STANDARD_REQUIRED ON

--- a/toolchains/vcpkg-win64.cmake
+++ b/toolchains/vcpkg-win64.cmake
@@ -20,6 +20,7 @@ endif()
 set(_toolchain_sanitizer_keys OFF ASAN)
 set(_toolchain_sanitizer_values "" "-asan")
 
+set(MUPEN64RR_LINK_STATIC OFF CACHE BOOL "If enabled, links dependencies statically.")
 set(MUPEN64RR_USE_SANITIZER OFF CACHE STRING "Specifies a sanitizer to compile with. [${_toolchain_sanitizer_keys}]")
 
 # validate sanitizer option
@@ -33,6 +34,12 @@ endif()
 list(GET _toolchain_sanitizer_values "${_key_index}" _vcpkg_san_suffix)
 set(_vcpkg_san_suffix "${_vcpkg_san_suffix}" PARENT_SCOPE)
 endblock()
+
+if (MUPEN64RR_LINK_STATIC)
+  set(_vcpkg_static_suffix "-static")
+else()
+  set(_vcpkg_static_suffix "")
+endif()
 
 # CONFIGURATION
 # =========================================================
@@ -83,7 +90,7 @@ if(NOT EXISTS "${MUPEN64RR_VCPKG_TOOLCHAIN}")
 endif()
 
 # set some necessary settings to get compilation to work properly
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>" CACHE INTERNAL "MSVCRT variant needed to get things to work.")
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL" CACHE INTERNAL "MSVCRT variant needed to get things to work.")
 
 set(CMAKE_C_FLAGS_DEBUG_INIT)
 set(CMAKE_CXX_FLAGS_DEBUG_INIT)
@@ -94,8 +101,9 @@ if("${MUPEN64RR_USE_SANITIZER}" STREQUAL "ASAN")
 endif()
 
 # setup a few last values for vcpkg
-set(VCPKG_TARGET_TRIPLET "${_vs_target_arch}-windows-static${_vcpkg_san_suffix}" CACHE INTERNAL "target triplet for vcpkg")
+set(VCPKG_TARGET_TRIPLET "${_vs_target_arch}-windows${_vcpkg_static_suffix}${_vcpkg_san_suffix}" CACHE INTERNAL "target triplet for vcpkg")
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_LIST_DIR}/vcpkg-triplets")
+set(VCPKG_APPLOCAL_DEPS CACHE BOOL "Automatically copy dependencies into the output directory for executables." OFF)
 message(STATUS "VS architecture set to: ${_vs_target_arch}")
 
 # hand off the rest to vcpkg

--- a/toolchains/vcpkg-win64.cmake
+++ b/toolchains/vcpkg-win64.cmake
@@ -103,8 +103,8 @@ endif()
 # setup a few last values for vcpkg
 set(VCPKG_TARGET_TRIPLET "${_vs_target_arch}-windows${_vcpkg_static_suffix}${_vcpkg_san_suffix}" CACHE INTERNAL "target triplet for vcpkg")
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_LIST_DIR}/vcpkg-triplets")
-set(VCPKG_APPLOCAL_DEPS CACHE BOOL "Automatically copy dependencies into the output directory for executables." OFF)
 message(STATUS "VS architecture set to: ${_vs_target_arch}")
 
 # hand off the rest to vcpkg
 include(${MUPEN64RR_VCPKG_TOOLCHAIN})
+set(VCPKG_APPLOCAL_DEPS OFF CACHE BOOL "Automatically copy dependencies into the output directory for executables." FORCE)


### PR DESCRIPTION
The provided changes still allow static linking to be enabled, though I have yet to test this. It also does tend to clog up the output directory.