### PR TITLE
fix(DialogService): crash when cancelling settings with silent mode

### DIFF
--- a/src/Views.Win32/DialogService.cpp
+++ b/src/Views.Win32/DialogService.cpp
@@ -11,7 +11,7 @@
 
 StrUtils::unordered_string_map<size_t> dialog_choice_map;
 
-const std::vector<std::string> ALWAYS_LOUD_IDS = {VIEW_DLG_RAMSTART};
+const std::vector<std::string> ALWAYS_LOUD_IDS = {VIEW_DLG_RAMSTART, VIEW_DLG_CONFIRM_SETTINGS_DISCARD};
 
 size_t DialogService::show_multiple_choice_dialog(std::string_view id, const std::vector<std::wstring> &choices,
                                                   const wchar_t *str, const wchar_t *title, core_dialog_type type,


### PR DESCRIPTION
## Bug

When **silent_mode** is enabled, cancelling settings with unsaved changes crashes the emulator.

**WinDbg stack trace (Settings -> change -> Cancel):**
```
00 KERNELBASE!RaiseException+0x62
01 VCRUNTIME140D!_CxxThrowException+0xa1
02 MSVCP140D!std::_Xinvalid_argument+0x20
03 mupen64!std::stoi+0x69
04 mupen64!DialogService::show_multiple_choice_dialog+0x1c8
05 mupen64!DialogService::show_ask_dialog+0x156
06 mupen64!base_pageproc+0xad
```

## Root Cause

VIEW_DLG_CONFIRM_SETTINGS_DISCARD was not in ALWAYS_LOUD_IDS. When silent_mode is active, the code tries to read the silent answer for this dialog from g_config.silent_mode_dialog_choices, which returns an empty string (key not found). std::stoi("") throws std::invalid_argument -> crash.

## Fix

Add VIEW_DLG_CONFIRM_SETTINGS_DISCARD to ALWAYS_LOUD_IDS. A "discard changes" confirmation dialog should never be silenced anyway.

## Verification
- Tested on Win10 22H2 with debug build
- Settings -> Cancel with unsaved changes no longer crashes
- Other silent-mode dialogs unaffected

changelog: skip
