### PR TITLE
perf: use 32bpp BGRA video buffers

### DIFF
--- a/src/Core/include/core_api.h
+++ b/src/Core/include/core_api.h
@@ -196,7 +196,7 @@ extern "C"
 
         /**
          * \brief Writes the MGE compositor's current emulation front buffer into the destination buffer.
-         * \param buffer The video buffer. Must be at least of size <c>width * height * 3</c>, as acquired by
+         * \param buffer The video buffer. Must be at least of size <c>width * height * 4</c>, as acquired by
          * <c>plugin_funcs.get_video_size</c>.
          */
         void (*copy_video)(void *buffer);
@@ -216,7 +216,7 @@ extern "C"
         /**
          * \brief Fills the screen with the specified data.
          * The size of the buffer is determined by the resolution returned by the get_video_size (MGE) or readScreen
-         * (Non-MGE) functions. Note that the buffer format is 24bpp.
+         * (Non-MGE) functions. Note that the buffer format is 32bpp BGRA.
          */
         void (*load_screen)(void *data);
 

--- a/src/Core/memory/savestates.cpp
+++ b/src/Core/memory/savestates.cpp
@@ -213,13 +213,13 @@ std::vector<uint8_t> generate_savestate()
         g_core->video_get_video_size(&width, &height);
         g_core->log_trace(std::format("Writing screen buffer to savestate, width: {}, height: {}", width, height));
 
-        void *video = malloc(width * height * 3);
+        void *video = malloc(width * height * 4);
         g_core->copy_video(video);
 
         MiscHelpers::vecwrite(b, screen_section, sizeof(screen_section));
         MiscHelpers::vecwrite(b, &width, sizeof(width));
         MiscHelpers::vecwrite(b, &height, sizeof(height));
-        MiscHelpers::vecwrite(b, video, width * height * 3);
+        MiscHelpers::vecwrite(b, video, width * height * 4);
 
         free(video);
     }
@@ -465,8 +465,15 @@ void savestates_load_immediate_impl(const t_savestate_task &task)
                 MiscHelpers::memread(&ptr, &video_width, sizeof(video_width));
                 MiscHelpers::memread(&ptr, &video_height, sizeof(video_height));
 
-                video_buffer = malloc(video_width * video_height * 3);
-                MiscHelpers::memread(&ptr, video_buffer, video_width * video_height * 3);
+                const auto remaining_space = decompressed_buf.size() - (ptr - decompressed_buf.data());
+                const auto has_enough_space = remaining_space >= video_width * video_height * 4;
+                if (has_enough_space)
+                {
+                    video_buffer = malloc(video_width * video_height * 4);
+                    MiscHelpers::memread(&ptr, video_buffer, video_width * video_height * 4);
+                }
+                else
+                    g_core->log_error(std::format("[Savestates] Not enough space left in buffer for screen buffer"));
             }
         }
 

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -22,7 +22,7 @@ void OGL_ReadPixels()
     // glReadBuffer(GL_FRONT);
 
     glReadBuffer(GL_BACK);
-    glReadPixels(0, OGL.heightOffset, OGL.width, OGL.height, GL_BGR, GL_UNSIGNED_BYTE, gCapturedPixels);
+    glReadPixels(0, OGL.heightOffset, OGL.width, OGL.height, GL_BGRA, GL_UNSIGNED_BYTE, gCapturedPixels);
     glReadBuffer(oldMode); // restore old read buffer
 }
 
@@ -913,16 +913,16 @@ void OGL_SaveScreenshot()
     BITMAPINFOHEADER infoHeader;
     HANDLE hBitmapFile;
 
-    gCapturedPixels = malloc(OGL.width * OGL.height * 3);
+    gCapturedPixels = malloc(OGL.width * OGL.height * 4);
     OGL_ReadPixels();
 
     infoHeader.biSize = sizeof(BITMAPINFOHEADER);
     infoHeader.biWidth = OGL.width;
     infoHeader.biHeight = OGL.height;
     infoHeader.biPlanes = 1;
-    infoHeader.biBitCount = 24;
+    infoHeader.biBitCount = 32;
     infoHeader.biCompression = BI_RGB;
