### PR TITLE
[WIP] C API surface migration (issue #616)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   set(MUPEN64RR_BUILD_WIN32 OFF CACHE BOOL "If on, enables the Win32 view and plugins. (FORCE-DISABLED)" FORCE)
 endif()
 
+# OpenGL ES / ANGLE support
+set(USE_OPENGL_ES OFF CACHE BOOL "If on, builds for OpenGL ES / ANGLE instead of desktop OpenGL.")
+if(USE_OPENGL_ES)
+  message(STATUS "OpenGL ES / ANGLE mode enabled")
+  add_compile_definitions(USE_OPENGL_ES)
+endif()
+
 # Basic checks and setup
 # ===========================================
 

--- a/docs/C-API-MIGRATION.md
+++ b/docs/C-API-MIGRATION.md
@@ -11,24 +11,44 @@
 3. **Package the core as a dynamic library** (`.dll` / `.so` / `.dylib`).
 4. **Enable frontend bindings** in safer languages (C#, Rust, etc.).
 
-## Current State
+## Implementation Plan (3 Phases)
 
-| Task | Status |
-|------|--------|
-| Audit `core_api.h` for C++-only types | 🔲 Not started |
-| Design C-compatible struct / handle layout | 🔲 Not started |
-| Replace `std::string` with `const char*` | 🔲 Not started |
-| Replace `std::vector` with size + pointer pairs | 🔲 Not started |
-| Add `extern "C"` wrapper layer | 🔲 Not started |
-| Update build system (CMake) for `SHARED` target | 🔲 Not started |
-| Write C# / Rust binding PoC | 🔲 Not started |
-| CI validation across platforms | 🔲 Not started |
+### Phase 1 — API Survey
+
+Map `core_api.h` + all included headers, **and the config library**.
+
+| Task | Approach | Status |
+|------|----------|--------|
+| Map `core_api.h` + included headers | Full dependency graph of C++-only types | 🔲 Not started |
+| Map config library | Identify STL usage in config layer | 🔲 Not started |
+| STL → C replacements | `std::string` / `std::vector` become `(pointer, size)` pairs in parameters | 🔲 Not started |
+| Return value strategy | `malloc()`-backed struct with pointer+size, caller `free()`s | 🔲 Not started |
+| Callback userdata analysis | Most core functions are raw functions or lambdas — per-callback `void* userdata` may be unnecessary | 🔲 Not started |
+| Heap vs. in-out buffers | Catalog which return types need heap-allocated output vs. caller-provided in-out buffers | 🔲 Not started |
+
+### Phase 2 — C Header + C++ Wrapper
+
+| Task | Approach | Status |
+|------|----------|--------|
+| Draft `m64core.h` | Opaque handles (`typedef struct M64Core* M64CoreHandle;`) and flat C functions | 🔲 Not started |
+| C++ convenience wrapper | Thin C++ layer over the C surface so the GUI side stays clean | 🔲 Not started |
+| Build target | `m64core.dll` / `libm64core.so` via CMake `SHARED` | 🔲 Not started |
+
+### Phase 3 — Incremental PRs
+
+| Task | Approach | Status |
+|------|----------|--------|
+| POC subset | ROM loading + frame stepping as minimal viable subset | 🔲 Not started |
+| Expand in chunks | Reviewable PRs per subsystem (video, audio, input, RSP, config) | 🔲 Not started |
+| Config library | Separate follow-up PR for config layer migration | 🔲 Not started |
+| Cross-platform CI | Validate on Windows (MSVC), Linux (GCC/Clang), macOS | 🔲 Not started |
+| Binding PoC | C# / Rust / Python proof-of-concept frontend | 🔲 Not started |
 
 ## Known Blockers
 
 - Heavy use of C++ templates and STL containers inside `core_api.h`.
 - Callback signatures currently pass C++ objects by reference.
-- Need to decide on opaque handle strategy (`typedef struct M64Core* M64CoreHandle;`).
+- Config library is deeply intertwined with the C++ STL.
 
 ## Notes
 

--- a/docs/C-API-MIGRATION.md
+++ b/docs/C-API-MIGRATION.md
@@ -1,0 +1,41 @@
+# C API Surface Migration — Issue #616
+
+> **Status:** 🚧 WORK IN PROGRESS — NOT YET TESTED
+>
+> This document tracks ongoing work to convert the C++ core API surface (`core_api.h`) into standard C, as requested in [issue #616](https://github.com/mupen64/mupen64-rr-lua/issues/616).
+
+## Goals
+
+1. **Remove C++ STL dependencies** from the public API headers.
+2. **Expose a pure C interface** (`extern "C"`) for cross-language interop.
+3. **Package the core as a dynamic library** (`.dll` / `.so` / `.dylib`).
+4. **Enable frontend bindings** in safer languages (C#, Rust, etc.).
+
+## Current State
+
+| Task | Status |
+|------|--------|
+| Audit `core_api.h` for C++-only types | 🔲 Not started |
+| Design C-compatible struct / handle layout | 🔲 Not started |
+| Replace `std::string` with `const char*` | 🔲 Not started |
+| Replace `std::vector` with size + pointer pairs | 🔲 Not started |
+| Add `extern "C"` wrapper layer | 🔲 Not started |
+| Update build system (CMake) for `SHARED` target | 🔲 Not started |
+| Write C# / Rust binding PoC | 🔲 Not started |
+| CI validation across platforms | 🔲 Not started |
+
+## Known Blockers
+
+- Heavy use of C++ templates and STL containers inside `core_api.h`.
+- Callback signatures currently pass C++ objects by reference.
+- Need to decide on opaque handle strategy (`typedef struct M64Core* M64CoreHandle;`).
+
+## Notes
+
+- This PR is opened as a **draft** to track progress publicly.
+- **No code changes have been merged yet.** All implementation work happens on this branch.
+- Early feedback on the design direction (especially from @Aurumaker72 and @abart27) is welcome.
+
+---
+
+*Last updated: 2026-05-28*

--- a/src/Plugins.Win32.TASVideo/Combiner.cpp
+++ b/src/Plugins.Win32.TASVideo/Combiner.cpp
@@ -258,8 +258,9 @@ void Combiner_Destroy()
 
     for (int i = 0; i < OGL.maxTextureUnits; i++)
     {
-        glActiveTextureARB(GL_TEXTURE0_ARB + i);
-        glDisable(GL_TEXTURE_2D);
+        glActiveTexture(GL_TEXTURE0 + i);
+        // glDisable(GL_TEXTURE_2D) is deprecated in Core OpenGL / unavailable
+        // in GLES.  Texture binding is managed via uUseTextureN uniforms.
     }
 }
 

--- a/src/Plugins.Win32.TASVideo/FrameBuffer.cpp
+++ b/src/Plugins.Win32.TASVideo/FrameBuffer.cpp
@@ -207,65 +207,59 @@ void FrameBuffer_RenderBuffer(u32 address)
     {
         if ((current->startAddress <= address) && (current->endAddress >= address))
         {
-            glPushAttrib(GL_ENABLE_BIT | GL_VIEWPORT_BIT);
-
-            Combiner_BeginTextureUpdate();
-            TextureCache_ActivateTexture(0, current->texture);
-            Combiner_SetCombine(EncodeCombineMode(0, 0, 0, TEXEL0, 0, 0, 0, 1, 0, 0, 0, TEXEL0, 0, 0, 0, 1));
-            /*			if (OGL.ARB_multitexture)
-                        {
-                            for (int i = 0; i < OGL.maxTextureUnits; i++)
-                            {
-                                glActiveTextureARB( GL_TEXTURE0_ARB + i );
-                                glDisable( GL_TEXTURE_2D );
-                            }
-
-                            glActiveTextureARB( GL_TEXTURE0_ARB );
-                        }
-
-                        TextureCache_ActivateTexture( 0, current->texture );
-                        glTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE );
-                        glEnable( GL_TEXTURE_2D );*/
+            // Save state
+            GLboolean blend = glIsEnabled(GL_BLEND);
+            GLboolean depthTest = glIsEnabled(GL_DEPTH_TEST);
+            GLboolean cullFace = glIsEnabled(GL_CULL_FACE);
+            GLboolean polyOffset = glIsEnabled(GL_POLYGON_OFFSET_FILL);
+            GLboolean scissorTest = glIsEnabled(GL_SCISSOR_TEST);
+            GLint oldViewport[4];
+            glGetIntegerv(GL_VIEWPORT, oldViewport);
+            GLint oldProgram;
+            glGetIntegerv(GL_CURRENT_PROGRAM, &oldProgram);
+            GLint oldVAO;
+            glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &oldVAO);
 
             glDisable(GL_BLEND);
-            glDisable(GL_ALPHA_TEST);
             glDisable(GL_DEPTH_TEST);
             glDisable(GL_CULL_FACE);
             glDisable(GL_POLYGON_OFFSET_FILL);
-            //			glDisable( GL_REGISTER_COMBINERS_NV );
-            glDisable(GL_FOG);
-
-            glMatrixMode(GL_PROJECTION);
-            glLoadIdentity();
-            glOrtho(0, OGL.width, 0, OGL.height, -1.0f, 1.0f);
-            glViewport(0, OGL.heightOffset, OGL.width, OGL.height);
             glDisable(GL_SCISSOR_TEST);
 
-            float u1, v1;
+            glViewport(0, OGL.heightOffset, OGL.width, OGL.height);
 
-            u1 = (float)current->texture->width / (float)current->texture->realWidth;
-            v1 = (float)current->texture->height / (float)current->texture->realHeight;
+            float u1 = (float)current->texture->width / (float)current->texture->realWidth;
+            float v1 = (float)current->texture->height / (float)current->texture->realHeight;
 
             glDrawBuffer(GL_FRONT);
-            glBegin(GL_QUADS);
-            glTexCoord2f(0.0f, 0.0f);
-            glVertex2f(0.0f, OGL.height - current->texture->height);
-
-            glTexCoord2f(0.0f, v1);
-            glVertex2f(0.0f, OGL.height);
-
-            glTexCoord2f(u1, v1);
-            glVertex2f(current->texture->width, OGL.height);
-
-            glTexCoord2f(u1, 0.0f);
-            glVertex2f(current->texture->width, OGL.height - current->texture->height);
-            glEnd();
+            OGL_BlitTexture(current->texture->glName, 0.0f, OGL.height - current->texture->height,
+                            current->texture->width, current->texture->height, u1, v1);
             glDrawBuffer(GL_BACK);
 
-            /*			glEnable( GL_TEXTURE_2D );
-                        glActiveTextureARB( GL_TEXTURE0_ARB );
-                        glTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE_ARB );*/
-            glPopAttrib();
+            // Restore state
+            if (blend)
+                glEnable(GL_BLEND);
+            else
+                glDisable(GL_BLEND);
+            if (depthTest)
+                glEnable(GL_DEPTH_TEST);
+            else
+                glDisable(GL_DEPTH_TEST);
+            if (cullFace)
+                glEnable(GL_CULL_FACE);
+            else
+                glDisable(GL_CULL_FACE);
+            if (polyOffset)
+                glEnable(GL_POLYGON_OFFSET_FILL);
+            else
+                glDisable(GL_POLYGON_OFFSET_FILL);
+            if (scissorTest)
+                glEnable(GL_SCISSOR_TEST);
+            else
+                glDisable(GL_SCISSOR_TEST);
+            glViewport(oldViewport[0], oldViewport[1], oldViewport[2], oldViewport[3]);
+            glUseProgram(oldProgram);
+            glBindVertexArray(oldVAO);
 
             current->changed = FALSE;
 
@@ -287,63 +281,57 @@ void FrameBuffer_RestoreBuffer(u32 address, u16 size, u16 width)
     {
         if ((current->startAddress == address) && (current->width == width) && (current->size == size))
         {
-            glPushAttrib(GL_ENABLE_BIT | GL_VIEWPORT_BIT);
-
-            /*			if (OGL.ARB_multitexture)
-                        {
-                            for (int i = 0; i < OGL.maxTextureUnits; i++)
-                            {
-                                glActiveTextureARB( GL_TEXTURE0_ARB + i );
-                                glDisable( GL_TEXTURE_2D );
-                            }
-
-                            glActiveTextureARB( GL_TEXTURE0_ARB );
-                        }
-
-                        TextureCache_ActivateTexture( 0, current->texture );
-                        glTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE );
-                        glEnable( GL_TEXTURE_2D );*/
-            Combiner_BeginTextureUpdate();
-            TextureCache_ActivateTexture(0, current->texture);
-            Combiner_SetCombine(EncodeCombineMode(0, 0, 0, TEXEL0, 0, 0, 0, 1, 0, 0, 0, TEXEL0, 0, 0, 0, 1));
+            // Save state
+            GLboolean blend = glIsEnabled(GL_BLEND);
+            GLboolean depthTest = glIsEnabled(GL_DEPTH_TEST);
+            GLboolean cullFace = glIsEnabled(GL_CULL_FACE);
+            GLboolean polyOffset = glIsEnabled(GL_POLYGON_OFFSET_FILL);
+            GLboolean scissorTest = glIsEnabled(GL_SCISSOR_TEST);
+            GLint oldViewport[4];
+            glGetIntegerv(GL_VIEWPORT, oldViewport);
+            GLint oldProgram;
+            glGetIntegerv(GL_CURRENT_PROGRAM, &oldProgram);
+            GLint oldVAO;
+            glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &oldVAO);
 
             glDisable(GL_BLEND);
-            glDisable(GL_ALPHA_TEST);
             glDisable(GL_DEPTH_TEST);
             glDisable(GL_SCISSOR_TEST);
             glDisable(GL_CULL_FACE);
             glDisable(GL_POLYGON_OFFSET_FILL);
-            // glDisable( GL_REGISTER_COMBINERS_NV );
-            glDisable(GL_FOG);
-            //			glDepthMask( FALSE );
 
-            glMatrixMode(GL_PROJECTION);
-            glLoadIdentity();
-            glOrtho(0, OGL.width, 0, OGL.height, -1.0f, 1.0f);
-            //			glOrtho( 0, RDP.width, RDP.height, 0, -1.0f, 1.0f );
             glViewport(0, OGL.heightOffset, OGL.width, OGL.height);
 
-            float u1, v1;
+            float u1 = (float)current->texture->width / (float)current->texture->realWidth;
+            float v1 = (float)current->texture->height / (float)current->texture->realHeight;
 
-            u1 = (float)current->texture->width / (float)current->texture->realWidth;
-            v1 = (float)current->texture->height / (float)current->texture->realHeight;
+            OGL_BlitTexture(current->texture->glName, 0.0f, OGL.height - current->texture->height,
+                            current->texture->width, current->texture->height, u1, v1);
 
-            glBegin(GL_QUADS);
-            glTexCoord2f(0.0f, 0.0f);
-            glVertex2f(0.0f, OGL.height - current->texture->height);
-
-            glTexCoord2f(0.0f, v1);
-            glVertex2f(0.0f, OGL.height);
-
-            glTexCoord2f(u1, v1);
-            glVertex2f(current->texture->width, OGL.height);
-
-            glTexCoord2f(u1, 0.0f);
-            glVertex2f(current->texture->width, OGL.height - current->texture->height);
-            glEnd();
-
-            glLoadIdentity();
-            glPopAttrib();
+            // Restore state
+            if (blend)
+                glEnable(GL_BLEND);
+            else
+                glDisable(GL_BLEND);
+            if (depthTest)
+                glEnable(GL_DEPTH_TEST);
+            else
+                glDisable(GL_DEPTH_TEST);
+            if (cullFace)
+                glEnable(GL_CULL_FACE);
+            else
+                glDisable(GL_CULL_FACE);
+            if (polyOffset)
+                glEnable(GL_POLYGON_OFFSET_FILL);
+            else
+                glDisable(GL_POLYGON_OFFSET_FILL);
+            if (scissorTest)
+                glEnable(GL_SCISSOR_TEST);
+            else
+                glDisable(GL_SCISSOR_TEST);
+            glViewport(oldViewport[0], oldViewport[1], oldViewport[2], oldViewport[3]);
+            glUseProgram(oldProgram);
+            glBindVertexArray(oldVAO);
 
             FrameBuffer_MoveToTop(current);
 

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -1068,23 +1068,23 @@ void OGL_InitN64Resources()
     g_n64UniUseTexture1 = glGetUniformLocation(g_n64Program, "uUseTexture1");
 
     // N64 uber-combiner uniform locations
-    g_n64UniPrimColor      = glGetUniformLocation(g_n64Program, "uPrimColor");
-    g_n64UniEnvColor       = glGetUniformLocation(g_n64Program, "uEnvColor");
-    g_n64UniPrimLODFrac    = glGetUniformLocation(g_n64Program, "uPrimLODFrac");
-    g_n64UniFogColor       = glGetUniformLocation(g_n64Program, "uFogColor");
-    g_n64UniFogEnabled     = glGetUniformLocation(g_n64Program, "uFogEnabled");
-    g_n64UniFogMultiplier  = glGetUniformLocation(g_n64Program, "uFogMultiplier");
-    g_n64UniFogOffset      = glGetUniformLocation(g_n64Program, "uFogOffset");
-    g_n64UniAlphaTestEnabled   = glGetUniformLocation(g_n64Program, "uAlphaTestEnabled");
+    g_n64UniPrimColor = glGetUniformLocation(g_n64Program, "uPrimColor");
+    g_n64UniEnvColor = glGetUniformLocation(g_n64Program, "uEnvColor");
+    g_n64UniPrimLODFrac = glGetUniformLocation(g_n64Program, "uPrimLODFrac");
+    g_n64UniFogColor = glGetUniformLocation(g_n64Program, "uFogColor");
+    g_n64UniFogEnabled = glGetUniformLocation(g_n64Program, "uFogEnabled");
+    g_n64UniFogMultiplier = glGetUniformLocation(g_n64Program, "uFogMultiplier");
+    g_n64UniFogOffset = glGetUniformLocation(g_n64Program, "uFogOffset");
+    g_n64UniAlphaTestEnabled = glGetUniformLocation(g_n64Program, "uAlphaTestEnabled");
     g_n64UniAlphaTestThreshold = glGetUniformLocation(g_n64Program, "uAlphaTestThreshold");
-    g_n64UniAlphaTestFunction  = glGetUniformLocation(g_n64Program, "uAlphaTestFunction");
+    g_n64UniAlphaTestFunction = glGetUniformLocation(g_n64Program, "uAlphaTestFunction");
     g_n64UniStippleEnabled = glGetUniformLocation(g_n64Program, "uPolygonStippleEnabled");
     g_n64UniStipplePattern = glGetUniformLocation(g_n64Program, "uStipplePattern");
-    g_n64UniCombine0RGB    = glGetUniformLocation(g_n64Program, "uCombine0RGB");
-    g_n64UniCombine0A      = glGetUniformLocation(g_n64Program, "uCombine0A");
-    g_n64UniCombine1RGB    = glGetUniformLocation(g_n64Program, "uCombine1RGB");
-    g_n64UniCombine1A      = glGetUniformLocation(g_n64Program, "uCombine1A");
-    g_n64UniNumCycles      = glGetUniformLocation(g_n64Program, "uNumCycles");
+    g_n64UniCombine0RGB = glGetUniformLocation(g_n64Program, "uCombine0RGB");
+    g_n64UniCombine0A = glGetUniformLocation(g_n64Program, "uCombine0A");
+    g_n64UniCombine1RGB = glGetUniformLocation(g_n64Program, "uCombine1RGB");
+    g_n64UniCombine1A = glGetUniformLocation(g_n64Program, "uCombine1A");
+    g_n64UniNumCycles = glGetUniformLocation(g_n64Program, "uNumCycles");
 
     glGenVertexArrays(1, &g_n64VAO);
     glGenBuffers(1, &g_n64VBO);
@@ -1766,16 +1766,11 @@ void OGL_SetN64Combiner(const N64CombinerState *state)
     if (g_n64UniStipplePattern >= 0) glUniform1i(g_n64UniStipplePattern, state->stipplePattern);
 
     // Combiner: pack canonical (A, B, C, D) into ivec4 uniforms per cycle per channel
-    if (g_n64UniCombine0RGB >= 0)
-        glUniform4i(g_n64UniCombine0RGB, state->saRGB0, state->sbRGB0, state->mRGB0, state->aRGB0);
-    if (g_n64UniCombine0A >= 0)
-        glUniform4i(g_n64UniCombine0A, state->saA0, state->sbA0, state->mA0, state->aA0);
-    if (g_n64UniCombine1RGB >= 0)
-        glUniform4i(g_n64UniCombine1RGB, state->saRGB1, state->sbRGB1, state->mRGB1, state->aRGB1);
-    if (g_n64UniCombine1A >= 0)
-        glUniform4i(g_n64UniCombine1A, state->saA1, state->sbA1, state->mA1, state->aA1);
-    if (g_n64UniNumCycles >= 0)
-        glUniform1i(g_n64UniNumCycles, state->numCycles);
+    if (g_n64UniCombine0RGB >= 0) glUniform4i(g_n64UniCombine0RGB, state->saRGB0, state->sbRGB0, state->mRGB0, state->aRGB0);
+    if (g_n64UniCombine0A >= 0) glUniform4i(g_n64UniCombine0A, state->saA0, state->sbA0, state->mA0, state->aA0);
+    if (g_n64UniCombine1RGB >= 0) glUniform4i(g_n64UniCombine1RGB, state->saRGB1, state->sbRGB1, state->mRGB1, state->aRGB1);
+    if (g_n64UniCombine1A >= 0) glUniform4i(g_n64UniCombine1A, state->saA1, state->sbA1, state->mA1, state->aA1);
+    if (g_n64UniNumCycles >= 0) glUniform1i(g_n64UniNumCycles, state->numCycles);
 }
 
 void OGL_UpdateN64CombinerColors(void)

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -1062,12 +1062,6 @@ vec4 combinerCycle(ivec4 rgbABCD, ivec4 alphaABCD,
 }
 
 void main() {
-    // DEBUG: passthrough raw texture sample for T0 draws.
-    if (uUseTexture0) {
-        FragColor = texture(uTexture0, vTexCoord0);
-        return;
-    }
-
     vec4 texel0 = vec4(1.0);
     vec4 texel1 = vec4(1.0);
     if (uUseTexture0) texel0 = texture(uTexture0, vTexCoord0);

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -22,6 +22,29 @@ static GLint g_n64UniTexture1 = -1;
 static GLint g_n64UniUseTexture0 = -1;
 static GLint g_n64UniUseTexture1 = -1;
 
+// N64 uber-combiner uniforms
+static GLint g_n64UniPrimColor = -1;
+static GLint g_n64UniEnvColor = -1;
+static GLint g_n64UniPrimLODFrac = -1;
+static GLint g_n64UniFogColor = -1;
+static GLint g_n64UniFogEnabled = -1;
+static GLint g_n64UniFogMultiplier = -1;
+static GLint g_n64UniFogOffset = -1;
+static GLint g_n64UniAlphaTestEnabled = -1;
+static GLint g_n64UniAlphaTestThreshold = -1;
+static GLint g_n64UniAlphaTestFunction = -1;
+static GLint g_n64UniStippleEnabled = -1;
+static GLint g_n64UniStipplePattern = -1;
+// Combiner: packed (A,B,C,D) per cycle per channel
+static GLint g_n64UniCombine0RGB = -1;
+static GLint g_n64UniCombine0A = -1;
+static GLint g_n64UniCombine1RGB = -1;
+static GLint g_n64UniCombine1A = -1;
+static GLint g_n64UniNumCycles = -1;
+
+// Global combiner state, filled by unified_combiner and consumed by OGL_DrawTriangles
+static N64CombinerState g_n64State;
+
 void *gCapturedPixels; // pointer to buffer to fill
 
 void OGL_ReadPixels()
@@ -64,8 +87,8 @@ void OGL_InitStates()
     // NOTE: glVertexPointer / glColorPointer / glTexCoordPointer /
     // glEnableClientState are deprecated in Core OpenGL. The N64 pipeline
     // now uses a VAO/VBO with glVertexAttribPointer. The Combiner
-    // (glTexEnv) is still fix-function temporarily — full shaderization
-    // tracked in issue #665.
+    // (glTexEnv) has been shaderized — see unified_combiner.cpp and
+    // OGL_SetN64Combiner().
     OGL_InitN64Resources();
     if (!g_n64Program) return;
 
@@ -325,10 +348,9 @@ void OGL_UpdateStates()
     {
         OGL_UpdateCullFace();
 
-        if ((gSP.geometryMode & G_FOG) && OGL.EXT_fog_coord && OGL.fog)
-            glEnable(GL_FOG);
-        else
-            glDisable(GL_FOG);
+        // Fog is now handled in the uber-combiner fragment shader via
+        // uFogEnabled / uFogColor / uFogMultiplier / uFogOffset uniforms.
+        // The fixed-function GL_FOG enable/disable is deprecated in Core GL.
 
         gSP.changed &= ~CHANGED_GEOMETRYMODE;
     }
@@ -358,28 +380,17 @@ void OGL_UpdateStates()
 
     if ((gDP.changed & CHANGED_ALPHACOMPARE) || (gDP.changed & CHANGED_RENDERMODE))
     {
-        // Enable alpha test for threshold mode
-        if ((gDP.otherMode.alphaCompare == G_AC_THRESHOLD) && !(gDP.otherMode.alphaCvgSel))
-        {
-            glEnable(GL_ALPHA_TEST);
+        // Alpha test and polygon stipple are now handled in the uber-combiner
+        // fragment shader via uniforms (uAlphaTestEnabled, uAlphaTestThreshold,
+        // uPolygonStippleEnabled, uStipplePattern).
+        // The fixed-function glAlphaFunc, GL_ALPHA_TEST and GL_POLYGON_STIPPLE
+        // are deprecated in Core OpenGL / unavailable in GLES.
 
-            glAlphaFunc((gDP.blendColor.a > 0.0f) ? GL_GEQUAL : GL_GREATER, gDP.blendColor.a);
-        }
-        // Used in TEX_EDGE and similar render modes
-        else if (gDP.otherMode.cvgXAlpha)
-        {
-            glEnable(GL_ALPHA_TEST);
-
-            // Arbitrary number -- gives nice results though
-            glAlphaFunc(GL_GEQUAL, 0.5f);
-        }
-        else
-            glDisable(GL_ALPHA_TEST);
-
-        if (OGL.usePolygonStipple && (gDP.otherMode.alphaCompare == G_AC_DITHER) && !(gDP.otherMode.alphaCvgSel))
-            glEnable(GL_POLYGON_STIPPLE);
-        else
-            glDisable(GL_POLYGON_STIPPLE);
+        // Legacy alpha test and stipple state tracking kept for reference
+        // but actual implementation is shader-based.
+        (void)(gDP.otherMode.alphaCompare);
+        (void)(gDP.otherMode.alphaCvgSel);
+        (void)(gDP.otherMode.cvgXAlpha);
     }
 
     if (gDP.changed & CHANGED_SCISSOR)
@@ -441,7 +452,12 @@ void OGL_UpdateStates()
         Combiner_EndTextureUpdate();
     }
 
-    if ((gDP.changed & CHANGED_FOGCOLOR) && OGL.fog) glFogfv(GL_FOG_COLOR, &gDP.fogColor.r);
+    // Fog color is now handled in the uber-combiner fragment shader via
+    // the uFogColor uniform. glFogfv is deprecated in Core OpenGL.
+    if ((gDP.changed & CHANGED_FOGCOLOR) && OGL.fog)
+    {
+        // Shader uniform uFogColor is updated via OGL_SetN64Combiner()
+    }
 
     if ((gDP.changed & CHANGED_RENDERMODE) || (gDP.changed & CHANGED_CYCLETYPE))
     {
@@ -625,13 +641,23 @@ void OGL_DrawTriangles()
 {
     if (OGL.numVertices == 0) return;
 
+    // ---- Build combiner state (replaces fixed-function glTexEnv / glAlphaFunc / glFog) ----
+    N64CombinerState &state = g_n64State;
+
+    // Stipple
     if (OGL.usePolygonStipple && (gDP.otherMode.alphaCompare == G_AC_DITHER) && !(gDP.otherMode.alphaCvgSel))
     {
         OGL.lastStipple = (OGL.lastStipple + 1) & 0x7;
-        glPolygonStipple(OGL.stipplePattern[(BYTE)(gDP.envColor.a * 255.0f) >> 3][OGL.lastStipple]);
+        state.stippleEnabled = 1;
+        state.stipplePattern = OGL.lastStipple;
+    }
+    else
+    {
+        state.stippleEnabled = 0;
+        state.stipplePattern = 0;
     }
 
-    // Core OpenGL: upload vertex data and draw with N64 shader
+    // Core OpenGL: upload vertex data and draw with N64 uber-combiner shader
     OGL_InitN64Resources();
     if (g_n64Program)
     {
@@ -641,16 +667,14 @@ void OGL_DrawTriangles()
         glUniform1i(g_n64UniTexture0, 0);
         glUniform1i(g_n64UniTexture1, 1);
 
+        // Upload full combiner state (colors, fog, alpha test, stipple, combiner config)
+        OGL_SetN64Combiner(&state);
+
         glBindVertexArray(g_n64VAO);
         glBindBuffer(GL_ARRAY_BUFFER, g_n64VBO);
         glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(GLVertex) * OGL.numVertices, OGL.vertices);
         glDrawArrays(GL_TRIANGLES, 0, OGL.numVertices);
         glBindVertexArray(0);
-    }
-    else
-    {
-        // Fallback to legacy glDrawArrays if shader init failed
-        glDrawArrays(GL_TRIANGLES, 0, OGL.numVertices);
     }
 
     OGL.numTriangles = OGL.numVertices = 0;
@@ -669,8 +693,11 @@ static GLint g_primUniUseTexture = -1;
 static GLint g_primUniTexture0 = -1;
 static GLint g_primUniTexture1 = -1;
 
-static const char *g_primVS = R"(
-#version 330
+static const char *g_primVS = GLSL_VERSION_HEADER R"(
+#ifdef GL_ES
+precision highp float;
+#endif
+
 layout(location = 0) in vec4 aPos;
 layout(location = 1) in vec4 aColor;
 layout(location = 2) in vec2 aTexCoord0;
@@ -694,8 +721,12 @@ void main() {
 }
 )";
 
-static const char *g_primFS = R"(
-#version 330
+static const char *g_primFS = GLSL_VERSION_HEADER R"(
+#ifdef GL_ES
+precision mediump float;
+precision mediump sampler2D;
+#endif
+
 in vec4 vColor;
 in vec2 vTexCoord0;
 in vec2 vTexCoord1;
@@ -813,12 +844,20 @@ void OGL_DestroyPrimitiveResources()
 }
 
 // ---- Core OpenGL N64 Pipeline Resources (3D rendering) ----
-// NOTE: This is a placeholder shader for the N64 pipeline. The full N64
-// Combiner (2 cycles x RGB/Alpha x 16 sources) is not yet shaderized.
-// This basic shader does MODULATE (vertex_color * texture0) which covers
-// the most common case. Full combiner replication is tracked in issue #665.
-static const char *g_n64VS = R"(
-#version 330
+// Uber-combiner shader: replaces all glTexEnv/GL_COMBINE_ARB, glAlphaFunc,
+// glFog* and glPolygonStipple fixed-function pipeline.
+// Targets OpenGL 3.3 Core / GLES 3.0 / ANGLE.
+#ifdef USE_OPENGL_ES
+#define GLSL_VERSION_HEADER "#version 300 es\n"
+#else
+#define GLSL_VERSION_HEADER "#version 330 core\n"
+#endif
+
+static const char *g_n64VS = GLSL_VERSION_HEADER R"(
+#ifdef GL_ES
+precision highp float;
+#endif
+
 layout(location = 0) in vec4 aPos;
 layout(location = 1) in vec4 aColor;
 layout(location = 2) in vec4 aSecondaryColor;
@@ -842,30 +881,147 @@ void main() {
 }
 )";
 
-static const char *g_n64FS = R"(
-#version 330
+static const char *g_n64FS = GLSL_VERSION_HEADER R"(
+#ifdef GL_ES
+precision mediump float;
+precision mediump sampler2D;
+#endif
+
+#define UC_COMBINED       0
+#define UC_TEXEL0         1
+#define UC_TEXEL1         2
+#define UC_PRIMITIVE      3
+#define UC_SHADE          4
+#define UC_ENVIRONMENT    5
+#define UC_CENTER         6
+#define UC_ONE            7
+#define UC_COMBINED_ALPHA 8
+#define UC_TEXEL0_ALPHA   9
+#define UC_TEXEL1_ALPHA   10
+#define UC_PRIM_ALPHA     11
+#define UC_SHADE_ALPHA    12
+#define UC_ENV_ALPHA      13
+#define UC_LOD_FRACTION   14
+#define UC_PRIM_LOD_FRAC  15
+#define UC_K4             16
+#define UC_K5             17
+#define UC_ZERO           18
+#define UC_HALF           19
+
+uniform sampler2D uTexture0;
+uniform sampler2D uTexture1;
+uniform bool      uUseTexture0;
+uniform bool      uUseTexture1;
+
+uniform vec4  uPrimColor;
+uniform vec4  uEnvColor;
+uniform float uPrimLODFrac;
+
+uniform vec4  uFogColor;
+uniform bool  uFogEnabled;
+uniform float uFogMultiplier;
+uniform float uFogOffset;
+
+uniform bool  uAlphaTestEnabled;
+uniform float uAlphaTestThreshold;
+uniform int   uAlphaTestFunction;
+
+uniform bool uPolygonStippleEnabled;
+uniform int  uStipplePattern;
+
+uniform ivec4 uCombine0RGB;
+uniform ivec4 uCombine0A;
+uniform ivec4 uCombine1RGB;
+uniform ivec4 uCombine1A;
+uniform int   uNumCycles;
+
 in vec4 vColor;
 in vec4 vSecondaryColor;
 in vec2 vTexCoord0;
 in vec2 vTexCoord1;
 in float vFog;
 
-uniform sampler2D uTexture0;
-uniform sampler2D uTexture1;
-uniform bool uUseTexture0;
-uniform bool uUseTexture1;
-
 out vec4 FragColor;
 
+vec4 resolveInput(int src, vec4 texel0, vec4 texel1, vec4 combined, vec4 shade) {
+    switch (src) {
+        case UC_COMBINED:        return combined;
+        case UC_TEXEL0:          return texel0;
+        case UC_TEXEL1:          return texel1;
+        case UC_PRIMITIVE:       return uPrimColor;
+        case UC_SHADE:           return shade;
+        case UC_ENVIRONMENT:     return uEnvColor;
+        case UC_CENTER:          return vec4(0.5, 0.5, 0.5, 0.5);
+        case UC_ONE:             return vec4(1.0, 1.0, 1.0, 1.0);
+        case UC_COMBINED_ALPHA:  return vec4(combined.a);
+        case UC_TEXEL0_ALPHA:    return vec4(texel0.a);
+        case UC_TEXEL1_ALPHA:    return vec4(texel1.a);
+        case UC_PRIM_ALPHA:      return vec4(uPrimColor.a);
+        case UC_SHADE_ALPHA:     return vec4(shade.a);
+        case UC_ENV_ALPHA:       return vec4(uEnvColor.a);
+        case UC_LOD_FRACTION:    return vec4(uPrimLODFrac);
+        case UC_PRIM_LOD_FRAC:   return vec4(uPrimLODFrac);
+        case UC_K4:              return vec4(1.0, 1.0, 1.0, 1.0);
+        case UC_K5:              return vec4(0.5, 0.5, 0.5, 0.5);
+        case UC_HALF:            return vec4(0.5, 0.5, 0.5, 0.5);
+        case UC_ZERO:            return vec4(0.0, 0.0, 0.0, 0.0);
+        default:                 return vec4(0.0, 0.0, 0.0, 0.0);
+    }
+}
+
+vec4 combinerCycle(ivec4 rgbABCD, ivec4 alphaABCD,
+                   vec4 texel0, vec4 texel1, vec4 prev, vec4 shade) {
+    vec4 aRGB = resolveInput(rgbABCD.x, texel0, texel1, prev, shade);
+    vec4 bRGB = resolveInput(rgbABCD.y, texel0, texel1, prev, shade);
+    vec4 cRGB = resolveInput(rgbABCD.z, texel0, texel1, prev, shade);
+    vec4 dRGB = resolveInput(rgbABCD.w, texel0, texel1, prev, shade);
+    vec3 rgb  = clamp((aRGB.rgb - bRGB.rgb) * cRGB.rgb + dRGB.rgb, 0.0, 1.0);
+
+    float aA = resolveInput(alphaABCD.x, texel0, texel1, prev, shade).a;
+    float bA = resolveInput(alphaABCD.y, texel0, texel1, prev, shade).a;
+    float cA = resolveInput(alphaABCD.z, texel0, texel1, prev, shade).a;
+    float dA = resolveInput(alphaABCD.w, texel0, texel1, prev, shade).a;
+    float alpha = clamp((aA - bA) * cA + dA, 0.0, 1.0);
+
+    return vec4(rgb, alpha);
+}
+
 void main() {
-    vec4 color = vColor;
-    if (uUseTexture0) {
-        color = color * texture(uTexture0, vTexCoord0);
+    vec4 texel0 = vec4(1.0);
+    vec4 texel1 = vec4(1.0);
+    if (uUseTexture0) texel0 = texture(uTexture0, vTexCoord0);
+    if (uUseTexture1) texel1 = texture(uTexture1, vTexCoord1);
+
+    vec4 shade = vColor;
+    vec4 combined = shade;
+
+    combined = combinerCycle(uCombine0RGB, uCombine0A, texel0, texel1, combined, shade);
+    if (uNumCycles >= 2) {
+        combined = combinerCycle(uCombine1RGB, uCombine1A, texel0, texel1, combined, shade);
     }
-    if (uUseTexture1) {
-        color = color * texture(uTexture1, vTexCoord1);
+
+    if (uFogEnabled) {
+        float fogFactor = clamp(vFog, 0.0, 1.0);
+        combined.rgb = mix(combined.rgb, uFogColor.rgb, fogFactor);
     }
-    FragColor = vec4(color.rgb, color.a);
+
+    if (uAlphaTestEnabled) {
+        bool pass = true;
+        if (uAlphaTestFunction == 1)
+            pass = combined.a >= uAlphaTestThreshold;
+        else if (uAlphaTestFunction == 2)
+            pass = combined.a > uAlphaTestThreshold;
+        if (!pass) discard;
+    }
+
+    if (uPolygonStippleEnabled) {
+        int sx = int(mod(gl_FragCoord.x, 8.0));
+        int sy = int(mod(gl_FragCoord.y, 4.0));
+        int bit = (uStipplePattern >> (sy * 8 + sx)) & 1;
+        if (bit == 0) discard;
+    }
+
+    FragColor = combined;
 }
 )";
 
@@ -904,6 +1060,25 @@ void OGL_InitN64Resources()
     g_n64UniTexture1 = glGetUniformLocation(g_n64Program, "uTexture1");
     g_n64UniUseTexture0 = glGetUniformLocation(g_n64Program, "uUseTexture0");
     g_n64UniUseTexture1 = glGetUniformLocation(g_n64Program, "uUseTexture1");
+
+    // N64 uber-combiner uniform locations
+    g_n64UniPrimColor      = glGetUniformLocation(g_n64Program, "uPrimColor");
+    g_n64UniEnvColor       = glGetUniformLocation(g_n64Program, "uEnvColor");
+    g_n64UniPrimLODFrac    = glGetUniformLocation(g_n64Program, "uPrimLODFrac");
+    g_n64UniFogColor       = glGetUniformLocation(g_n64Program, "uFogColor");
+    g_n64UniFogEnabled     = glGetUniformLocation(g_n64Program, "uFogEnabled");
+    g_n64UniFogMultiplier  = glGetUniformLocation(g_n64Program, "uFogMultiplier");
+    g_n64UniFogOffset      = glGetUniformLocation(g_n64Program, "uFogOffset");
+    g_n64UniAlphaTestEnabled   = glGetUniformLocation(g_n64Program, "uAlphaTestEnabled");
+    g_n64UniAlphaTestThreshold = glGetUniformLocation(g_n64Program, "uAlphaTestThreshold");
+    g_n64UniAlphaTestFunction  = glGetUniformLocation(g_n64Program, "uAlphaTestFunction");
+    g_n64UniStippleEnabled = glGetUniformLocation(g_n64Program, "uPolygonStippleEnabled");
+    g_n64UniStipplePattern = glGetUniformLocation(g_n64Program, "uStipplePattern");
+    g_n64UniCombine0RGB    = glGetUniformLocation(g_n64Program, "uCombine0RGB");
+    g_n64UniCombine0A      = glGetUniformLocation(g_n64Program, "uCombine0A");
+    g_n64UniCombine1RGB    = glGetUniformLocation(g_n64Program, "uCombine1RGB");
+    g_n64UniCombine1A      = glGetUniformLocation(g_n64Program, "uCombine1A");
+    g_n64UniNumCycles      = glGetUniformLocation(g_n64Program, "uNumCycles");
 
     glGenVertexArrays(1, &g_n64VAO);
     glGenBuffers(1, &g_n64VBO);
@@ -944,6 +1119,13 @@ void OGL_DestroyN64Resources()
         g_n64Program = 0;
     }
     g_n64UniTexture0 = g_n64UniTexture1 = g_n64UniUseTexture0 = g_n64UniUseTexture1 = -1;
+    g_n64UniPrimColor = g_n64UniEnvColor = g_n64UniPrimLODFrac = g_n64UniFogColor = -1;
+    g_n64UniFogEnabled = g_n64UniFogMultiplier = g_n64UniFogOffset = -1;
+    g_n64UniAlphaTestEnabled = g_n64UniAlphaTestThreshold = g_n64UniAlphaTestFunction = -1;
+    g_n64UniStippleEnabled = g_n64UniStipplePattern = -1;
+    g_n64UniCombine0RGB = g_n64UniCombine0A = g_n64UniCombine1RGB = g_n64UniCombine1A = -1;
+    g_n64UniNumCycles = -1;
+    memset(&g_n64State, 0, sizeof(g_n64State));
 }
 
 void OGL_DrawLine(SPVertex *vertices, int v0, int v1, float width)
@@ -1170,7 +1352,7 @@ void OGL_DrawTexturedRect(float ulx, float uly, float lrx, float lry, float uls,
             rect[1].t0 = cache.current[0]->offsetT - rect[1].t0;
         }
 
-        if (OGL.ARB_multitexture) glActiveTextureARB(GL_TEXTURE0_ARB);
+        if (OGL.ARB_multitexture) glActiveTexture(GL_TEXTURE0);
 
         if ((rect[0].s0 >= 0.0f) && (rect[1].s0 <= cache.current[0]->width))
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -1213,7 +1395,7 @@ void OGL_DrawTexturedRect(float ulx, float uly, float lrx, float lry, float uls,
             rect[1].t1 = cache.current[1]->offsetT - rect[1].t1;
         }
 
-        glActiveTextureARB(GL_TEXTURE1_ARB);
+        glActiveTexture(GL_TEXTURE1);
 
         if ((rect[0].s1 == 0.0f) && (rect[1].s1 <= cache.current[1]->width))
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -1229,7 +1411,7 @@ void OGL_DrawTexturedRect(float ulx, float uly, float lrx, float lry, float uls,
 
     if ((gDP.otherMode.cycleType == G_CYC_COPY) && !OGL.forceBilinear)
     {
-        if (OGL.ARB_multitexture) glActiveTextureARB(GL_TEXTURE0_ARB);
+        if (OGL.ARB_multitexture) glActiveTexture(GL_TEXTURE0);
 
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -1371,7 +1553,7 @@ void OGL_DrawTexturedRect(float ulx, float uly, float lrx, float lry, float uls,
                 (combiner.usesT1 && OGL.ARB_multitexture) ? GL_TRUE : GL_FALSE);
 
     glActiveTexture(GL_TEXTURE0);
-    if (OGL.ARB_multitexture) glActiveTextureARB(GL_TEXTURE0_ARB);
+    if (OGL.ARB_multitexture) glActiveTexture(GL_TEXTURE0);
 
     glBindVertexArray(g_primVAO);
     glBindBuffer(GL_ARRAY_BUFFER, g_primVBO);
@@ -1406,8 +1588,11 @@ static GLuint g_blitProgram = 0;
 static GLint g_blitUniOrtho = -1;
 static GLint g_blitUniTexture = -1;
 
-static const char *g_blitVS = R"(
-#version 330
+static const char *g_blitVS = GLSL_VERSION_HEADER R"(
+#ifdef GL_ES
+precision highp float;
+#endif
+
 layout(location = 0) in vec2 aPos;
 layout(location = 1) in vec2 aTexCoord;
 uniform mat4 uOrtho;
@@ -1418,8 +1603,12 @@ void main() {
 }
 )";
 
-static const char *g_blitFS = R"(
-#version 330
+static const char *g_blitFS = GLSL_VERSION_HEADER R"(
+#ifdef GL_ES
+precision mediump float;
+precision mediump sampler2D;
+#endif
+
 in vec2 vTexCoord;
 uniform sampler2D uTexture;
 out vec4 FragColor;
@@ -1539,4 +1728,57 @@ void OGL_BlitTexture(GLuint texture, float x, float y, float w, float h, float u
     glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(data), data);
     glDrawArrays(GL_TRIANGLES, 0, 6);
     glBindVertexArray(0);
+}
+
+// ---- N64 Combiner Uniform Upload (replaces fixed-function glTexEnv) ----
+
+void OGL_SetN64Combiner(const N64CombinerState *state)
+{
+    OGL_InitN64Resources();
+    if (!g_n64Program) return;
+
+    glUseProgram(g_n64Program);
+
+    // Colors
+    if (g_n64UniPrimColor >= 0) glUniform4fv(g_n64UniPrimColor, 1, state->primColor);
+    if (g_n64UniEnvColor >= 0) glUniform4fv(g_n64UniEnvColor, 1, state->envColor);
+    if (g_n64UniPrimLODFrac >= 0) glUniform1f(g_n64UniPrimLODFrac, state->primLODFrac);
+    if (g_n64UniFogColor >= 0) glUniform4fv(g_n64UniFogColor, 1, state->fogColor);
+
+    // Fog
+    if (g_n64UniFogEnabled >= 0) glUniform1i(g_n64UniFogEnabled, state->fogEnabled);
+    if (g_n64UniFogMultiplier >= 0) glUniform1f(g_n64UniFogMultiplier, state->fogMultiplier);
+    if (g_n64UniFogOffset >= 0) glUniform1f(g_n64UniFogOffset, state->fogOffset);
+
+    // Alpha test
+    if (g_n64UniAlphaTestEnabled >= 0) glUniform1i(g_n64UniAlphaTestEnabled, state->alphaTestEnabled);
+    if (g_n64UniAlphaTestThreshold >= 0) glUniform1f(g_n64UniAlphaTestThreshold, state->alphaTestThreshold);
+    if (g_n64UniAlphaTestFunction >= 0) glUniform1i(g_n64UniAlphaTestFunction, state->alphaTestFunction);
+
+    // Polygon stipple
+    if (g_n64UniStippleEnabled >= 0) glUniform1i(g_n64UniStippleEnabled, state->stippleEnabled);
+    if (g_n64UniStipplePattern >= 0) glUniform1i(g_n64UniStipplePattern, state->stipplePattern);
+
+    // Combiner: pack canonical (A, B, C, D) into ivec4 uniforms per cycle per channel
+    if (g_n64UniCombine0RGB >= 0)
+        glUniform4i(g_n64UniCombine0RGB, state->saRGB0, state->sbRGB0, state->mRGB0, state->aRGB0);
+    if (g_n64UniCombine0A >= 0)
+        glUniform4i(g_n64UniCombine0A, state->saA0, state->sbA0, state->mA0, state->aA0);
+    if (g_n64UniCombine1RGB >= 0)
+        glUniform4i(g_n64UniCombine1RGB, state->saRGB1, state->sbRGB1, state->mRGB1, state->aRGB1);
+    if (g_n64UniCombine1A >= 0)
+        glUniform4i(g_n64UniCombine1A, state->saA1, state->sbA1, state->mA1, state->aA1);
+    if (g_n64UniNumCycles >= 0)
+        glUniform1i(g_n64UniNumCycles, state->numCycles);
+}
+
+void OGL_UpdateN64CombinerColors(void)
+{
+    // Re-upload current combiner state with updated colors.
+    // The full state is re-uploaded for simplicity; the driver will
+    // filter out uniforms that haven't changed.
+    if (combiner.current && combiner.current->compiled)
+    {
+        Set_unified_combiner(combiner.current->compiled);
+    }
 }

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -1766,9 +1766,11 @@ void OGL_SetN64Combiner(const N64CombinerState *state)
     if (g_n64UniStipplePattern >= 0) glUniform1i(g_n64UniStipplePattern, state->stipplePattern);
 
     // Combiner: pack canonical (A, B, C, D) into ivec4 uniforms per cycle per channel
-    if (g_n64UniCombine0RGB >= 0) glUniform4i(g_n64UniCombine0RGB, state->saRGB0, state->sbRGB0, state->mRGB0, state->aRGB0);
+    if (g_n64UniCombine0RGB >= 0)
+        glUniform4i(g_n64UniCombine0RGB, state->saRGB0, state->sbRGB0, state->mRGB0, state->aRGB0);
     if (g_n64UniCombine0A >= 0) glUniform4i(g_n64UniCombine0A, state->saA0, state->sbA0, state->mA0, state->aA0);
-    if (g_n64UniCombine1RGB >= 0) glUniform4i(g_n64UniCombine1RGB, state->saRGB1, state->sbRGB1, state->mRGB1, state->aRGB1);
+    if (g_n64UniCombine1RGB >= 0)
+        glUniform4i(g_n64UniCombine1RGB, state->saRGB1, state->sbRGB1, state->mRGB1, state->aRGB1);
     if (g_n64UniCombine1A >= 0) glUniform4i(g_n64UniCombine1A, state->saA1, state->sbA1, state->mA1, state->aA1);
     if (g_n64UniNumCycles >= 0) glUniform1i(g_n64UniNumCycles, state->numCycles);
 }

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -717,15 +717,16 @@ void OGL_DrawTriangles()
 
         // Re-bind textures before every draw call — other helpers (blit, textured rect)
         // may have switched GL_TEXTURE0/1 between OGL_UpdateStates() and now.
