### PR TITLE
perf: skip audio thread creation if plugin doesnt need it

### DIFF
--- a/src/Core/include/core_api.h
+++ b/src/Core/include/core_api.h
@@ -253,7 +253,6 @@ extern "C"
         AILENCHANGED audio_ai_len_changed;
         AIREADLENGTH audio_ai_read_length;
         PROCESSALIST audio_process_alist;
-        AIUPDATE audio_ai_update;
 
         CONTROLLERCOMMAND input_controller_command;
         GETKEYS input_get_keys;

--- a/src/Core/include/core_plugin.h
+++ b/src/Core/include/core_plugin.h
@@ -247,7 +247,6 @@ extern "C"
     typedef void(CALL *AILENCHANGED)();
     typedef uint32_t(CALL *AIREADLENGTH)();
     typedef void(CALL *PROCESSALIST)();
-    typedef void(CALL *AIUPDATE)(int32_t wait);
 
     typedef void(CALL *CONTROLLERCOMMAND)(int32_t controller, unsigned char *command);
     typedef void(CALL *GETKEYS)(int32_t controller, core_buttons *keys);

--- a/src/Core/r4300/r4300.cpp
+++ b/src/Core/r4300/r4300.cpp
@@ -26,9 +26,6 @@
 #endif
 
 std::thread emu_thread_handle;
-std::thread audio_thread_handle;
-
-std::atomic<bool> audio_thread_stop_requested;
 
 // Lock to prevent emu state change race conditions
 std::recursive_mutex g_emu_cs;
@@ -2023,22 +2020,6 @@ void clear_save_data()
     fclose(g_mpak_file);
 }
 
-void audio_thread()
-{
-    g_core->log_info("Sound thread entering...");
-    while (true)
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-        if (audio_thread_stop_requested == true) break;
-
-        if (vcr.seek_to_frame.has_value()) continue;
-
-        g_core->audio_ai_update(0);
-    }
-    g_core->log_info("Sound thread exiting...");
-}
-
 void emu_thread()
 {
     auto start_time = std::chrono::high_resolution_clock::now();
@@ -2050,8 +2031,6 @@ void emu_thread()
     g_core->callbacks.emu_starting();
 
     dynacore = g_core->cfg->core_type;
-
-    audio_thread_handle = std::thread(audio_thread);
 
     g_core->callbacks.emu_launched_changed(true);
     g_core->callbacks.emu_starting_changed(false);
@@ -2083,10 +2062,6 @@ core_result vr_close_rom_impl(bool stop_vcr)
     }
 
     vr_resume_emu_impl(true);
-
-    audio_thread_stop_requested = true;
-    audio_thread_handle.join();
-    audio_thread_stop_requested = false;
 
     if (stop_vcr)
     {

--- a/src/Plugins.Win32.TASAudio/Main.cpp
+++ b/src/Plugins.Win32.TASAudio/Main.cpp
@@ -157,6 +157,9 @@ EXPORT void CALL AiDacrateChanged(int32_t system_type)
 
 EXPORT void CALL AiLenChanged(void)
 {
+    const auto effective_speed_mode = g_ef->get_effective_speed_mode();
+    if (effective_speed_mode == CoreSpeedMode::UltraFastForward) return;
+
     // push new samples
     if (!g_audio_info || !g_backend) return;
     uint32_t addr = *g_audio_info->ai_dram_addr_reg & 0x00FF'FFF8;

--- a/src/Plugins.Win32.TASAudio/Main.cpp
+++ b/src/Plugins.Win32.TASAudio/Main.cpp
@@ -172,8 +172,3 @@ EXPORT void CALL AiLenChanged(void)
         g_ef->log_error(IOUtils::to_wide_string(std::format("Exception at AiLenChanged(): {}", e.what())).c_str());
     }
 }
-
-EXPORT void CALL AiUpdate(int32_t wait)
-{
-    // no-op
-}

--- a/src/Views.Win32/Main.cpp
+++ b/src/Views.Win32/Main.cpp
@@ -1106,6 +1106,7 @@ int CALLBACK WinMain(const HINSTANCE hInstance, HINSTANCE, LPSTR, const int nSho
     std::filesystem::create_directories(Config::logs_directory());
 
     Loggers::init();
+    PluginUtil::init();
 
     g_view_logger->info("WinMain");
     g_view_logger->info(get_mupen_name());

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -13,6 +13,7 @@
 #include <components/ConfigDialog.h>
 #include <components/Statusbar.h>
 #include <ThreadPool.h>
+#include <Messenger.h>
 
 #define CALL _cdecl
 
@@ -36,6 +37,8 @@ static std::shared_ptr<Plugin> video_plugin;
 static std::shared_ptr<Plugin> audio_plugin;
 static std::shared_ptr<Plugin> input_plugin;
 static std::shared_ptr<Plugin> rsp_plugin;
+
+static std::jthread s_audio_thread;
 
 plugin_funcs g_plugin_funcs{};
 
@@ -131,6 +134,28 @@ static void CALL dummy_capture_screen(char *)
 }
 
 #pragma endregion
