### PR TITLE
perf(LuaRenderer): skip expensive `TransparentBlt` during capture

### DIFF
--- a/src/Views.Win32/capture/CaptureManager.cpp
+++ b/src/Views.Win32/capture/CaptureManager.cpp
@@ -174,22 +174,7 @@ void readscreen_hybrid()
                           m_video_buf, &bmp_info, DIB_RGB_COLORS, SRCCOPY);
         }
 
-        // First, composite the lua's dxgi surfaces
-        for (auto &lua : g_lua_environments)
-        {
-            if (lua->rctx.presenter)
-            {
-                lua->rctx.presenter->blit(
-                    hy_dc, {0, 0, (LONG)lua->rctx.presenter->size().width, (LONG)lua->rctx.presenter->size().height});
-            }
-        }
-
-        // Then, blit the GDI back DCs
-        for (auto &lua : g_lua_environments)
-        {
-            TransparentBlt(hy_dc, 0, 0, lua->rctx.dc_size.width, lua->rctx.dc_size.height, lua->rctx.gdi_back_dc, 0, 0,
-                           lua->rctx.dc_size.width, lua->rctx.dc_size.height, LuaRenderer::LUA_GDI_COLOR_MASK);
-        }
+        LuaRenderer::blit_all(hy_dc);
 
         BITMAPINFO bmp_info{};
         bmp_info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);

--- a/src/Views.Win32/lua/LuaRenderer.cpp
+++ b/src/Views.Win32/lua/LuaRenderer.cpp
@@ -433,3 +433,22 @@ HBRUSH LuaRenderer::alpha_mask_brush()
 {
     return g_alpha_mask_brush;
 }
+
+void LuaRenderer::blit_all(HDC hdc)
+{
+    for (const auto &lua : g_lua_environments)
+    {
+        if (!lua->rctx.presenter) continue;
+
+        lua->rctx.presenter->blit(
+            hdc, {0, 0, (LONG)lua->rctx.presenter->size().width, (LONG)lua->rctx.presenter->size().height});
+    }
+
+    for (const auto &lua : g_lua_environments)
+    {
+        if (!lua->rctx.has_gdi_content) continue;
+
+        TransparentBlt(hdc, 0, 0, lua->rctx.dc_size.width, lua->rctx.dc_size.height, lua->rctx.gdi_back_dc, 0, 0,
+                       lua->rctx.dc_size.width, lua->rctx.dc_size.height, LuaRenderer::LUA_GDI_COLOR_MASK);
+    }
+}

--- a/src/Views.Win32/lua/LuaRenderer.cpp
+++ b/src/Views.Win32/lua/LuaRenderer.cpp
@@ -440,8 +440,8 @@ void LuaRenderer::blit_all(HDC hdc)
     {
         if (!lua->rctx.presenter) continue;
 
-        lua->rctx.presenter->blit(
-            hdc, {0, 0, (LONG)lua->rctx.presenter->size().width, (LONG)lua->rctx.presenter->size().height});
+        const auto presenter_size = lua->rctx.presenter->size();
+        lua->rctx.presenter->blit(hdc, {0, 0, (LONG)presenter_size.width, (LONG)presenter_size.height});
     }
 
     for (const auto &lua : g_lua_environments)

--- a/src/Views.Win32/lua/LuaRenderer.h
+++ b/src/Views.Win32/lua/LuaRenderer.h
@@ -70,4 +70,9 @@ void set_target_fps(t_lua_rendering_context *rctx, std::optional<float> fps);
  * the renderer.
  */
 HBRUSH alpha_mask_brush();
+
+/**
+ * \brief Blits the graphics contents of all active Lua instances to the given HDC.
+ */
+void blit_all(HDC hdc);
 } // namespace LuaRenderer


### PR DESCRIPTION
whenever possible

also contains a neat refactor