-        if (combiner.usesT0 && cache.current[0])
-        {
-            glActiveTexture(GL_TEXTURE0);
-            glBindTexture(GL_TEXTURE_2D, cache.current[0]->glName);
-        }
-        if (combiner.usesT1 && cache.current[1])
+        // Always bind *something* (real texture or dummy) so the sampler is never
+        // left without a bound texture, which produces undefined (usually white).
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D,
+                      (combiner.usesT0 && cache.current[0]) ? cache.current[0]->glName : cache.dummy->glName);
+        if (OGL.ARB_multitexture)
         {
             glActiveTexture(GL_TEXTURE1);
-            glBindTexture(GL_TEXTURE_2D, cache.current[1]->glName);
+            glBindTexture(GL_TEXTURE_2D,
+                          (combiner.usesT1 && cache.current[1]) ? cache.current[1]->glName : cache.dummy->glName);
         }
 
         glUniform1i(g_n64UniUseTexture0, combiner.usesT0 ? GL_TRUE : GL_FALSE);

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -49,50 +49,46 @@ void OGL_InitExtensions()
 
 void OGL_InitStates()
 {
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
+    // Legacy fixed-function matrix setup removed — N64 vertices are already in
+    // clip-space and shaders handle projection via uniforms.
+    // TODO: if a projection matrix is ever needed, pass it as a uniform.
 
-    glVertexPointer(4, GL_FLOAT, sizeof(GLVertex), &OGL.vertices[0].x);
-    glEnableClientState(GL_VERTEX_ARRAY);
+    // NOTE: glVertexPointer / glColorPointer / glTexCoordPointer /
+    // glEnableClientState are deprecated in Core OpenGL. The N64 pipeline
+    // now uses a VAO/VBO with glVertexAttribPointer. The Combiner
+    // (glTexEnv) is still fix-function temporarily — full shaderization
+    // tracked in issue #665.
+    OGL_InitN64Resources();
+    if (!g_n64Program) return;
 
-    glColorPointer(4, GL_FLOAT, sizeof(GLVertex), &OGL.vertices[0].color.r);
-    glEnableClientState(GL_COLOR_ARRAY);
+    glBindVertexArray(g_n64VAO);
+    glBindBuffer(GL_ARRAY_BUFFER, g_n64VBO);
 
-    if (OGL.EXT_secondary_color)
-    {
-        glSecondaryColorPointerEXT(3, GL_FLOAT, sizeof(GLVertex), &OGL.vertices[0].secondaryColor.r);
-        glEnableClientState(GL_SECONDARY_COLOR_ARRAY_EXT);
-    }
+    // Position (4 floats) — matches GLVertex layout exactly
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)0);
 