-    infoHeader.biSizeImage = OGL.width * OGL.height * 3;
+    infoHeader.biSizeImage = OGL.width * OGL.height * 4;
     infoHeader.biXPelsPerMeter = 0;
     infoHeader.biYPelsPerMeter = 0;
     infoHeader.biClrUsed = 0;

--- a/src/Plugins.Win32.TASVideo/glN64.cpp
+++ b/src/Plugins.Win32.TASVideo/glN64.cpp
@@ -232,7 +232,7 @@ EXPORT void CALL ReadScreen2(void **dest, long *width, long *height)
     *width = OGL.width;
     *height = OGL.height;
 
-    *dest = malloc(OGL.height * OGL.width * 3);
+    *dest = malloc(OGL.height * OGL.width * 4);
     if (*dest == 0) return;
     gCapturedPixels = *dest;
     if (RSP.thread)
@@ -248,7 +248,7 @@ void CALL mge_get_video_size(long *width, long *height)
     *height = OGL.height;
 }
 
-void CALL mge_read_video(void **buffer)
+void CALL mge_read_video2(void **buffer)
 {
     extern void *gCapturedPixels;
     gCapturedPixels = *buffer;

--- a/src/Views.Win32/Config.h
+++ b/src/Views.Win32/Config.h
@@ -142,7 +142,7 @@ struct t_config
     /// FFmpeg post-stream option format string which is used when capturing using the FFmpeg encoder type
     /// </summary>
     std::wstring ffmpeg_final_options =
-        L"-y -f rawvideo -pixel_format bgr24 -video_size %dx%d -framerate %d -i %s "
+        L"-y -f rawvideo -pixel_format bgra -video_size %dx%d -framerate %d -i %s "
         L"-f s16le -sample_rate %d -ac 2 -channel_layout stereo -i %s "
         L"-c:v libx264 -preset veryfast -tune zerolatency -crf 23 -c:a aac -b:a 128k -vf \"vflip\" -f mp4 %s";
 

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -183,7 +183,7 @@ void load_gfx(HMODULE handle)
     FUNC(g_plugin_funcs.video_capture_screen, CAPTURESCREEN, nullptr, "CaptureScreen");
     FUNC(g_plugin_funcs.video_read_screen, READSCREEN, (READSCREEN)GetProcAddress(handle, "ReadScreen2"), "ReadScreen");
     FUNC(g_plugin_funcs.video_get_video_size, GETVIDEOSIZE, nullptr, "mge_get_video_size");
-    FUNC(g_plugin_funcs.video_read_video, READVIDEO, nullptr, "mge_read_video");
+    FUNC(g_plugin_funcs.video_read_video, READVIDEO, nullptr, "mge_read_video2");
     FUNC(g_plugin_funcs.video_fb_read, FBREAD, dummy_fb_read, "FBRead");
     FUNC(g_plugin_funcs.video_fb_write, FBWRITE, dummy_fb_write, "FBWrite");
     FUNC(g_plugin_funcs.video_fb_get_frame_buffer_info, FBGETFRAMEBUFFERINFO, dummy_fb_get_framebuffer_info,
@@ -536,6 +536,14 @@ void Plugin::initiate()
     case plugin_rsp:
         load_rsp(m_module);
         break;
+    }
+
+    // Old MGE plugins with 24bpp mge_read_video aren't supported anymore.
+    if (!g_plugin_funcs.video_read_video && GetProcAddress(m_module, "mge_read_video"))
+    {
+        const auto msg = std::format(L"The plugin {} is incompatible with this version of Mupen64.",
+                                     IOUtils::to_wide_string(m_name));
+        DialogService::show_dialog(msg.c_str(), L"Plugin Incompatibility", fsvc_error);
     }
 }
 

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -540,8 +540,9 @@ void Plugin::initiate()
 
     bool compat_error = false;
 
-    // Old MGE plugins with 24bpp mge_read_video aren't supported anymore.
-    if (!g_plugin_funcs.video_read_video && GetProcAddress(m_module, "mge_read_video")) compat_error = true;
+    // Old MGE video plugins with 24bpp mge_read_video aren't supported anymore.
+    if (m_type == plugin_video && !g_plugin_funcs.video_read_video && GetProcAddress(m_module, "mge_read_video"))
+        compat_error = true;
 
     if (compat_error)
     {

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -538,11 +538,16 @@ void Plugin::initiate()
         break;
     }
 
