### PR TITLE
chore: update vcpkg baseline

### DIFF
--- a/src/Common/include/CommonPCH.h
+++ b/src/Common/include/CommonPCH.h
@@ -42,6 +42,10 @@
 #include <vector>
 #include <latch>
 #include <xxh64.h>
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_init.h>
+#include <SDL3/SDL_audio.h>
 #include "MiscHelpers.h"
 #include "StrUtils.h"
 #include "IOUtils.h"

--- a/src/Plugins.Win32.TASAudio/Main.cpp
+++ b/src/Plugins.Win32.TASAudio/Main.cpp
@@ -13,8 +13,6 @@
 #include "core_plugin.h"
 #include <CommonPCH.h>
 
-#include <SDL3/SDL_error.h>
-#include <SDL3/SDL_init.h>
 #include <VersionNameHelpers.h>
 #include <core_api.h>
 #include <Views.Win32/ViewPlugin.h>
@@ -32,8 +30,6 @@ core_plugin_extended_funcs *g_ef = nullptr;
 
 std::filesystem::path g_dll_path{}; // currently set in Main_Win32.cpp
 static bool g_sdl_is_init = false;
-
-static const SDL_InitFlags SDL_INIT_NEEDED = SDL_INIT_AUDIO;
 
 static uint32_t compute_sample_rate(uint32_t system_type, uint32_t dacrate)
 {
@@ -95,7 +91,6 @@ void write_config(const SDLAudio::Config &config)
 EXPORT void CALL CloseDLL(void)
 {
     if (g_backend.has_value()) g_backend.reset();
-    SDL_QuitSubSystem(SDL_INIT_NEEDED);
 }
 
 EXPORT void CALL ReceiveExtendedFuncs(core_plugin_extended_funcs *g_fwd_funcs)
@@ -119,7 +114,6 @@ EXPORT int32_t CALL InitiateAudio(core_audio_info Audio_Info)
     try
     {
         SDLAudio::Config cfg = win32_read_config();
-        if (!SDL_Init(SDL_INIT_NEEDED)) throw std::runtime_error(SDL_GetError());
         g_backend.emplace(std::move(cfg)); // TODO: add config dialog
     }
     catch (std::exception &e)

--- a/src/Plugins.Win32.TASAudio/SDLBackend.cpp
+++ b/src/Plugins.Win32.TASAudio/SDLBackend.cpp
@@ -6,8 +6,6 @@
 
 #include "SDLBackend.hpp"
 #include "Main.hpp"
-#include <SDL3/SDL_audio.h>
-#include <SDL3/SDL_error.h>
 #include <algorithm>
 #include <array>
 #include <bit>

--- a/src/Plugins.Win32.TASAudio/SDLBackend.hpp
+++ b/src/Plugins.Win32.TASAudio/SDLBackend.hpp
@@ -7,10 +7,6 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
-
-#include <SDL3/SDL_audio.h>
-
 #include "Config.hpp"
 
 namespace SDLAudio

--- a/src/Plugins.Win32.TASInput/Common.h
+++ b/src/Plugins.Win32.TASInput/Common.h
@@ -41,7 +41,6 @@
 #include <core_plugin.h>
 #include <Resource.h>
 #include <gdiplus.h>
-#include <SDL3/SDL.h>
 #pragma warning(pop)
 
 #include <Helpers.h>

--- a/src/Plugins.Win32.TASInput/ConfigDialog.cpp
+++ b/src/Plugins.Win32.TASInput/ConfigDialog.cpp
@@ -343,15 +343,11 @@ static LRESULT CALLBACK hotkey_button_subclass_proc(HWND hwnd, UINT msg, WPARAM 
 
 static LRESULT CALLBACK dlgproc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
-    Main::pump_sdl_events();
-
     auto controller_config = &new_config.controller_config[g_ctx.selected_controller];
 
     switch (msg)
     {
     case WM_INITDIALOG: {
-        Main::init_sdl();
-
         g_ctx.hwnd = hwnd;
         update_visuals();
 

--- a/src/Plugins.Win32.TASInput/GamepadManager.h
+++ b/src/Plugins.Win32.TASInput/GamepadManager.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <core_types.h>
+
 /**
  * \brief Provides gamepad-related functionality.
  */

--- a/src/Plugins.Win32.TASInput/Main.cpp
+++ b/src/Plugins.Win32.TASInput/Main.cpp
@@ -44,18 +44,3 @@ EXPORT void CALL ReceiveExtendedFuncs(core_plugin_extended_funcs *funcs)
 {
     g_ef = funcs;
 }
-
-void Main::init_sdl()
-{
-    RT_ASSERT(SDL_Init(SDL_INIT_GAMEPAD | SDL_INIT_JOYSTICK), L"Failed to initialize SDL subsystems");
-}
-
-void Main::pump_sdl_events()
-{
-    SDL_Event e;
-    while (SDL_PollEvent(&e))
-    {
-        GamepadManager::on_sdl_event(e);
-        ConfigDialog::on_sdl_event(e);
-    }
-}

--- a/src/Plugins.Win32.TASInput/Main.h
+++ b/src/Plugins.Win32.TASInput/Main.h
@@ -12,9 +12,3 @@ extern core_plugin_extended_funcs *g_ef;
 #define PLUGIN_NAME VERSION_NAME_HELPER_GEN_NAME(L"TAS Input", L"2.0.5")
 
 #define NUMBER_OF_CONTROLS 4
-
-namespace Main
-{
-void init_sdl();
-void pump_sdl_events();
-} // namespace Main

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -1011,8 +1011,6 @@ static void show_activated_windows()
 
 static void ui_thread()
 {
-    Main::init_sdl();
-
     Gdiplus::GdiplusStartupInput startup_input;
     GdiplusStartup(&gdi_plus_token, &startup_input, NULL);
 
@@ -1070,8 +1068,6 @@ static void ui_thread()
                     DispatchMessage(&msg);
                 }
             }
-
-            Main::pump_sdl_events();
         }
     }
 

--- a/src/Views.Win32/CMakeLists.txt
+++ b/src/Views.Win32/CMakeLists.txt
@@ -160,6 +160,7 @@ target_link_libraries(Mupen64RR.Views.Win32 PRIVATE
     Mupen64RR.Views.Win32.Headers
     Lua::Lua
     spdlog::spdlog
+    SDL3::SDL3
     nlohmann_json::nlohmann_json
     PkgConfig::speexdsp
     PkgConfig::libav

--- a/src/Views.Win32/Main.cpp
+++ b/src/Views.Win32/Main.cpp
@@ -741,7 +741,6 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
         MGECompositor::create(hwnd);
         PianoRoll::init();
         LuaDialog::init();
-
         return TRUE;
     case WM_DESTROY:
         g_main_ctx.exiting = true;
@@ -751,6 +750,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
         Config::save();
         Gdiplus::GdiplusShutdown(gdi_plus_token);
         CoUninitialize();
+        SDL_Quit();
         PostQuitMessage(0);
         break;
     case WM_PREDESTROY:

--- a/src/Views.Win32/Main.cpp
+++ b/src/Views.Win32/Main.cpp
@@ -1091,6 +1091,19 @@ static bool is_running_under_wine()
     return GetProcAddress(ntdll, "wine_get_version") != nullptr;
 }
 
+void Main::init_sdl()
+{
+    static bool s_sdl_initialized = false;
+    if (!s_sdl_initialized)
+    {
+        g_main_ctx.dispatcher->invoke([] {
+            RT_ASSERT(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMEPAD | SDL_INIT_JOYSTICK),
+                      L"SDL_Init failed");
+        });
+        s_sdl_initialized = true;
+    }
+}
+
 int CALLBACK WinMain(const HINSTANCE hInstance, HINSTANCE, LPSTR, const int nShowCmd)
 {
     enable_mitigations();

--- a/src/Views.Win32/Main.h
+++ b/src/Views.Win32/Main.h
@@ -114,3 +114,12 @@ void set_cwd();
  * \return The path to the savestate file.
  */
 std::filesystem::path get_st_with_slot_path(size_t slot);
+
+namespace Main
+{
+
+/**
+ * \brief Initializes SDL on the GUI thread if necessary.
+ */
+void init_sdl();
+} // namespace Main

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -518,6 +518,8 @@ void Plugin::initiate()
 
 void Plugin::initiate_dummy()
 {
+    Main::init_sdl();
+
     const auto receive_extended_funcs = (RECEIVEEXTENDEDFUNCS)GetProcAddress(m_module, "ReceiveExtendedFuncs");
     if (receive_extended_funcs)
     {
@@ -818,15 +820,7 @@ bool PluginUtil::load_plugins()
         g_view_logger->trace(L"Loading input plugin: {}", g_config.selected_input_plugin);
         g_view_logger->trace(L"Loading RSP plugin: {}", g_config.selected_rsp_plugin);
 
-        static bool s_sdl_initialized = false;
-        if (!s_sdl_initialized)
-        {
-            g_main_ctx.dispatcher->invoke([] {
-                RT_ASSERT(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMEPAD | SDL_INIT_JOYSTICK),
-                          L"SDL_Init failed");
-            });
-            s_sdl_initialized = true;
-        }
+        Main::init_sdl();
 
         auto video_pl = Plugin::create(g_config.selected_video_plugin);
         auto audio_pl = Plugin::create(g_config.selected_audio_plugin);

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -818,6 +818,16 @@ bool PluginUtil::load_plugins()
         g_view_logger->trace(L"Loading input plugin: {}", g_config.selected_input_plugin);
         g_view_logger->trace(L"Loading RSP plugin: {}", g_config.selected_rsp_plugin);
 
+        static bool s_sdl_initialized = false;
+        if (!s_sdl_initialized)
+        {
+            g_main_ctx.dispatcher->invoke([] {
+                RT_ASSERT(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMEPAD | SDL_INIT_JOYSTICK),
+                          L"SDL_Init failed");
+            });
+            s_sdl_initialized = true;
+        }
+
         auto video_pl = Plugin::create(g_config.selected_video_plugin);
         auto audio_pl = Plugin::create(g_config.selected_audio_plugin);
         auto input_pl = Plugin::create(g_config.selected_input_plugin);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -22,5 +22,5 @@
     "glew",
     "sdl3"
   ],
-  "builtin-baseline": "a62ce77d56ee07513b4b67de1ec2daeaebfae51a"
+  "builtin-baseline": "10ceb139a610ebf3c6aa49cdc4a4b7f3db5d3f2b"
 }


### PR DESCRIPTION
This updates all packages to their latest versions. The notable change here is Lua updating to 5.5.0.

Due to SDL failing assertions about multiple initialization, we now initialize it in Mupen on the GUI thread, with the TAS plugins just take advantage of that. This is scuffed and not documented anywhere, but we don't need to care because these are *our* plugins :D

Closes #663