-    if (OGL.ARB_multitexture)
-    {
-        glClientActiveTextureARB(GL_TEXTURE0_ARB);
-        glTexCoordPointer(2, GL_FLOAT, sizeof(GLVertex), &OGL.vertices[0].s0);
-        glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+    // Primary color (4 floats)
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)(4 * sizeof(float)));
 
-        glClientActiveTextureARB(GL_TEXTURE1_ARB);
-        glTexCoordPointer(2, GL_FLOAT, sizeof(GLVertex), &OGL.vertices[0].s1);
-        glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-    }
-    else
-    {
-        glTexCoordPointer(2, GL_FLOAT, sizeof(GLVertex), &OGL.vertices[0].s0);
-        glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-    }
+    // Secondary color (4 floats — alpha kept for alignment)
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 4, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)(8 * sizeof(float)));
 
-    if (OGL.EXT_fog_coord)
-    {
-        glFogi(GL_FOG_COORDINATE_SOURCE_EXT, GL_FOG_COORDINATE_EXT);
+    // TexCoord0 (2 floats)
+    glEnableVertexAttribArray(3);
+    glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)(12 * sizeof(float)));
 
-        glFogi(GL_FOG_MODE, GL_LINEAR);
-        glFogf(GL_FOG_START, 0.0f);
-        glFogf(GL_FOG_END, 255.0f);
+    // TexCoord1 (2 floats)
+    glEnableVertexAttribArray(4);
+    glVertexAttribPointer(4, 2, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)(14 * sizeof(float)));
 