+    bool compat_error = false;
+
     // Old MGE plugins with 24bpp mge_read_video aren't supported anymore.
-    if (!g_plugin_funcs.video_read_video && GetProcAddress(m_module, "mge_read_video"))
+    if (!g_plugin_funcs.video_read_video && GetProcAddress(m_module, "mge_read_video")) compat_error = true;
+
+    if (compat_error)
     {
-        const auto msg = std::format(L"The plugin {} is incompatible with this version of Mupen64.",
-                                     IOUtils::to_wide_string(m_name));
+        const auto msg =
+            std::format(L"The plugin {} is incompatible with this version of Mupen64 and may not work properly.",
+                        IOUtils::to_wide_string(m_name));
         DialogService::show_dialog(msg.c_str(), L"Plugin Incompatibility", fsvc_error);
     }
 }

--- a/src/Views.Win32/capture/CaptureManager.cpp
+++ b/src/Views.Win32/capture/CaptureManager.cpp
@@ -61,7 +61,7 @@ void readscreen_plugin(int32_t *width = nullptr, int32_t *height = nullptr)
         int32_t w;
         int32_t h;
         g_plugin_funcs.video_read_screen(&buf, &w, &h);
-        memcpy(m_video_buf, buf, w * h * 3);
+        memcpy(m_video_buf, buf, w * h * 4);
         g_plugin_funcs.video_dll_crt_free(buf);
 
         if (width)
@@ -91,10 +91,12 @@ void readscreen_window()
         bmp_info.bmiHeader.biWidth = m_video_width;
         bmp_info.bmiHeader.biHeight = m_video_height;
         bmp_info.bmiHeader.biPlanes = 1;
-        bmp_info.bmiHeader.biBitCount = 24;
+        bmp_info.bmiHeader.biBitCount = 32;
         bmp_info.bmiHeader.biCompression = BI_RGB;
 
         GetDIBits(compat_dc, bitmap, 0, m_video_height, m_video_buf, &bmp_info, DIB_RGB_COLORS);
+        for (int i = 3; i < m_video_width * m_video_height * 4; i += 4)
+            m_video_buf[i] = 0xFF;
 
         SelectObject(compat_dc, nullptr);
         DeleteObject(bitmap);
@@ -122,10 +124,12 @@ void readscreen_desktop()
         bmp_info.bmiHeader.biWidth = m_video_width;
         bmp_info.bmiHeader.biHeight = m_video_height;
         bmp_info.bmiHeader.biPlanes = 1;
-        bmp_info.bmiHeader.biBitCount = 24;
+        bmp_info.bmiHeader.biBitCount = 32;
         bmp_info.bmiHeader.biCompression = BI_RGB;
 
         GetDIBits(compat_dc, bitmap, 0, m_video_height, m_video_buf, &bmp_info, DIB_RGB_COLORS);
+        for (int i = 3; i < m_video_width * m_video_height * 4; i += 4)
+            m_video_buf[i] = 0xFF;
 
         SelectObject(compat_dc, nullptr);
         DeleteObject(bitmap);
@@ -162,7 +166,7 @@ void readscreen_hybrid()
             BITMAPINFO bmp_info{};
             bmp_info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
             bmp_info.bmiHeader.biPlanes = 1;
-            bmp_info.bmiHeader.biBitCount = 24;
+            bmp_info.bmiHeader.biBitCount = 32;
             bmp_info.bmiHeader.biWidth = raw_video_width;
             bmp_info.bmiHeader.biHeight = raw_video_height;
             bmp_info.bmiHeader.biCompression = BI_RGB;
@@ -194,10 +198,12 @@ void readscreen_hybrid()
         bmp_info.bmiHeader.biWidth = m_video_width;
         bmp_info.bmiHeader.biHeight = m_video_height;
         bmp_info.bmiHeader.biPlanes = 1;