+
+static void audio_thread_proc(std::stop_token st)
+{
+    while (!st.stop_requested())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        g_plugin_funcs.audio_ai_update(0);
+    }
+}
+
+static void stop_audio_thread()
+{
+    if (!s_audio_thread.joinable()) return;
+    s_audio_thread.request_stop();
+    s_audio_thread = {};
+}
+
+static void start_audio_thread()
+{
+    if (s_audio_thread.joinable()) stop_audio_thread();
+    s_audio_thread = std::jthread(audio_thread_proc);
+}
 
 #define FUNC(target, type, fallback, name)                                                                             \
     target = (type)GetProcAddress((HMODULE)handle, name);                                                              \
@@ -579,6 +604,11 @@ void Plugin::deinitiate_dummy()
     if (close_dll) close_dll();
 }
 
+void PluginUtil::init()
+{
+    Messenger::subscribe(Messenger::Message::EmuStopping, [](const auto &...) { stop_audio_thread(); });
+}
+
 t_plugin_discovery_result PluginUtil::discover_plugins(const std::filesystem::path &directory)
 {
     std::vector<std::unique_ptr<Plugin>> plugins;
@@ -731,7 +761,6 @@ void PluginUtil::start_plugins()
     g_main_ctx.core.audio_ai_len_changed = g_plugin_funcs.audio_ai_len_changed;
     g_main_ctx.core.audio_ai_read_length = g_plugin_funcs.audio_ai_read_length;
     g_main_ctx.core.audio_process_alist = g_plugin_funcs.audio_process_alist;
-    g_main_ctx.core.audio_ai_update = g_plugin_funcs.audio_ai_update;
 
     g_main_ctx.core.input_controller_command = g_plugin_funcs.input_controller_command;
     g_main_ctx.core.input_get_keys = g_plugin_funcs.input_get_keys;
@@ -743,6 +772,8 @@ void PluginUtil::start_plugins()
     g_plugin_funcs.video_rom_open();
     g_plugin_funcs.input_rom_open();
     g_plugin_funcs.audio_rom_open();
+
+    start_audio_thread();
 }
 
 void PluginUtil::stop_plugins()

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -153,6 +153,15 @@ static void stop_audio_thread()
 
 static void start_audio_thread()
 {
+    // We can forego thread creation for plugins with no AiUpdate implementation because they do audio heartbeat
+    // themselves
+    if (g_plugin_funcs.audio_ai_update == dummy_ai_update)
+    {
+        g_view_logger->info("Skipping audio thread creation");
+        return;
+    }
+
+    g_view_logger->info("Starting audio thread...");
     if (s_audio_thread.joinable()) stop_audio_thread();
     s_audio_thread = std::jthread(audio_thread_proc);
 }

--- a/src/Views.Win32/Plugin.h
+++ b/src/Views.Win32/Plugin.h
@@ -154,6 +154,11 @@ extern plugin_funcs g_plugin_funcs;
 namespace PluginUtil
 {
 /**
+ * \brief Initializes the plugin utility module.
+ */
+void init();
+
+/**
  * \brief Discovers plugins in the given directory.
  * \param directory The directory to search for plugins in.
  * \return The plugin discovery result.

--- a/src/Views.Win32/include/Views.Win32/ViewPlugin.h
+++ b/src/Views.Win32/include/Views.Win32/ViewPlugin.h
@@ -73,6 +73,7 @@ extern "C"
     typedef void(CALL *READVIDEO)(void **);
 
     typedef int32_t(CALL *INITIATEAUDIO)(core_audio_info);
+    typedef void(CALL *AIUPDATE)(int32_t wait);
 
     typedef void(CALL *OLD_INITIATECONTROLLERS)(void *hwnd, core_controller controls[4]);
     typedef void(CALL *INITIATECONTROLLERS)(core_input_info control_info);


### PR DESCRIPTION
Skip creating an audio heartbeat thread if the current audio plugin doesnt need it.

Has little direct performance impact but reduces mupen's general resource consumption.

Also refactors the surrounding audio thread management: it's now in the view (as it shouldve been all along), and it now uses more idiomatic C++.