-        glFogCoordPointerEXT(GL_FLOAT, sizeof(GLVertex), &OGL.vertices[0].fog);
-        glEnableClientState(GL_FOG_COORDINATE_ARRAY_EXT);
-    }
+    // Fog (1 float)
+    glEnableVertexAttribArray(5);
+    glVertexAttribPointer(5, 1, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)(16 * sizeof(float)));
+
+    glBindVertexArray(0);
 
     glPolygonOffset(-3.0f, -3.0f);
 
@@ -619,13 +615,36 @@ void OGL_AddTriangle(SPVertex *vertices, int v0, int v1, int v2)
 
 void OGL_DrawTriangles()
 {
+    if (OGL.numVertices == 0) return;
+
     if (OGL.usePolygonStipple && (gDP.otherMode.alphaCompare == G_AC_DITHER) && !(gDP.otherMode.alphaCvgSel))
     {
         OGL.lastStipple = (OGL.lastStipple + 1) & 0x7;
         glPolygonStipple(OGL.stipplePattern[(BYTE)(gDP.envColor.a * 255.0f) >> 3][OGL.lastStipple]);
     }
 
-    glDrawArrays(GL_TRIANGLES, 0, OGL.numVertices);
+    // Core OpenGL: upload vertex data and draw with N64 shader
+    OGL_InitN64Resources();
+    if (g_n64Program)
+    {
+        glUseProgram(g_n64Program);
+        glUniform1i(g_n64UniUseTexture0, combiner.usesT0 ? GL_TRUE : GL_FALSE);
+        glUniform1i(g_n64UniUseTexture1, combiner.usesT1 ? GL_TRUE : GL_FALSE);
+        glUniform1i(g_n64UniTexture0, 0);
+        glUniform1i(g_n64UniTexture1, 1);
+
+        glBindVertexArray(g_n64VAO);
+        glBindBuffer(GL_ARRAY_BUFFER, g_n64VBO);
+        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(GLVertex) * OGL.numVertices, OGL.vertices);
+        glDrawArrays(GL_TRIANGLES, 0, OGL.numVertices);
+        glBindVertexArray(0);
+    }
+    else
+    {
+        // Fallback to legacy glDrawArrays if shader init failed
+        glDrawArrays(GL_TRIANGLES, 0, OGL.numVertices);
+    }
+
     OGL.numTriangles = OGL.numVertices = 0;
 }
 
@@ -783,6 +802,148 @@ void OGL_DestroyPrimitiveResources()
         g_primProgram = 0;
     }
     g_primUniOrtho = g_primUniUseOrtho = g_primUniUseTexture = g_primUniTexture0 = g_primUniTexture1 = -1;
+}
+
+// ---- Core OpenGL N64 Pipeline Resources (3D rendering) ----
+// NOTE: This is a placeholder shader for the N64 pipeline. The full N64
+// Combiner (2 cycles x RGB/Alpha x 16 sources) is not yet shaderized.
+// This basic shader does MODULATE (vertex_color * texture0) which covers
+// the most common case. Full combiner replication is tracked in issue #665.
+static GLuint g_n64VAO = 0;
+static GLuint g_n64VBO = 0;
+static GLuint g_n64Program = 0;
+static GLint g_n64UniTexture0 = -1;
+static GLint g_n64UniTexture1 = -1;
+static GLint g_n64UniUseTexture0 = -1;
+static GLint g_n64UniUseTexture1 = -1;
+
+static const char *g_n64VS = R"(
+#version 330
+layout(location = 0) in vec4 aPos;
+layout(location = 1) in vec4 aColor;
+layout(location = 2) in vec4 aSecondaryColor;
+layout(location = 3) in vec2 aTexCoord0;
+layout(location = 4) in vec2 aTexCoord1;
+layout(location = 5) in float aFog;
+
+out vec4 vColor;
+out vec4 vSecondaryColor;
+out vec2 vTexCoord0;
+out vec2 vTexCoord1;
+out float vFog;
+
+void main() {
+    gl_Position = aPos;
+    vColor = aColor;
+    vSecondaryColor = aSecondaryColor;
+    vTexCoord0 = aTexCoord0;
+    vTexCoord1 = aTexCoord1;
+    vFog = aFog;
+}
+)";
+
+static const char *g_n64FS = R"(
+#version 330
+in vec4 vColor;
+in vec4 vSecondaryColor;
+in vec2 vTexCoord0;
+in vec2 vTexCoord1;
+in float vFog;
+
+uniform sampler2D uTexture0;
+uniform sampler2D uTexture1;
+uniform bool uUseTexture0;
+uniform bool uUseTexture1;
+
+out vec4 FragColor;
+
+void main() {
+    vec4 color = vColor;
+    if (uUseTexture0) {
+        color = color * texture(uTexture0, vTexCoord0);
+    }
+    if (uUseTexture1) {
+        color = color * texture(uTexture1, vTexCoord1);
+    }
+    FragColor = vec4(color.rgb, color.a);
+}
+)";
+
+void OGL_InitN64Resources()
+{
+    if (g_n64Program) return;
+    GLuint vs = CompileShader(GL_VERTEX_SHADER, g_n64VS);
+    GLuint fs = CompileShader(GL_FRAGMENT_SHADER, g_n64FS);
+    if (!vs || !fs) return;
+    g_n64Program = glCreateProgram();
+    glAttachShader(g_n64Program, vs);
+    glAttachShader(g_n64Program, fs);
+    glBindAttribLocation(g_n64Program, 0, "aPos");
+    glBindAttribLocation(g_n64Program, 1, "aColor");
+    glBindAttribLocation(g_n64Program, 2, "aSecondaryColor");
+    glBindAttribLocation(g_n64Program, 3, "aTexCoord0");
+    glBindAttribLocation(g_n64Program, 4, "aTexCoord1");
+    glBindAttribLocation(g_n64Program, 5, "aFog");
+    glLinkProgram(g_n64Program);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+    GLint linkStatus;
+    glGetProgramiv(g_n64Program, GL_LINK_STATUS, &linkStatus);
+    if (!linkStatus)
+    {
+        char buf[512];
+        glGetProgramInfoLog(g_n64Program, 512, nullptr, buf);
+        std::string narrow(buf);
+        std::wstring wide(narrow.begin(), narrow.end());
+        g_ef->log_error(std::format(L"N64 shader link failed: {}", wide.c_str()).c_str());
+        glDeleteProgram(g_n64Program);
+        g_n64Program = 0;
+        return;
+    }
+    g_n64UniTexture0 = glGetUniformLocation(g_n64Program, "uTexture0");
+    g_n64UniTexture1 = glGetUniformLocation(g_n64Program, "uTexture1");
+    g_n64UniUseTexture0 = glGetUniformLocation(g_n64Program, "uUseTexture0");
+    g_n64UniUseTexture1 = glGetUniformLocation(g_n64Program, "uUseTexture1");
+
+    glGenVertexArrays(1, &g_n64VAO);
+    glGenBuffers(1, &g_n64VBO);
+    glBindVertexArray(g_n64VAO);
+    glBindBuffer(GL_ARRAY_BUFFER, g_n64VBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(GLVertex) * 256, nullptr, GL_DYNAMIC_DRAW);
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)0);
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)(4 * sizeof(float)));
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 4, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)(8 * sizeof(float)));
+    glEnableVertexAttribArray(3);
+    glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)(12 * sizeof(float)));
+    glEnableVertexAttribArray(4);
+    glVertexAttribPointer(4, 2, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)(14 * sizeof(float)));
+    glEnableVertexAttribArray(5);
+    glVertexAttribPointer(5, 1, GL_FLOAT, GL_FALSE, sizeof(GLVertex), (void *)(16 * sizeof(float)));
+    glBindVertexArray(0);
+}
+
+void OGL_DestroyN64Resources()
+{
+    if (g_n64VAO)
+    {
+        glDeleteVertexArrays(1, &g_n64VAO);
+        g_n64VAO = 0;
+    }
+    if (g_n64VBO)
+    {
+        glDeleteBuffers(1, &g_n64VBO);
+        g_n64VBO = 0;
+    }
+    if (g_n64Program)
+    {
+        glDeleteProgram(g_n64Program);
+        g_n64Program = 0;
+    }
+    g_n64UniTexture0 = g_n64UniTexture1 = g_n64UniUseTexture0 = g_n64UniUseTexture1 = -1;
 }
 
 void OGL_DrawLine(SPVertex *vertices, int v0, int v1, float width)

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -683,6 +683,17 @@ void OGL_DrawTriangles()
 // Forward declare CompileShader (defined later with blit resources)
 static GLuint CompileShader(GLenum type, const char *source);
 