-        bmp_info.bmiHeader.biBitCount = 24;
+        bmp_info.bmiHeader.biBitCount = 32;
         bmp_info.bmiHeader.biCompression = BI_RGB;
 
         GetDIBits(hy_dc, hy_bmp, 0, m_video_height, m_video_buf, &bmp_info, DIB_RGB_COLORS);
+        for (int i = 3; i < m_video_width * m_video_height * 4; i += 4)
+            m_video_buf[i] = 0xFF;
     });
 }
 
@@ -359,7 +365,7 @@ bool start_capture_impl(std::filesystem::path path, t_config::EncoderType encode
 
     free(m_video_buf);
     get_video_dimensions(&m_video_width, &m_video_height);
-    m_video_buf = (uint8_t *)malloc(m_video_width * m_video_height * 3);
+    m_video_buf = (uint8_t *)malloc(m_video_width * m_video_height * 4);
 
     m_encoder_params = Encoder::Params{
         .path = m_current_path,

--- a/src/Views.Win32/capture/encoders/FFmpegEncoder.cpp
+++ b/src/Views.Win32/capture/encoders/FFmpegEncoder.cpp
@@ -61,7 +61,7 @@ std::optional<std::wstring> FFmpegEncoder::start(Params params)
     }
 
     m_silence_buffer = static_cast<uint8_t *>(calloc(params.arate, 1));
-    m_blank_buffer = static_cast<uint8_t *>(calloc(m_params.width * m_params.height * 3, 1));
+    m_blank_buffer = static_cast<uint8_t *>(calloc(m_params.width * m_params.height * 4, 1));
     m_dropped_frames = 0;
 
     m_video_thread = std::thread(&FFmpegEncoder::write_video_thread, this);
@@ -169,7 +169,7 @@ bool FFmpegEncoder::append_video(uint8_t *image)
 
     m_last_write_was_video = true;
 
-    auto buf = static_cast<uint8_t *>(malloc(m_params.width * m_params.height * 3));
+    auto buf = static_cast<uint8_t *>(malloc(m_params.width * m_params.height * 4));
 
     // HACK: If we run out of memory, we start writing empty video frames
     // This can happen when capturing at high resolutions, as ffmpeg might not start processing the pipe writes in time
@@ -186,7 +186,7 @@ bool FFmpegEncoder::append_video(uint8_t *image)
         return true;
     }
 