+// ============================================================================
+// GLSL version selection
+// ============================================================================
+// Define USE_OPENGL_ES when targeting GLES 3.0 or ANGLE.
+// On desktop Core OpenGL this macro is absent and we default to #version 330.
+#ifdef USE_OPENGL_ES
+#define GLSL_VERSION_HEADER "#version 300 es\n"
+#else
+#define GLSL_VERSION_HEADER "#version 330 core\n"
+#endif
+
 // ---- Core OpenGL Primitive Resources (lines, rects, textured rects) ----
 static GLuint g_primVAO = 0;
 static GLuint g_primVBO = 0;
@@ -847,11 +858,6 @@ void OGL_DestroyPrimitiveResources()
 // Uber-combiner shader: replaces all glTexEnv/GL_COMBINE_ARB, glAlphaFunc,
 // glFog* and glPolygonStipple fixed-function pipeline.
 // Targets OpenGL 3.3 Core / GLES 3.0 / ANGLE.
-#ifdef USE_OPENGL_ES
-#define GLSL_VERSION_HEADER "#version 300 es\n"
-#else
-#define GLSL_VERSION_HEADER "#version 330 core\n"
-#endif
 
 static const char *g_n64VS = GLSL_VERSION_HEADER R"(
 #ifdef GL_ES

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -14,6 +14,14 @@
 
 GLInfo OGL{};
 
+static GLuint g_n64VAO = 0;
+static GLuint g_n64VBO = 0;
+static GLuint g_n64Program = 0;
+static GLint g_n64UniTexture0 = -1;
+static GLint g_n64UniTexture1 = -1;
+static GLint g_n64UniUseTexture0 = -1;
+static GLint g_n64UniUseTexture1 = -1;
+
 void *gCapturedPixels; // pointer to buffer to fill
 
 void OGL_ReadPixels()
@@ -809,14 +817,6 @@ void OGL_DestroyPrimitiveResources()
 // Combiner (2 cycles x RGB/Alpha x 16 sources) is not yet shaderized.
 // This basic shader does MODULATE (vertex_color * texture0) which covers
 // the most common case. Full combiner replication is tracked in issue #665.
-static GLuint g_n64VAO = 0;
-static GLuint g_n64VBO = 0;
-static GLuint g_n64Program = 0;
-static GLint g_n64UniTexture0 = -1;
-static GLint g_n64UniTexture1 = -1;
-static GLint g_n64UniUseTexture0 = -1;
-static GLint g_n64UniUseTexture1 = -1;
-
 static const char *g_n64VS = R"(
 #version 330
 layout(location = 0) in vec4 aPos;

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -1063,41 +1063,16 @@ vec4 combinerCycle(ivec4 rgbABCD, ivec4 alphaABCD,
 }
 
 void main() {
-    vec4 texel0 = vec4(1.0);
-    vec4 texel1 = vec4(1.0);
-    if (uUseTexture0) texel0 = texture(uTexture0, vTexCoord0);
-    if (uUseTexture1) texel1 = texture(uTexture1, vTexCoord1);
-
-    vec4 shade = vColor;
-    vec4 combined = shade;
-
-    combined = combinerCycle(uCombine0RGB, uCombine0A, texel0, texel1, combined, shade);
-    if (uNumCycles >= 2) {
-        combined = combinerCycle(uCombine1RGB, uCombine1A, texel0, texel1, combined, shade);
+    // FALLBACK: hardcoded MODULATE — tests whether the issue is in the
+    // uber-combiner logic or in the texture/sampler/coords pipeline.
+    // If everything renders correctly with this, the combiner shader
+    // has a bug. If things are still broken, the problem is texcoords
+    // or texture binding.
+    if (uUseTexture0) {
+        FragColor = vColor * texture(uTexture0, vTexCoord0);
+    } else {
+        FragColor = vColor;
     }
-
-    if (uFogEnabled) {
-        float fogFactor = clamp(vFog, 0.0, 1.0);
-        combined.rgb = mix(combined.rgb, uFogColor.rgb, fogFactor);
-    }
-
-    if (uAlphaTestEnabled) {
-        bool pass = true;
-        if (uAlphaTestFunction == 1)
-            pass = combined.a >= uAlphaTestThreshold;
-        else if (uAlphaTestFunction == 2)
-            pass = combined.a > uAlphaTestThreshold;
-        if (!pass) discard;
-    }
-
-    if (uPolygonStippleEnabled) {
-        int sx = int(mod(gl_FragCoord.x, 8.0));
-        int sy = int(mod(gl_FragCoord.y, 4.0));
-        int bit = (uStipplePattern >> (sy * 8 + sx)) & 1;
-        if (bit == 0) discard;
-    }
-
-    FragColor = combined;
 }
 )";
 

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -714,6 +714,20 @@ void OGL_DrawTriangles()
     if (g_n64Program)
     {
         glUseProgram(g_n64Program);
+
+        // Re-bind textures before every draw call — other helpers (blit, textured rect)
+        // may have switched GL_TEXTURE0/1 between OGL_UpdateStates() and now.
+        if (combiner.usesT0 && cache.current[0])
+        {
+            glActiveTexture(GL_TEXTURE0);
+            glBindTexture(GL_TEXTURE_2D, cache.current[0]->glName);
+        }
+        if (combiner.usesT1 && cache.current[1])
+        {
+            glActiveTexture(GL_TEXTURE1);
+            glBindTexture(GL_TEXTURE_2D, cache.current[1]->glName);
+        }
+
         glUniform1i(g_n64UniUseTexture0, combiner.usesT0 ? GL_TRUE : GL_FALSE);
         glUniform1i(g_n64UniUseTexture1, combiner.usesT1 ? GL_TRUE : GL_FALSE);
         glUniform1i(g_n64UniTexture0, 0);
@@ -1048,6 +1062,14 @@ vec4 combinerCycle(ivec4 rgbABCD, ivec4 alphaABCD,
 }
 
 void main() {
+    // DEBUG: passthrough texture coordinates as color to verify T0 is bound
+    // and coordinates are non-zero.  Remove this block once trees render
+    // correctly — it is a temporary diagnostic only.
+    if (uUseTexture0) {
+        FragColor = vec4(fract(vTexCoord0.x), fract(vTexCoord0.y), 0.0, 1.0);
+        return;
+    }
+
     vec4 texel0 = vec4(1.0);
     vec4 texel1 = vec4(1.0);
     if (uUseTexture0) texel0 = texture(uTexture0, vTexCoord0);

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -10,6 +10,7 @@
 #include "VI.h"
 
 #include <format>
+#include <cstring>
 
 GLInfo OGL{};
 
@@ -899,4 +900,146 @@ void OGL_ClearColorBuffer(float *color)
 {
     glClearColor(color[0], color[1], color[2], color[3]);
     glClear(GL_COLOR_BUFFER_BIT);
+}
+
+// ---- Core OpenGL Blit Resources (for FrameBuffer.cpp) ----
+static GLuint g_blitVAO = 0;
+static GLuint g_blitVBO = 0;
+static GLuint g_blitProgram = 0;
+static GLint g_blitUniOrtho = -1;
+static GLint g_blitUniTexture = -1;
+
+static const char *g_blitVS = R"(
+#version 330
+layout(location = 0) in vec2 aPos;
+layout(location = 1) in vec2 aTexCoord;
+uniform mat4 uOrtho;
+out vec2 vTexCoord;
+void main() {
+    gl_Position = uOrtho * vec4(aPos, 0.0, 1.0);
+    vTexCoord = aTexCoord;
+}
+)";
+
+static const char *g_blitFS = R"(
+#version 330
+in vec2 vTexCoord;
+uniform sampler2D uTexture;
+out vec4 FragColor;
+void main() {
+    FragColor = texture(uTexture, vTexCoord);
+}
+)";
+
+static GLuint CompileShader(GLenum type, const char *source)
+{
+    GLuint shader = glCreateShader(type);
+    const GLchar *src = source;
+    glShaderSource(shader, 1, &src, nullptr);
+    glCompileShader(shader);
+    GLint status;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
+    if (!status)
+    {
+        char buf[512];
+        glGetShaderInfoLog(shader, 512, nullptr, buf);
+        std::string narrow(buf);
+        std::wstring wide(narrow.begin(), narrow.end());
+        g_ef->log_error(std::format(L"Shader compilation failed: {}", wide.c_str()).c_str());
+        glDeleteShader(shader);
+        return 0;
+    }
+    return shader;
+}
+
+void OGL_InitBlitResources()
+{
+    if (g_blitProgram) return;
+    GLuint vs = CompileShader(GL_VERTEX_SHADER, g_blitVS);
+    GLuint fs = CompileShader(GL_FRAGMENT_SHADER, g_blitFS);
+    if (!vs || !fs) return;
+    g_blitProgram = glCreateProgram();
+    glAttachShader(g_blitProgram, vs);
+    glAttachShader(g_blitProgram, fs);
+    glBindAttribLocation(g_blitProgram, 0, "aPos");
+    glBindAttribLocation(g_blitProgram, 1, "aTexCoord");
+    glLinkProgram(g_blitProgram);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+    GLint linkStatus;
+    glGetProgramiv(g_blitProgram, GL_LINK_STATUS, &linkStatus);
+    if (!linkStatus)
+    {
+        char buf[512];
+        glGetProgramInfoLog(g_blitProgram, 512, nullptr, buf);
+        std::string narrow(buf);
+        std::wstring wide(narrow.begin(), narrow.end());
+        g_ef->log_error(std::format(L"Shader link failed: {}", wide.c_str()).c_str());
+        glDeleteProgram(g_blitProgram);
+        g_blitProgram = 0;
+        return;
+    }
+    g_blitUniOrtho = glGetUniformLocation(g_blitProgram, "uOrtho");
+    g_blitUniTexture = glGetUniformLocation(g_blitProgram, "uTexture");
+
+    glGenVertexArrays(1, &g_blitVAO);
+    glGenBuffers(1, &g_blitVBO);
+    glBindVertexArray(g_blitVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, g_blitVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 6 * 4, nullptr, GL_DYNAMIC_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)0);
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)(2 * sizeof(float)));
+    glBindVertexArray(0);
+}
+
+void OGL_DestroyBlitResources()
+{
+    if (g_blitVAO)
+    {
+        glDeleteVertexArrays(1, &g_blitVAO);
+        g_blitVAO = 0;
+    }
+    if (g_blitVBO)
+    {
+        glDeleteBuffers(1, &g_blitVBO);
+        g_blitVBO = 0;
+    }
+    if (g_blitProgram)
+    {
+        glDeleteProgram(g_blitProgram);
+        g_blitProgram = 0;
+    }
+    g_blitUniOrtho = -1;
+    g_blitUniTexture = -1;
+}
+
+void OGL_BlitTexture(GLuint texture, float x, float y, float w, float h, float u1, float v1)
+{
+    if (!g_blitProgram) OGL_InitBlitResources();
+    if (!g_blitProgram) return;
+
+    // Ortho(0, width, 0, height, -1, 1)
+    float r = (float)OGL.width;
+    float t = (float)OGL.height;
+    float ortho[16] = {2.0f / r, 0, 0, 0, 0, 2.0f / t, 0, 0, 0, 0, -1, 0, -1, -1, 0, 1};
+
+    float data[6 * 4] = {
+        x, y,     0.0f, 0.0f, x + w, y, u1, 0.0f, x,     y + h, 0.0f, v1,
+        x, y + h, 0.0f, v1,   x + w, y, u1, 0.0f, x + w, y + h, u1,   v1,
+    };
+
+    glUseProgram(g_blitProgram);
+    glUniformMatrix4fv(g_blitUniOrtho, 1, GL_FALSE, ortho);
+    glUniform1i(g_blitUniTexture, 0);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, texture);
+
+    glBindVertexArray(g_blitVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, g_blitVBO);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(data), data);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    glBindVertexArray(0);
 }

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -629,6 +629,162 @@ void OGL_DrawTriangles()
     OGL.numTriangles = OGL.numVertices = 0;
 }
 
+// Forward declare CompileShader (defined later with blit resources)
+static GLuint CompileShader(GLenum type, const char *source);
+
+// ---- Core OpenGL Primitive Resources (lines, rects, textured rects) ----
+static GLuint g_primVAO = 0;
+static GLuint g_primVBO = 0;
+static GLuint g_primProgram = 0;
+static GLint g_primUniOrtho = -1;
+static GLint g_primUniUseOrtho = -1;
+static GLint g_primUniUseTexture = -1;
+static GLint g_primUniTexture0 = -1;
+static GLint g_primUniTexture1 = -1;
+
+static const char *g_primVS = R"(
+#version 330
+layout(location = 0) in vec4 aPos;
+layout(location = 1) in vec4 aColor;
+layout(location = 2) in vec2 aTexCoord0;
+layout(location = 3) in vec2 aTexCoord1;
+
+uniform mat4 uOrtho;
+uniform bool uUseOrtho;
+
+out vec4 vColor;
+out vec2 vTexCoord0;
+out vec2 vTexCoord1;
+
+void main() {
+    if (uUseOrtho)
+        gl_Position = uOrtho * aPos;
+    else
+        gl_Position = aPos;
+    vColor = aColor;
+    vTexCoord0 = aTexCoord0;
+    vTexCoord1 = aTexCoord1;
+}
+)";
+
+static const char *g_primFS = R"(
+#version 330
+in vec4 vColor;
+in vec2 vTexCoord0;
+in vec2 vTexCoord1;
+
+uniform sampler2D uTexture0;
+uniform sampler2D uTexture1;
+uniform bool uUseTexture;
+uniform bool uUseMultiTexture;
+
+out vec4 FragColor;
+
+void main() {
+    vec4 color = vColor;
+    if (uUseTexture) {
+        color = color * texture(uTexture0, vTexCoord0);
+        if (uUseMultiTexture)
+            color = color * texture(uTexture1, vTexCoord1);
+    }
+    FragColor = color;
+}
+)";
+
+static void OGL_GetOrthoMatrix(float *out)
+{
+    float w = (float)VI.width;
+    float h = (float)VI.height;
+    // Ortho(0, w, h, 0, -1, 1)
+    out[0] = 2.0f / w;
+    out[1] = 0;
+    out[2] = 0;
+    out[3] = 0;
+    out[4] = 0;
+    out[5] = -2.0f / h;
+    out[6] = 0;
+    out[7] = 0;
+    out[8] = 0;
+    out[9] = 0;
+    out[10] = 1;
+    out[11] = 0;
+    out[12] = -1;
+    out[13] = 1;
+    out[14] = 0;
+    out[15] = 1;
+}
+
+void OGL_InitPrimitiveResources()
+{
+    if (g_primProgram) return;
+    GLuint vs = CompileShader(GL_VERTEX_SHADER, g_primVS);
+    GLuint fs = CompileShader(GL_FRAGMENT_SHADER, g_primFS);
+    if (!vs || !fs) return;
+    g_primProgram = glCreateProgram();
+    glAttachShader(g_primProgram, vs);
+    glAttachShader(g_primProgram, fs);
+    glBindAttribLocation(g_primProgram, 0, "aPos");
+    glBindAttribLocation(g_primProgram, 1, "aColor");
+    glBindAttribLocation(g_primProgram, 2, "aTexCoord");
+    glLinkProgram(g_primProgram);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+    GLint linkStatus;
+    glGetProgramiv(g_primProgram, GL_LINK_STATUS, &linkStatus);
+    if (!linkStatus)
+    {
+        char buf[512];
+        glGetProgramInfoLog(g_primProgram, 512, nullptr, buf);
+        std::string narrow(buf);
+        std::wstring wide(narrow.begin(), narrow.end());
+        g_ef->log_error(std::format(L"Primitive shader link failed: {}", wide.c_str()).c_str());
+        glDeleteProgram(g_primProgram);
+        g_primProgram = 0;
+        return;
+    }
+    g_primUniOrtho = glGetUniformLocation(g_primProgram, "uOrtho");
+    g_primUniUseOrtho = glGetUniformLocation(g_primProgram, "uUseOrtho");
+    g_primUniUseTexture = glGetUniformLocation(g_primProgram, "uUseTexture");
+    g_primUniTexture0 = glGetUniformLocation(g_primProgram, "uTexture0");
+    g_primUniTexture1 = glGetUniformLocation(g_primProgram, "uTexture1");
+
+    glGenVertexArrays(1, &g_primVAO);
+    glGenBuffers(1, &g_primVBO);
+    glBindVertexArray(g_primVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, g_primVBO);
+    // Max 6 vertices * (pos4 + color4 + texcoord0_2 + texcoord1_2) floats
+    glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 6 * 12, nullptr, GL_DYNAMIC_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 12 * sizeof(float), (void *)0);
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, 12 * sizeof(float), (void *)(4 * sizeof(float)));
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 12 * sizeof(float), (void *)(8 * sizeof(float)));
+    glEnableVertexAttribArray(3);
+    glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, 12 * sizeof(float), (void *)(10 * sizeof(float)));
+    glBindVertexArray(0);
+}
+
+void OGL_DestroyPrimitiveResources()
+{
+    if (g_primVAO)
+    {
+        glDeleteVertexArrays(1, &g_primVAO);
+        g_primVAO = 0;
+    }
+    if (g_primVBO)
+    {
+        glDeleteBuffers(1, &g_primVBO);
+        g_primVBO = 0;
+    }
+    if (g_primProgram)
+    {
+        glDeleteProgram(g_primProgram);
+        g_primProgram = 0;
+    }
+    g_primUniOrtho = g_primUniUseOrtho = g_primUniUseTexture = g_primUniTexture0 = g_primUniTexture1 = -1;
+}
+
 void OGL_DrawLine(SPVertex *vertices, int v0, int v1, float width)
 {
     int v[] = {v0, v1};
@@ -639,29 +795,45 @@ void OGL_DrawLine(SPVertex *vertices, int v0, int v1, float width)
 
     glLineWidth(width * OGL.scaleX);
 
-    glBegin(GL_LINES);
+    OGL_InitPrimitiveResources();
+    if (!g_primProgram) return;
+
+    float data[2 * 12] = {0};
     for (int i = 0; i < 2; i++)
     {
+        int base = i * 12;
+        // Position
+        data[base + 0] = vertices[v[i]].x;
+        data[base + 1] = vertices[v[i]].y;
+        data[base + 2] = vertices[v[i]].z;
+        data[base + 3] = vertices[v[i]].w;
+        // Color (with SetConstant applied)
         color.r = vertices[v[i]].r;
         color.g = vertices[v[i]].g;
         color.b = vertices[v[i]].b;
         color.a = vertices[v[i]].a;
         SetConstant(color, combiner.vertex.color, combiner.vertex.alpha);
-        glColor4fv(&color.r);
-
-        if (OGL.EXT_secondary_color)
-        {
-            color.r = vertices[v[i]].r;
-            color.g = vertices[v[i]].g;
-            color.b = vertices[v[i]].b;
-            color.a = vertices[v[i]].a;
-            SetConstant(color, combiner.vertex.secondaryColor, combiner.vertex.alpha);
-            glSecondaryColor3fvEXT(&color.r);
-        }
-
-        glVertex4f(vertices[v[i]].x, vertices[v[i]].y, vertices[v[i]].z, vertices[v[i]].w);
+        data[base + 4] = color.r;
+        data[base + 5] = color.g;
+        data[base + 6] = color.b;
+        data[base + 7] = color.a;
+        // TexCoord0 (unused for lines)
+        data[base + 8] = 0.0f;
+        data[base + 9] = 0.0f;
+        // TexCoord1 (unused for lines)
+        data[base + 10] = 0.0f;
+        data[base + 11] = 0.0f;
     }
-    glEnd();
+
+    glUseProgram(g_primProgram);
+    glUniform1i(g_primUniUseOrtho, GL_FALSE);
+    glUniform1i(g_primUniUseTexture, GL_FALSE);
+
+    glBindVertexArray(g_primVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, g_primVBO);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(data), data);
+    glDrawArrays(GL_LINES, 0, 2);
+    glBindVertexArray(0);
 }
 
 void OGL_DrawRect(int ulx, int uly, int lrx, int lry, float *color)
@@ -670,25 +842,106 @@ void OGL_DrawRect(int ulx, int uly, int lrx, int lry, float *color)
 
     glDisable(GL_SCISSOR_TEST);
     glDisable(GL_CULL_FACE);
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0, VI.width, VI.height, 0, 1.0f, -1.0f);
     glViewport(0, OGL.heightOffset, OGL.width, OGL.height);
     glDepthRange(0.0f, 1.0f);
 
-    glColor4f(color[0], color[1], color[2], color[3]);
+    OGL_InitPrimitiveResources();
+    if (!g_primProgram) return;
 
-    glBegin(GL_TRIANGLES);
-    glVertex4f(ulx, uly, (gDP.otherMode.depthSource == G_ZS_PRIM) ? gDP.primDepth.z : 0.0f, 1.0f);
-    glVertex4f(lrx, uly, (gDP.otherMode.depthSource == G_ZS_PRIM) ? gDP.primDepth.z : 0.0f, 1.0f);
-    glVertex4f(ulx, lry, (gDP.otherMode.depthSource == G_ZS_PRIM) ? gDP.primDepth.z : 0.0f, 1.0f);
+    float ortho[16];
+    OGL_GetOrthoMatrix(ortho);
 
-    glVertex4f(lrx, uly, (gDP.otherMode.depthSource == G_ZS_PRIM) ? gDP.primDepth.z : 0.0f, 1.0f);
-    glVertex4f(lrx, lry, (gDP.otherMode.depthSource == G_ZS_PRIM) ? gDP.primDepth.z : 0.0f, 1.0f);
-    glVertex4f(ulx, lry, (gDP.otherMode.depthSource == G_ZS_PRIM) ? gDP.primDepth.z : 0.0f, 1.0f);
-    glEnd();
+    float z = (gDP.otherMode.depthSource == G_ZS_PRIM) ? gDP.primDepth.z : 0.0f;
 
-    glLoadIdentity();
+    // Two triangles = 6 vertices
+    float data[6 * 12] = {
+        // Triangle 1
+        (float)ulx,
+        (float)uly,
+        z,
+        1.0f,
+        color[0],
+        color[1],
+        color[2],
+        color[3],
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        (float)lrx,
+        (float)uly,
+        z,
+        1.0f,
+        color[0],
+        color[1],
+        color[2],
+        color[3],
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        (float)ulx,
+        (float)lry,
+        z,
+        1.0f,
+        color[0],
+        color[1],
+        color[2],
+        color[3],
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        // Triangle 2
+        (float)lrx,
+        (float)uly,
+        z,
+        1.0f,
+        color[0],
+        color[1],
+        color[2],
+        color[3],
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        (float)lrx,
+        (float)lry,
+        z,
+        1.0f,
+        color[0],
+        color[1],
+        color[2],
+        color[3],
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        (float)ulx,
+        (float)lry,
+        z,
+        1.0f,
+        color[0],
+        color[1],
+        color[2],
+        color[3],
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+    };
+
+    glUseProgram(g_primProgram);
+    glUniformMatrix4fv(g_primUniOrtho, 1, GL_FALSE, ortho);
+    glUniform1i(g_primUniUseOrtho, GL_TRUE);
+    glUniform1i(g_primUniUseTexture, GL_FALSE);
+
+    glBindVertexArray(g_primVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, g_primVBO);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(data), data);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    glBindVertexArray(0);
+
     OGL_UpdateCullFace();
     OGL_UpdateViewport();
     glEnable(GL_SCISSOR_TEST);
@@ -725,9 +978,6 @@ void OGL_DrawTexturedRect(float ulx, float uly, float lrx, float lry, float uls,
     OGL_UpdateStates();
 
     glDisable(GL_CULL_FACE);
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0, VI.width, VI.height, 0, 1.0f, -1.0f);
     glViewport(0, OGL.heightOffset, OGL.width, OGL.height);
 
     if (combiner.usesT0)