-    memcpy(buf, image, m_params.width * m_params.height * 3);
+    memcpy(buf, image, m_params.width * m_params.height * 4);
 
     {
         std::lock_guard lock(m_video_queue_mutex);
@@ -246,7 +246,7 @@ void FFmpegEncoder::write_video_thread()
         this->m_video_queue.pop();
         lock.unlock();
 
-        write_pipe_checked(m_video_pipe, (char *)pair.first, m_params.width * m_params.height * 3, true);
+        write_pipe_checked(m_video_pipe, (char *)pair.first, m_params.width * m_params.height * 4, true);
         if (pair.second)
         {
             free(pair.first);

--- a/src/Views.Win32/capture/encoders/VFWEncoder.cpp
+++ b/src/Views.Win32/capture/encoders/VFWEncoder.cpp
@@ -24,9 +24,9 @@ std::optional<std::wstring> VFWEncoder::start(Params params)
     m_info_hdr.biWidth = params.width;
     m_info_hdr.biHeight = params.height;
     m_info_hdr.biPlanes = 1;
-    m_info_hdr.biBitCount = 24;
+    m_info_hdr.biBitCount = 32;
     m_info_hdr.biCompression = BI_RGB;
-    m_info_hdr.biSizeImage = params.width * params.height * 3;
+    m_info_hdr.biSizeImage = params.width * params.height * 4;
     m_info_hdr.biXPelsPerMeter = 0;
     m_info_hdr.biYPelsPerMeter = 0;
     m_info_hdr.biClrUsed = 0;

--- a/src/Views.Win32/components/MGECompositor.cpp
+++ b/src/Views.Win32/components/MGECompositor.cpp
@@ -10,7 +10,7 @@
 #include <Messenger.h>
 
 constexpr auto CONTROL_CLASS_NAME = L"game_control";
-constexpr DXGI_FORMAT TEXTURE_FORMAT = DXGI_FORMAT_B8G8R8X8_UNORM;
+constexpr DXGI_FORMAT TEXTURE_FORMAT = DXGI_FORMAT_B8G8R8A8_UNORM;
 constexpr float CLEAR_COLOR[4] = {0, 0, 0, 1};
 
 const std::string VERTEX_SHADER = R"(
@@ -61,7 +61,6 @@ struct t_mge_context
     int32_t last_height{};
     int32_t width{};
     int32_t height{};
-    void *buffer{};
     void *rgba_buffer{};
 
     HWND hwnd{};
@@ -275,28 +274,7 @@ static void render_and_present()
     hr = mge_context.swapchain->Present(0, DXGI_PRESENT_DO_NOT_WAIT);
 }
 
-static void copy_rgb24_buffer_to_rgb32()
-{
-    const auto src = static_cast<const uint8_t *>(mge_context.buffer);
-    const auto dst = static_cast<uint8_t *>(mge_context.rgba_buffer);
 
-    const int width = mge_context.width;
-    const int height = mge_context.height;
-
-    for (int y = 0; y < height; ++y)
-    {
-        const uint8_t *srow = src + y * width * 3;
-        uint8_t *drow = dst + y * width * 4;
-
-        for (int x = 0; x < width; ++x)
-        {
-            std::memcpy(drow, srow, 3);
-
-            srow += 3;
-            drow += 4;
-        }
-    }
-}
 
 static void recreate_mge_context_d3d()
 {
@@ -307,18 +285,14 @@ static void recreate_mge_context_d3d()
         create_d3d(mge_context.hwnd);
     }
 
-    _aligned_free(mge_context.buffer);
     _aligned_free(mge_context.rgba_buffer);
 
-    const auto rgb24_buffer_size = mge_context.width * mge_context.height * 3;
-    const auto rgba32_buffer_size = mge_context.width * mge_context.height * 4;
+    const auto buffer_size = mge_context.width * mge_context.height * 4;
 
-    mge_context.buffer = _aligned_malloc(rgb24_buffer_size, 16);
-    mge_context.rgba_buffer = _aligned_malloc(rgba32_buffer_size, 16);
-    RT_ASSERT(mge_context.buffer && mge_context.rgba_buffer, L"Failed to allocate MGE buffers");
+    mge_context.rgba_buffer = _aligned_malloc(buffer_size, 16);
+    RT_ASSERT(mge_context.rgba_buffer, L"Failed to allocate MGE buffers");
 
-    ZeroMemory(mge_context.buffer, rgb24_buffer_size);
-    ZeroMemory(mge_context.rgba_buffer, rgba32_buffer_size);
+    ZeroMemory(mge_context.rgba_buffer, buffer_size);
 
     RECT rc;
     RT_ASSERT(GetClientRect(mge_context.hwnd, &rc), L"GetClientRect failed");
@@ -389,9 +363,8 @@ void MGECompositor::update_screen()
         recreate_mge_context_d3d();
     }
 
-    g_plugin_funcs.video_read_video(&mge_context.buffer);
+    g_plugin_funcs.video_read_video(&mge_context.rgba_buffer);
 
-    copy_rgb24_buffer_to_rgb32();
     upload_rgb32_buffer();
     render_and_present();
 