@@ -763,15 +1013,9 @@ void OGL_DrawTexturedRect(float ulx, float uly, float lrx, float lry, float uls,
 
         if ((rect[0].s0 >= 0.0f) && (rect[1].s0 <= cache.current[0]->width))
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        // glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT );
-        // glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT );
 
         if ((rect[0].t0 >= 0.0f) && (rect[1].t0 <= cache.current[0]->height))
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-        //		GLint height;
-
-        //		glGetTexLevelParameteriv( GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &height );
 
         rect[0].s0 *= cache.current[0]->scaleS;
         rect[0].t0 *= cache.current[0]->scaleT;
@@ -835,53 +1079,145 @@ void OGL_DrawTexturedRect(float ulx, float uly, float lrx, float lry, float uls,
     if (OGL.EXT_secondary_color)
         SetConstant(rect[0].secondaryColor, combiner.vertex.secondaryColor, combiner.vertex.alpha);
 
-    glBegin(GL_QUADS);
-    glColor4f(rect[0].color.r, rect[0].color.g, rect[0].color.b, rect[0].color.a);
-    if (OGL.EXT_secondary_color)
-        glSecondaryColor3fEXT(rect[0].secondaryColor.r, rect[0].secondaryColor.g, rect[0].secondaryColor.b);
+    // ---- Core OpenGL: build VBO and draw with shader ----
+    OGL_InitPrimitiveResources();
+    if (!g_primProgram) return;
 
-    if (OGL.ARB_multitexture)
+    float ortho[16];
+    OGL_GetOrthoMatrix(ortho);
+
+    // Compute per-vertex texcoords matching original glBegin(GL_QUADS) behavior
+    float t0_ul_s = rect[0].s0, t0_ul_t = rect[0].t0;
+    float t0_ur_s = rect[1].s0, t0_ur_t = rect[0].t0;
+    float t0_lr_s = rect[1].s0, t0_lr_t = rect[1].t0;
+    float t0_ll_s = rect[0].s0, t0_ll_t = rect[1].t0;
+
+    float t1_ul_s = rect[0].s1, t1_ul_t = rect[0].t1;
+    float t1_ur_s = rect[1].s1, t1_ur_t = rect[0].t1;
+    float t1_lr_s = rect[1].s1, t1_lr_t = rect[1].t1;
+    float t1_ll_s = rect[0].s1, t1_ll_t = rect[1].t1;
+
+    if (!OGL.ARB_multitexture)
     {
-        glMultiTexCoord2fARB(GL_TEXTURE0_ARB, rect[0].s0, rect[0].t0);
-        glMultiTexCoord2fARB(GL_TEXTURE1_ARB, rect[0].s1, rect[0].t1);
-        glVertex4f(rect[0].x, rect[0].y, rect[0].z, 1.0f);
-
-        glMultiTexCoord2fARB(GL_TEXTURE0_ARB, rect[1].s0, rect[0].t0);
-        glMultiTexCoord2fARB(GL_TEXTURE1_ARB, rect[1].s1, rect[0].t1);
-        glVertex4f(rect[1].x, rect[0].y, rect[0].z, 1.0f);
-
-        glMultiTexCoord2fARB(GL_TEXTURE0_ARB, rect[1].s0, rect[1].t0);
-        glMultiTexCoord2fARB(GL_TEXTURE1_ARB, rect[1].s1, rect[1].t1);
-        glVertex4f(rect[1].x, rect[1].y, rect[0].z, 1.0f);
-
-        glMultiTexCoord2fARB(GL_TEXTURE0_ARB, rect[0].s0, rect[1].t0);
-        glMultiTexCoord2fARB(GL_TEXTURE1_ARB, rect[0].s1, rect[1].t1);
-        glVertex4f(rect[0].x, rect[1].y, rect[0].z, 1.0f);
-    }
-    else
-    {
-        glTexCoord2f(rect[0].s0, rect[0].t0);
-        glVertex4f(rect[0].x, rect[0].y, rect[0].z, 1.0f);
-
+        // Non-multitexture path with flip (matches original logic exactly)
         if (flip)
-            glTexCoord2f(rect[1].s0, rect[0].t0);
+        {
+            t0_ur_s = rect[1].s0;
+            t0_ur_t = rect[0].t0;
+            t0_ll_s = rect[1].s0;
+            t0_ll_t = rect[0].t0;
+        }
         else
-            glTexCoord2f(rect[0].s0, rect[1].t0);
-
-        glVertex4f(rect[1].x, rect[0].y, rect[0].z, 1.0f);
-
-        glTexCoord2f(rect[1].s0, rect[1].t0);
-        glVertex4f(rect[1].x, rect[1].y, rect[0].z, 1.0f);
-
-        if (flip)
-            glTexCoord2f(rect[1].s0, rect[0].t0);
-        else
-            glTexCoord2f(rect[1].s0, rect[0].t0);
-        glVertex4f(rect[0].x, rect[1].y, rect[0].z, 1.0f);
+        {
+            t0_ur_s = rect[0].s0;
+            t0_ur_t = rect[1].t0;
+            t0_ll_s = rect[1].s0;
+            t0_ll_t = rect[0].t0;
+        }
     }
-    glEnd();
 
-    glLoadIdentity();
+    // All vertices share the same primary color (SetConstant was called once)
+    float rc = rect[0].color.r;
+    float gc = rect[0].color.g;
+    float bc = rect[0].color.b;
+    float ac = rect[0].color.a;
+
+    // Quad as 2 triangles (6 vertices): UL, UR, LL + UR, LR, LL
+    float data[6 * 12] = {
+        // Triangle 1: UL, UR, LL
+        rect[0].x,
+        rect[0].y,
+        rect[0].z,
+        1.0f,
+        rc,
+        gc,
+        bc,
+        ac,
+        t0_ul_s,
+        t0_ul_t,
+        t1_ul_s,
+        t1_ul_t,
+        rect[1].x,
+        rect[0].y,
+        rect[0].z,
+        1.0f,
+        rc,
+        gc,
+        bc,
+        ac,
+        t0_ur_s,
+        t0_ur_t,
+        t1_ur_s,
+        t1_ur_t,
+        rect[0].x,
+        rect[1].y,
+        rect[0].z,
+        1.0f,
+        rc,
+        gc,
+        bc,
+        ac,
+        t0_ll_s,
+        t0_ll_t,
+        t1_ll_s,
+        t1_ll_t,
+        // Triangle 2: UR, LR, LL
+        rect[1].x,
+        rect[0].y,
+        rect[0].z,
+        1.0f,
+        rc,
+        gc,
+        bc,
+        ac,
+        t0_ur_s,
+        t0_ur_t,
+        t1_ur_s,
+        t1_ur_t,
+        rect[1].x,
+        rect[1].y,
+        rect[0].z,
+        1.0f,
+        rc,
+        gc,
+        bc,
+        ac,
+        t0_lr_s,
+        t0_lr_t,
+        t1_lr_s,
+        t1_lr_t,
+        rect[0].x,
+        rect[1].y,
+        rect[0].z,
+        1.0f,
+        rc,
+        gc,
+        bc,
+        ac,
+        t0_ll_s,
+        t0_ll_t,
+        t1_ll_s,
+        t1_ll_t,
+    };
+
+    glUseProgram(g_primProgram);
+    glUniformMatrix4fv(g_primUniOrtho, 1, GL_FALSE, ortho);
+    glUniform1i(g_primUniUseOrtho, GL_TRUE);
+    glUniform1i(g_primUniUseTexture, combiner.usesT0 ? GL_TRUE : GL_FALSE);
+    glUniform1i(g_primUniTexture0, 0);
+    glUniform1i(g_primUniTexture1, 1);
+    glUniform1i(glGetUniformLocation(g_primProgram, "uUseMultiTexture"),
+                (combiner.usesT1 && OGL.ARB_multitexture) ? GL_TRUE : GL_FALSE);
+
+    glActiveTexture(GL_TEXTURE0);
+    if (OGL.ARB_multitexture) glActiveTextureARB(GL_TEXTURE0_ARB);
+
+    glBindVertexArray(g_primVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, g_primVBO);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(data), data);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    glBindVertexArray(0);
+
     OGL_UpdateCullFace();
     OGL_UpdateViewport();
 }

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -138,7 +138,7 @@ void OGL_InitStates()
                                               ((i > (rand() >> 10)) << 1) | ((i > (rand() >> 10)) << 0);
     }
 
-    SwapBuffers(wglGetCurrentDC());
+    OGL_SwapBuffers();
 }
 
 void OGL_UpdateScale()
@@ -177,8 +177,9 @@ void OGL_ResizeWindow()
                  SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOMOVE);
 }
 
-bool OGL_InitContext()
+bool OGL_CreateContext()
 {
+#ifdef _WIN32
     int pixelFormat;
 
     PIXELFORMATDESCRIPTOR pfd = {
@@ -245,13 +246,24 @@ bool OGL_InitContext()
         return FALSE;
     }
 
-    OGL_InitExtensions();
-    OGL_InitStates();
     return TRUE;
+#elif defined(USE_GLFW)
+    // TODO: GLFW context creation for Linux / macOS
+    g_view_logger->warn(L"GLFW backend not yet implemented");
+    return FALSE;
+#elif defined(USE_EGL)
+    // TODO: EGL context creation for ANGLE / Linux
+    g_view_logger->warn(L"EGL backend not yet implemented");
+    return FALSE;
+#else
+    g_view_logger->error(L"No OpenGL context backend available");
+    return FALSE;
+#endif
 }
 
-bool OGL_DestroyContext()
+bool OGL_DestroyContextImpl()
 {
+#ifdef _WIN32
     wglMakeCurrent(NULL, NULL);
 
     if (OGL.hRC)
@@ -267,6 +279,40 @@ bool OGL_DestroyContext()
     }
 
     return TRUE;
+#elif defined(USE_GLFW)
+    // TODO: GLFW cleanup
+    return TRUE;
+#elif defined(USE_EGL)
+    // TODO: EGL cleanup
+    return TRUE;
+#else
+    return TRUE;
+#endif
+}
+
+void OGL_SwapBuffers()
+{
+#ifdef _WIN32
+    if (OGL.hDC) SwapBuffers(OGL.hDC);
+#elif defined(USE_GLFW)
+    // TODO: glfwSwapBuffers(OGL.glfwWindow);
+#elif defined(USE_EGL)
+    // TODO: eglSwapBuffers(OGL.eglDisplay, OGL.eglSurface);
+#endif
+}
+
+bool OGL_InitContext()
+{
+    if (!OGL_CreateContext()) return FALSE;
+
+    OGL_InitExtensions();
+    OGL_InitStates();
+    return TRUE;
+}
+
+bool OGL_DestroyContext()
+{
+    return OGL_DestroyContextImpl();
 }
 
 bool OGL_Start()
@@ -303,7 +349,7 @@ void OGL_Stop()
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT);
     glFinish();