@@ -418,14 +391,13 @@ void MGECompositor::get_video_size(int32_t *width, int32_t *height)
 
 void MGECompositor::copy_video(void *buffer)
 {
-    memcpy(buffer, mge_context.buffer, mge_context.width * mge_context.height * 3);
+    memcpy(buffer, mge_context.rgba_buffer, mge_context.width * mge_context.height * 4);
 }
 
 void MGECompositor::load_screen(void *data)
 {
-    memcpy(mge_context.buffer, data, mge_context.width * mge_context.height * 3);
+    memcpy(mge_context.rgba_buffer, data, mge_context.width * mge_context.height * 4);
 
-    copy_rgb24_buffer_to_rgb32();
     ensure_texture_exists_with_size(mge_context.width, mge_context.height);
     upload_rgb32_buffer();
     render_and_present();

--- a/src/Views.Win32/components/MGECompositor.h
+++ b/src/Views.Win32/components/MGECompositor.h
@@ -41,16 +41,16 @@ void get_video_size(int32_t *width, int32_t *height);
 
 /**
  * \brief Writes the MGE compositor's current emulation front buffer into the destination buffer.
- * \param buffer The video buffer. Must be at least of size <c>width * height * 3</c>, as acquired by
- * <c>mge_get_video_size</c>.
+ * \param buffer The video buffer. Must be at least of size <c>width * height * 4</c>, as acquired by
+ * <c>mge_get_video_size</c>. The buffer format is 32bpp BGRA.
  */
 void copy_video(void *buffer);
 
 /**
  * \brief Draws the given data to the MGE surface.
- * \param data The buffer holding video data. Must be at least of size <c>width * height * 3</c>, as acquired by
- * <c>mge_get_video_size</c>. \remarks The video buffer's size must match the current video size provided by
- * <c>get_video_size</c>.
+ * \param data The buffer holding video data. Must be at least of size <c>width * height * 4</c>, as acquired by
+ * <c>mge_get_video_size</c>. The buffer format is 32bpp BGRA. \remarks The video buffer's size must match the
+ * current video size provided by <c>get_video_size</c>.
  */
 void load_screen(void *data);
 } // namespace MGECompositor

--- a/src/Views.Win32/include/Views.Win32/ViewPlugin.h
+++ b/src/Views.Win32/include/Views.Win32/ViewPlugin.h
@@ -115,7 +115,7 @@ extern "C"
     EXPORT void CALL ViStatusChanged(void);
     EXPORT void CALL ViWidthChanged(void);
     EXPORT void CALL mge_get_video_size(long *width, long *height);
-    EXPORT void CALL mge_read_video(void **);
+    EXPORT void CALL mge_read_video2(void **);
 
 #pragma endregion
 

--- a/src/Website/static/docs/win/8. Data-Formats.md
+++ b/src/Website/static/docs/win/8. Data-Formats.md
@@ -140,4 +140,4 @@ Video buffer (only present if user enabled it):
 `0xA02BCC` + Interrupt queue length + 4 * (Sample count + 1) | 4 | Video section identifier - `0x53435200` (st file ends here on savestates without this section)
 `0xA02BCC` + Interrupt queue length + 4 * (Sample count + 1) + 4 | 4 | Video buffer width
 `0xA02BCC` + Interrupt queue length + 4 * (Sample count + 1) + 8 | 4 | Video buffer height
-`0xA02BCC` + Interrupt queue length + 4 * (Sample count + 1) + 12 | width * height * 4 | RGBA Video buffer data.
+`0xA02BCC` + Interrupt queue length + 4 * (Sample count + 1) + 12 | width * height * 4 | 32bpp BGRA Video buffer data.

--- a/src/Website/static/docs/win/8. Data-Formats.md
+++ b/src/Website/static/docs/win/8. Data-Formats.md
@@ -140,4 +140,4 @@ Video buffer (only present if user enabled it):
 `0xA02BCC` + Interrupt queue length + 4 * (Sample count + 1) | 4 | Video section identifier - `0x53435200` (st file ends here on savestates without this section)
 `0xA02BCC` + Interrupt queue length + 4 * (Sample count + 1) + 4 | 4 | Video buffer width
 `0xA02BCC` + Interrupt queue length + 4 * (Sample count + 1) + 8 | 4 | Video buffer height
-`0xA02BCC` + Interrupt queue length + 4 * (Sample count + 1) + 12 | width * height * 3 | Video buffer data
+`0xA02BCC` + Interrupt queue length + 4 * (Sample count + 1) + 12 | width * height * 4 | RGBA Video buffer data.


### PR DESCRIPTION
Changes all game video buffer stuff to be 32bpp with an opaque alpha channel. This allows skipping the CPU-side 24bpp RGB-> 32bpp BGRA conversion step in the MGE compositor, which improves performance on the UI thread and therefore also lowers dispatcher latency (speeds up Lua).

Comes with a bonus bombastic plugin API compatibility break which requires updating TASVideo, but we ship all this stuff together so that's fine :D