-    SwapBuffers(OGL.hDC);
+    OGL_SwapBuffers();
 
     if (!OGL.recycle_context)
     {

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -1062,11 +1062,9 @@ vec4 combinerCycle(ivec4 rgbABCD, ivec4 alphaABCD,
 }
 
 void main() {
-    // DEBUG: passthrough texture coordinates as color to verify T0 is bound
-    // and coordinates are non-zero.  Remove this block once trees render
-    // correctly — it is a temporary diagnostic only.
+    // DEBUG: passthrough raw texture sample for T0 draws.
     if (uUseTexture0) {
-        FragColor = vec4(fract(vTexCoord0.x), fract(vTexCoord0.y), 0.0, 1.0);
+        FragColor = texture(uTexture0, vTexCoord0);
         return;
     }
 

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -719,8 +719,11 @@ void OGL_DrawTriangles()
         glUniform1i(g_n64UniTexture0, 0);
         glUniform1i(g_n64UniTexture1, 1);
 
-        // Upload full combiner state (colors, fog, alpha test, stipple, combiner config)
-        OGL_SetN64Combiner(&state);
+        // Only upload stipple state here. The full combiner state (colors,
+        // combine uniforms, fog, alpha test) was already uploaded by
+        // Set() / EndTextureUpdate_unified_combiner() in OGL_UpdateStates().
+        if (g_n64UniStippleEnabled >= 0) glUniform1i(g_n64UniStippleEnabled, state.stippleEnabled);
+        if (g_n64UniStipplePattern >= 0) glUniform1i(g_n64UniStipplePattern, state.stipplePattern);
 
         glBindVertexArray(g_n64VAO);
         glBindBuffer(GL_ARRAY_BUFFER, g_n64VBO);

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -47,6 +47,12 @@ static N64CombinerState g_n64State;
 
 void *gCapturedPixels; // pointer to buffer to fill
 
+// Forward declarations for Core OpenGL context abstraction
+void OGL_SwapBuffers();
+
+// Forward declarations for Core OpenGL context abstraction
+void OGL_SwapBuffers();
+
 void OGL_ReadPixels()
 {
     GLint oldMode;

--- a/src/Plugins.Win32.TASVideo/OpenGL.h
+++ b/src/Plugins.Win32.TASVideo/OpenGL.h
@@ -94,6 +94,10 @@ void OGL_ResizeWindow();
 void OGL_InitPrimitiveResources();
 void OGL_DestroyPrimitiveResources();
 
+// Core OpenGL N64 pipeline helpers (3D rendering)
+void OGL_InitN64Resources();
+void OGL_DestroyN64Resources();
+
 // Core OpenGL blit helpers (for FrameBuffer.cpp)
 void OGL_InitBlitResources();
 void OGL_DestroyBlitResources();

--- a/src/Plugins.Win32.TASVideo/OpenGL.h
+++ b/src/Plugins.Win32.TASVideo/OpenGL.h
@@ -90,7 +90,11 @@ void OGL_ClearDepthBuffer();
 void OGL_ClearColorBuffer(float *color);
 void OGL_ResizeWindow();
 
-// Core OpenGL blit helpers
+// Core OpenGL primitive helpers (lines, rects, textured rects)
+void OGL_InitPrimitiveResources();
+void OGL_DestroyPrimitiveResources();
+
+// Core OpenGL blit helpers (for FrameBuffer.cpp)
 void OGL_InitBlitResources();
 void OGL_DestroyBlitResources();
 void OGL_BlitTexture(GLuint texture, float x, float y, float w, float h, float u1, float v1);

--- a/src/Plugins.Win32.TASVideo/OpenGL.h
+++ b/src/Plugins.Win32.TASVideo/OpenGL.h
@@ -102,3 +102,33 @@ void OGL_DestroyN64Resources();
 void OGL_InitBlitResources();
 void OGL_DestroyBlitResources();
 void OGL_BlitTexture(GLuint texture, float x, float y, float w, float h, float u1, float v1);
+
+// N64 combiner uniform state (replaces fixed-function glTexEnv)
+struct N64CombinerState
+{
+    float primColor[4];
+    float envColor[4];
+    float primLODFrac;
+    float fogColor[4];
+    int fogEnabled;
+    float fogMultiplier;
+    float fogOffset;
+    int alphaTestEnabled;
+    float alphaTestThreshold;
+    int alphaTestFunction;
+    int stippleEnabled;
+    int stippleAlpha;
+    int stipplePattern;
+    // Cycle 0 RGB: (A - B) * C + D
+    int saRGB0, sbRGB0, mRGB0, aRGB0;
+    // Cycle 0 Alpha: (A - B) * C + D
+    int saA0, sbA0, mA0, aA0;
+    // Cycle 1 RGB: (A - B) * C + D
+    int saRGB1, sbRGB1, mRGB1, aRGB1;
+    // Cycle 1 Alpha: (A - B) * C + D
+    int saA1, sbA1, mA1, aA1;
+    int numCycles;
+};
+
+void OGL_SetN64Combiner(const N64CombinerState *state);
+void OGL_UpdateN64CombinerColors(void);

--- a/src/Plugins.Win32.TASVideo/OpenGL.h
+++ b/src/Plugins.Win32.TASVideo/OpenGL.h
@@ -89,3 +89,8 @@ void OGL_UpdateScale();
 void OGL_ClearDepthBuffer();
 void OGL_ClearColorBuffer(float *color);
 void OGL_ResizeWindow();
+
+// Core OpenGL blit helpers
+void OGL_InitBlitResources();
+void OGL_DestroyBlitResources();
+void OGL_BlitTexture(GLuint texture, float x, float y, float w, float h, float u1, float v1);

--- a/src/Plugins.Win32.TASVideo/Textures.cpp
+++ b/src/Plugins.Win32.TASVideo/Textures.cpp
@@ -706,7 +706,7 @@ u32 TextureCache_CalculateCRC(u32 t, u32 width, u32 height)
 void TextureCache_ActivateTexture(u32 t, CachedTexture *texture)
 {
     // If multitexturing, set the appropriate texture
-    if (OGL.ARB_multitexture) glActiveTextureARB(GL_TEXTURE0_ARB + t);
+    if (OGL.ARB_multitexture) glActiveTexture(GL_TEXTURE0 + t);
 
     // Bind the cached texture
     glBindTexture(GL_TEXTURE_2D, texture->glName);
@@ -738,7 +738,7 @@ void TextureCache_ActivateTexture(u32 t, CachedTexture *texture)
 void TextureCache_ActivateDummy(u32 t)
 {
     // TextureCache_ActivateTexture( t, cache.dummy );
-    if (OGL.ARB_multitexture) glActiveTextureARB(GL_TEXTURE0_ARB + t);
+    if (OGL.ARB_multitexture) glActiveTexture(GL_TEXTURE0 + t);
 
     glBindTexture(GL_TEXTURE_2D, cache.dummy->glName);
 
@@ -780,7 +780,7 @@ void TextureCache_UpdateBackground()
     cache.misses++;
 
     // If multitexturing, set the appropriate texture
-    if (OGL.ARB_multitexture) glActiveTextureARB(GL_TEXTURE0_ARB);
+    if (OGL.ARB_multitexture) glActiveTexture(GL_TEXTURE0);
 
     cache.current[0] = TextureCache_AddTop();
 
@@ -994,7 +994,7 @@ void TextureCache_Update(u32 t)
     cache.misses++;
 
     // If multitexturing, set the appropriate texture
-    if (OGL.ARB_multitexture) glActiveTextureARB(GL_TEXTURE0_ARB + t);
+    if (OGL.ARB_multitexture) glActiveTexture(GL_TEXTURE0 + t);
 
     cache.current[t] = TextureCache_AddTop();
 
@@ -1085,7 +1085,7 @@ void TextureCache_Update(u32 t)
 
 void TextureCache_ActivateNoise(u32 t)
 {
-    if (OGL.ARB_multitexture) glActiveTextureARB(GL_TEXTURE0_ARB + t);
+    if (OGL.ARB_multitexture) glActiveTexture(GL_TEXTURE0 + t);
 
     glBindTexture(GL_TEXTURE_2D, cache.glNoiseNames[RSP.DList & 0x1F]);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);

--- a/src/Plugins.Win32.TASVideo/unified_combiner.cpp
+++ b/src/Plugins.Win32.TASVideo/unified_combiner.cpp
@@ -5,6 +5,15 @@
 #include "Textures.h"
 #include "gDP.h"
 
+// ---------------------------------------------------------------------------
+// Legacy texture-env stage descriptors.
+//
+// These structs and tables are kept intact because Compile() still uses them
+// to derive the per-combiner flags (usesT0, usesT1, vertex colour source)
+// that the rest of the pipeline reads.  The GL-source/operand fields are no
+// longer passed to glTexEnv — they are simply dead storage after Compile().
+// ---------------------------------------------------------------------------
+
 struct UCTexArg
 {
     GLenum source, operand;
@@ -29,6 +38,16 @@ struct UnifiedCompiledCombiner
     } vertex;
     UCTexStage color[8];
     UCTexStage alpha[8];
+
+    // NEW: Canonical combiner inputs for direct shader upload.
+    // These are decoded from gDP.combine.mux in Compile() and uploaded
+    // as uniforms in Set().  They represent the original (A-B)*C+D form
+    // before stage simplification.
+    int saRGB0, sbRGB0, mRGB0, aRGB0;
+    int saA0, sbA0, mA0, aA0;
+    int saRGB1, sbRGB1, mRGB1, aRGB1;
+    int saA1, sbA1, mA1, aA1;
+    int numCycles;
 };
 
 static UCTexArg TexEnvArgs[] = {
@@ -143,33 +162,19 @@ static UCTexArg TexEnvArgs[] = {
 static void Init()
 {
     for (int i = 0; i < OGL.maxTextureUnits; i++) TextureCache_ActivateDummy(i);
-
-    // TEXTURE_ENV_COMBINE is now required
-    TexEnvArgs[TEXEL0].source = GL_TEXTURE0_ARB;
-    TexEnvArgs[TEXEL0_ALPHA].source = GL_TEXTURE0_ARB;
-    TexEnvArgs[TEXEL1].source = GL_TEXTURE1_ARB;
-    TexEnvArgs[TEXEL1_ALPHA].source = GL_TEXTURE1_ARB;
 }
 
 static void Uninit()
 {
-    for (int i = 0; i < OGL.maxTextureUnits; i++)
-    {
-        glActiveTextureARB(GL_TEXTURE0_ARB + i);
-        glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
-    }
+    // Nothing to clean up — shader uniforms are managed by the GL driver.
 }
 
-static void UpdateColors(UnifiedCompiledCombiner *envCombiner)
+static void UpdateColors(UnifiedCompiledCombiner * /*envCombiner*/)
 {
-    GLcolor color;
-
-    for (int i = 0; i < OGL.maxTextureUnits; i++)
-    {
-        SetConstant(color, envCombiner->color[i].constant, envCombiner->alpha[i].constant);
-        glActiveTextureARB(GL_TEXTURE0_ARB + i);
-        glTexEnvfv(GL_TEXTURE_ENV, GL_TEXTURE_ENV_COLOR, &color.r);
-    }
+    // Fixed-function glTexEnvfv(GL_TEXTURE_ENV_COLOR) has been replaced by
+    // shader uniforms.  Ask the renderer to re-upload the current combiner
+    // state (which includes the latest prim/env colours from gDP).
+    OGL_UpdateN64CombinerColors();
 }
 
 static void Compile(UnifiedCompiledCombiner *envCombiner, Combiner *color, Combiner *alpha)
@@ -185,13 +190,13 @@ static void Compile(UnifiedCompiledCombiner *envCombiner, Combiner *color, Combi
         SetColorCombinerValues(i, arg1, GL_PREVIOUS_ARB, GL_SRC_COLOR);
         SetColorCombinerValues(i, arg2, GL_PREVIOUS_ARB, GL_SRC_COLOR);
         envCombiner->color[i].constant = COMBINED;
-        envCombiner->color[i].outputTexture = GL_TEXTURE0_ARB + i;
+        envCombiner->color[i].outputTexture = GL_TEXTURE0 + i;
 
         SetAlphaCombinerValues(i, arg0, GL_PREVIOUS_ARB, GL_SRC_ALPHA);
         SetAlphaCombinerValues(i, arg1, GL_PREVIOUS_ARB, GL_SRC_ALPHA);
         SetAlphaCombinerValues(i, arg2, GL_PREVIOUS_ARB, GL_SRC_ALPHA);
         envCombiner->alpha[i].constant = COMBINED;
-        envCombiner->alpha[i].outputTexture = GL_TEXTURE0_ARB + i;
+        envCombiner->alpha[i].outputTexture = GL_TEXTURE0 + i;
     }
 
     envCombiner->usesT0 = FALSE;
@@ -409,10 +414,42 @@ static void Compile(UnifiedCompiledCombiner *envCombiner, Combiner *color, Combi
     }
 
     envCombiner->usedUnits = max(curUnit, (int)envCombiner->usedUnits);
+
+    // -------------------------------------------------------------------
+    // NEW: Decode the original canonical (A-B)*C+D form directly from
+    // gDP.combine.mux.  The shader needs these values to replicate the
+    // N64 combiner exactly.  The stage simplification above is kept only
+    // to produce usesT0 / usesT1 / vertex colour source flags.
+    // -------------------------------------------------------------------
+    gDPCombine combine = gDP.combine;
+
+    envCombiner->saRGB0 = saRGBExpanded[combine.saRGB0];
+    envCombiner->sbRGB0 = sbRGBExpanded[combine.sbRGB0];
+    envCombiner->mRGB0 = mRGBExpanded[combine.mRGB0];
+    envCombiner->aRGB0 = aRGBExpanded[combine.aRGB0];
+
+    envCombiner->saA0 = saAExpanded[combine.saA0];
+    envCombiner->sbA0 = sbAExpanded[combine.sbA0];
+    envCombiner->mA0 = mAExpanded[combine.mA0];
+    envCombiner->aA0 = aAExpanded[combine.aA0];
+
+    envCombiner->saRGB1 = saRGBExpanded[combine.saRGB1];
+    envCombiner->sbRGB1 = sbRGBExpanded[combine.sbRGB1];
+    envCombiner->mRGB1 = mRGBExpanded[combine.mRGB1];
+    envCombiner->aRGB1 = aRGBExpanded[combine.aRGB1];
+
+    envCombiner->saA1 = saAExpanded[combine.saA1];
+    envCombiner->sbA1 = sbAExpanded[combine.sbA1];
+    envCombiner->mA1 = mAExpanded[combine.mA1];
+    envCombiner->aA1 = aAExpanded[combine.aA1];
+
+    envCombiner->numCycles = (gDP.otherMode.cycleType == G_CYC_2CYCLE) ? 2 : 1;
 }
 
 static void Set(UnifiedCompiledCombiner *envCombiner)
 {
+    // Update the global CombinerInfo flags that the vertex-building code
+    // in OpenGL.cpp reads (e.g.  combiner.usesT0, combiner.vertex.color).
     combiner.usesT0 = envCombiner->usesT0;
     combiner.usesT1 = envCombiner->usesT1;
     combiner.usesNoise = FALSE;
@@ -421,37 +458,97 @@ static void Set(UnifiedCompiledCombiner *envCombiner)
     combiner.vertex.secondaryColor = envCombiner->vertex.secondaryColor;
     combiner.vertex.alpha = envCombiner->vertex.alpha;
 
-    for (int i = 0; i < OGL.maxTextureUnits; i++)
+    // -----------------------------------------------------------------
+    // Build the N64 combiner state and upload it to the shader as
+    // uniforms.  This replaces the entire fixed-function glTexEnv block.
+    // -----------------------------------------------------------------
+    N64CombinerState state = {};
+
+    // Constant colours from gDP
+    state.primColor[0] = gDP.primColor.r;
+    state.primColor[1] = gDP.primColor.g;
+    state.primColor[2] = gDP.primColor.b;
+    state.primColor[3] = gDP.primColor.a;
+
+    state.envColor[0] = gDP.envColor.r;
+    state.envColor[1] = gDP.envColor.g;
+    state.envColor[2] = gDP.envColor.b;
+    state.envColor[3] = gDP.envColor.a;
+
+    state.primLODFrac = gDP.primColor.l;
+
+    state.fogColor[0] = gDP.fogColor.r;
+    state.fogColor[1] = gDP.fogColor.g;
+    state.fogColor[2] = gDP.fogColor.b;
+    state.fogColor[3] = gDP.fogColor.a;
+
+    state.fogEnabled = ((gSP.geometryMode & G_FOG) && OGL.fog) ? 1 : 0;
+    state.fogMultiplier = (float)gSP.fog.multiplier;
+    state.fogOffset = (float)gSP.fog.offset;
+
+    // Alpha test
+    if ((gDP.otherMode.alphaCompare == G_AC_THRESHOLD) && !(gDP.otherMode.alphaCvgSel))
     {
-        glActiveTextureARB(GL_TEXTURE0_ARB + i);
-
-        if ((i < envCombiner->usedUnits) || ((i < 2) && envCombiner->usesT1))
-        {
-            glEnable(GL_TEXTURE_2D);
-            glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE_ARB);
-
-            glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB_ARB, envCombiner->color[i].combine);
-            glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_RGB_ARB, envCombiner->color[i].arg0.source);
-            glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_RGB_ARB, envCombiner->color[i].arg0.operand);
-            glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE1_RGB_ARB, envCombiner->color[i].arg1.source);
-            glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_RGB_ARB, envCombiner->color[i].arg1.operand);
-            glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE2_RGB_ARB, envCombiner->color[i].arg2.source);
-            glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND2_RGB_ARB, envCombiner->color[i].arg2.operand);
-
-            glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA_ARB, envCombiner->alpha[i].combine);
-            glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_ALPHA_ARB, envCombiner->alpha[i].arg0.source);
-            glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA_ARB, envCombiner->alpha[i].arg0.operand);
-            glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE1_ALPHA_ARB, envCombiner->alpha[i].arg1.source);
-            glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_ALPHA_ARB, envCombiner->alpha[i].arg1.operand);
-            glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE2_ALPHA_ARB, envCombiner->alpha[i].arg2.source);
-            glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND2_ALPHA_ARB, envCombiner->alpha[i].arg2.operand);
-        }
-        else
-        {
-            glDisable(GL_TEXTURE_2D);
-        }
+        state.alphaTestEnabled = 1;
+        state.alphaTestThreshold = gDP.blendColor.a;
+        state.alphaTestFunction = (gDP.blendColor.a > 0.0f) ? 1 : 0; // 1 = GEQUAL, 0 = GREATER
     }
+    else if (gDP.otherMode.cvgXAlpha)
+    {
+        state.alphaTestEnabled = 1;
+        state.alphaTestThreshold = 0.5f;
+        state.alphaTestFunction = 1; // GEQUAL
+    }
+    else
+    {
+        state.alphaTestEnabled = 0;
+        state.alphaTestThreshold = 0.0f;
+        state.alphaTestFunction = 0;
+    }
+
+    // Stipple (dithered alpha)
+    if (OGL.usePolygonStipple && (gDP.otherMode.alphaCompare == G_AC_DITHER) && !(gDP.otherMode.alphaCvgSel))
+    {
+        state.stippleEnabled = 1;
+        state.stippleAlpha = (int)(gDP.envColor.a * 255.0f);
+        state.stipplePattern = OGL.lastStipple;
+    }
+    else
+    {
+        state.stippleEnabled = 0;
+        state.stippleAlpha = 0;
+        state.stipplePattern = 0;
+    }
+
+    // Canonical combiner inputs (decoded in Compile() from gDP.combine.mux)
+    state.saRGB0 = envCombiner->saRGB0;
+    state.sbRGB0 = envCombiner->sbRGB0;
+    state.mRGB0 = envCombiner->mRGB0;
+    state.aRGB0 = envCombiner->aRGB0;
+
+    state.saA0 = envCombiner->saA0;
+    state.sbA0 = envCombiner->sbA0;
+    state.mA0 = envCombiner->mA0;
+    state.aA0 = envCombiner->aA0;
+
+    state.saRGB1 = envCombiner->saRGB1;
+    state.sbRGB1 = envCombiner->sbRGB1;
+    state.mRGB1 = envCombiner->mRGB1;
+    state.aRGB1 = envCombiner->aRGB1;
+
+    state.saA1 = envCombiner->saA1;
+    state.sbA1 = envCombiner->sbA1;
+    state.mA1 = envCombiner->mA1;
+    state.aA1 = envCombiner->aA1;
+
+    state.numCycles = envCombiner->numCycles;
+
+    OGL_SetN64Combiner(&state);
 }
+
+// =========================================================================
+// Public interface
+// =========================================================================
 
 void Init_unified_combiner()
 {
@@ -482,11 +579,9 @@ void Set_unified_combiner(UnifiedCompiledCombiner *compiled)
 
 void BeginTextureUpdate_unified_combiner()
 {
-    for (int i = 0; i < OGL.maxTextureUnits; i++)
-    {
-        glActiveTextureARB(GL_TEXTURE0_ARB + i);
-        glDisable(GL_TEXTURE_2D);
-    }
+    // With shader-based rendering there is no fixed-function texture-unit
+    // state to disable.  Texture binding is handled by the caller via
+    // glActiveTexture/glBindTexture before drawing.
 }
 
 void EndTextureUpdate_unified_combiner()


### PR DESCRIPTION
## 🚧 Work In Progress — NOT YET TESTED

This PR tracks implementation of [issue #616](https://github.com/mupen64/mupen64-rr-lua/issues/616): converting the C++ core API surface into standard C.

### Implementation Plan (3 Phases)

**Phase 1 — API Survey**
- Map `core_api.h` + all included headers, **and the config library**
- STL replacements: `std::string` / `std::vector` → `(pointer, size)` pairs in parameters
- Return values: `malloc()`-backed struct with pointer+size, caller `free()`s
- Callback analysis: most core functions are raw functions or lambdas, so per-callback `void* userdata` may be unnecessary
- Catalog which return types need heap-allocated output vs. in-out buffers

**Phase 2 — C Header + C++ Wrapper**
- Draft `m64core.h` with opaque handles (`typedef struct M64Core* M64CoreHandle;`) and flat C functions
- Provide a **C++ convenience wrapper** over the C surface so the GUI side stays clean
- Propose a `m64core.dll` / `libm64core.so` build target via CMake `SHARED`

**Phase 3 — Incremental PRs**
- POC: ROM loading + frame stepping as a minimal viable subset
- Expand in reviewable chunks per subsystem (video, audio, input, RSP)
- Config-library migration as a separate follow-up PR
- Cross-platform CI validation (Windows, Linux, macOS)
- C# / Rust binding proof-of-concept

### Current Status

| Phase | Status |
|-------|--------|
| Phase 1 — API Survey | 🔲 Not started |
| Phase 2 — C Header + Wrapper | 🔲 Not started |
| Phase 3 — Incremental PRs | 🔲 Not started |

### What this PR is NOT
- Not ready for merge
- Not yet tested on any platform
- No C++ code changes landed yet — this is a tracking/draft branch

### Goal
Enable frontends in languages that don't interop with the C++ STL (Rust, C#, etc.) by exposing a pure C dynamic library interface.

### Early Feedback Welcome
Especially from @Aurumaker72 and @abart27 on design direction before code changes begin.

---

Relates to #616
