### PR TITLE
feat: switch to JSON config

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -50,6 +50,10 @@
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Linux"
+      },
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
       }
     }
   ],

--- a/src/Common/include/IOUtils.h
+++ b/src/Common/include/IOUtils.h
@@ -325,7 +325,7 @@ inline std::filesystem::path compute_config_path()
 #ifdef _WIN32
     wchar_t path_buffer[MAX_PATH] = {L'\0'};
     DWORD rc;
-    rc = GetEnvironmentVariableW(L"LOCALAPPDATA", path_buffer, sizeof(path_buffer));
+    rc = GetEnvironmentVariableW(L"LOCALAPPDATA", path_buffer, MAX_PATH);
     if (rc == 0)
     {
         throw std::system_error((int)GetLastError(), std::system_category());
@@ -341,7 +341,7 @@ inline std::filesystem::path compute_config_path()
     }
 
     const char *env_home = getenv("HOME");
-    assert(env_home != nullptr);
+    if (env_home == nullptr) throw std::runtime_error("$HOME is undefined");
 
     return std::filesystem::path(env_home) / ".config/mupen64-rr-lua";
 #else

--- a/src/Common/include/IOUtils.h
+++ b/src/Common/include/IOUtils.h
@@ -334,7 +334,12 @@ inline std::filesystem::path compute_config_path()
 #endif
 }
 
-// Gets the path of the config directory, creating it if needed.
+/**
+ * @brief Gets the path to the config directory.
+ *
+ * This is usually tied to `%LOCALAPPDATA%` on Windows, and `$XDG_CONFIG_HOME` or `~/.config`
+ * on Linux.
+ */
 inline const std::filesystem::path& config_path() {
     static const std::filesystem::path cached_path = compute_config_path();
     if (!std::filesystem::is_directory(cached_path))

--- a/src/Common/include/IOUtils.h
+++ b/src/Common/include/IOUtils.h
@@ -10,7 +10,9 @@
 #define NOMINMAX
 #include <Windows.h>
 #elif defined(__linux__)
-#include <stdio.h>
+#include <stdexcept>
+#include <cstdio>
+#include <cstdlib>
 #endif
 
 namespace IOUtils
@@ -301,14 +303,16 @@ inline std::filesystem::path compute_exe_path()
         throw std::system_error((int)GetLastError(), std::system_category());
     }
     return std::filesystem::path(path_buffer);
+#elif defined(__linux__)
+    return std::filesystem::read_symlink("/proc/self/exe");
 #else
-#error TODO: compute_exe_path not defined on this platform
+#error TODO: compute_exe_path() not defined on this platform
 #endif
 }
 
 // Gets the path of the current executable file.
 // This is only computed once and cached for the rest of the program.
-inline const std::filesystem::path& exe_path()
+inline const std::filesystem::path &exe_path()
 {
     // this ensures that the exe path is cached.
     static const std::filesystem::path cached_path = compute_exe_path();
@@ -329,6 +333,17 @@ inline std::filesystem::path compute_config_path()
 
     auto dir = std::filesystem::path(path_buffer) / "mupen64-rr-lua";
     return dir;
+#elif defined(__linux__)
+    const char *env_config = getenv("XDG_CONFIG_HOME");
+    if (env_config != nullptr)
+    {
+        return std::filesystem::path(env_config) / "mupen64-rr-lua";
+    }
+
+    const char *env_home = getenv("HOME");
+    assert(env_home != nullptr);
+
+    return std::filesystem::path(env_home) / ".config/mupen64-rr-lua";
 #else
 #error TODO: compute_config_dir not defined on this platform
 #endif
@@ -340,10 +355,10 @@ inline std::filesystem::path compute_config_path()
  * This is usually tied to `%LOCALAPPDATA%` on Windows, and `$XDG_CONFIG_HOME` or `~/.config`
  * on Linux.
  */
-inline const std::filesystem::path& config_path() {
+inline const std::filesystem::path &config_path()
+{
     static const std::filesystem::path cached_path = compute_config_path();
-    if (!std::filesystem::is_directory(cached_path))
-        std::filesystem::create_directories(cached_path);
+    if (!std::filesystem::is_directory(cached_path)) std::filesystem::create_directories(cached_path);
     return cached_path;
 }
 

--- a/src/Common/include/IOUtils.h
+++ b/src/Common/include/IOUtils.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <filesystem>
 #if defined(_WIN32)
 #define NOMINMAX
 #include <Windows.h>
@@ -287,26 +288,57 @@ inline FILE *path_fopen_shared(const std::filesystem::path &path, const char *mo
 #endif
 }
 
-// Gets the path of the current executable file.
-inline std::filesystem::path exe_path()
+// Computes the path of the current executable file.
+inline std::filesystem::path compute_exe_path()
 {
 #ifdef _WIN32
     wchar_t path_buffer[MAX_PATH] = {L'\0'};
-    int rc;
+    DWORD rc;
 
     rc = GetModuleFileNameW(NULL, path_buffer, sizeof(path_buffer) / sizeof(wchar_t));
     if (rc == 0)
     {
-        throw std::system_error(GetLastError(), std::system_category());
+        throw std::system_error((int)GetLastError(), std::system_category());
     }
     return std::filesystem::path(path_buffer);
+#else
+#error TODO: compute_exe_path not defined on this platform
 #endif
 }
+
 // Gets the path of the current executable file.
-inline std::filesystem::path exe_path_cached()
+// This is only computed once and cached for the rest of the program.
+inline const std::filesystem::path& exe_path()
 {
     // this ensures that the exe path is cached.
-    static std::filesystem::path cached_path = exe_path();
+    static const std::filesystem::path cached_path = compute_exe_path();
+    return cached_path;
+}
+
+// Computes the path of the config directory.
+inline std::filesystem::path compute_config_path()
+{
+#ifdef _WIN32
+    wchar_t path_buffer[MAX_PATH] = {L'\0'};
+    DWORD rc;
+    rc = GetEnvironmentVariableW(L"LOCALAPPDATA", path_buffer, sizeof(path_buffer));
+    if (rc == 0)
+    {
+        throw std::system_error((int)GetLastError(), std::system_category());
+    }
+
+    auto dir = std::filesystem::path(path_buffer) / "mupen64-rr-lua";
+    return dir;
+#else
+#error TODO: compute_config_dir not defined on this platform
+#endif
+}
+
+// Gets the path of the config directory, creating it if needed.
+inline const std::filesystem::path& config_path() {
+    static const std::filesystem::path cached_path = compute_config_path();
+    if (!std::filesystem::is_directory(cached_path))
+        std::filesystem::create_directories(cached_path);
     return cached_path;
 }
 

--- a/src/Plugins.Win32.TASAudio/Main.cpp
+++ b/src/Plugins.Win32.TASAudio/Main.cpp
@@ -97,16 +97,7 @@ EXPORT void CALL CloseDLL(void)
 EXPORT void CALL ReceiveExtendedFuncs(core_plugin_extended_funcs *g_fwd_funcs)
 {
     g_ef = g_fwd_funcs;
-
-    // CONFIG PATH
-    // get length
-    size_t len = g_ef->config_path(nullptr, 0);
-    // copy string
-    std::string path_temp(len, '\0');
-    g_ef->config_path(path_temp.data(), path_temp.size());
-    // drop the terminating null
-    path_temp.pop_back();
-    g_config_path = std::filesystem::absolute(path_temp);
+    g_config_path = ViewPluginHelpers::get_config_path(g_ef);
 }
 
 EXPORT void CALL GetDllInfo(core_plugin_info *PluginInfo)

--- a/src/Plugins.Win32.TASAudio/Main.cpp
+++ b/src/Plugins.Win32.TASAudio/Main.cpp
@@ -7,11 +7,11 @@
 #include "Main.hpp"
 #include "Config.hpp"
 #include "IOUtils.h"
-#include "Main_Win32.hpp"
 #include "SDLBackend.hpp"
 
 #include "core_plugin.h"
 #include <CommonPCH.h>
+#include <SDL3/SDL.h>
 
 #include <VersionNameHelpers.h>
 #include <core_api.h>
@@ -125,8 +125,8 @@ EXPORT int32_t CALL InitiateAudio(core_audio_info Audio_Info)
     try
     {
         SDLAudio::Config cfg = read_config();
-        if (!SDL_Init(SDL_INIT_NEEDED)) throw std::runtime_error(SDL_GetError());
-        g_backend.emplace(std::move(cfg)); // TODO: add config dialog
+        if (!SDL_Init(SDL_INIT_AUDIO)) throw std::runtime_error(SDL_GetError());
+        g_backend.emplace(std::move(cfg));
     }
     catch (std::exception &e)
     {

--- a/src/Plugins.Win32.TASAudio/Main.cpp
+++ b/src/Plugins.Win32.TASAudio/Main.cpp
@@ -29,6 +29,7 @@ std::optional<SDLAudio::SDLBackend> g_backend{};
 core_plugin_extended_funcs *g_ef = nullptr;
 
 std::filesystem::path g_dll_path{}; // currently set in Main_Win32.cpp
+std::filesystem::path g_config_path{};
 static bool g_sdl_is_init = false;
 
 static uint32_t compute_sample_rate(uint32_t system_type, uint32_t dacrate)
@@ -53,7 +54,7 @@ static uint32_t compute_sample_rate(uint32_t system_type, uint32_t dacrate)
 
 static inline std::filesystem::path config_path()
 {
-    return g_dll_path.parent_path() / "TASAudio.conf.json";
+    return g_config_path / "TASAudio.json";
 }
 
 SDLAudio::Config read_config()
@@ -96,6 +97,16 @@ EXPORT void CALL CloseDLL(void)
 EXPORT void CALL ReceiveExtendedFuncs(core_plugin_extended_funcs *g_fwd_funcs)
 {
     g_ef = g_fwd_funcs;
+
+    // CONFIG PATH
+    // get length
+    size_t len = g_ef->config_path(nullptr, 0);
+    // copy string
+    std::string path_temp(len, '\0');
+    g_ef->config_path(path_temp.data(), path_temp.size());
+    // drop the terminating null
+    path_temp.pop_back();
+    g_config_path = std::filesystem::absolute(path_temp);
 }
 
 EXPORT void CALL GetDllInfo(core_plugin_info *PluginInfo)
@@ -113,7 +124,8 @@ EXPORT int32_t CALL InitiateAudio(core_audio_info Audio_Info)
 
     try
     {
-        SDLAudio::Config cfg = win32_read_config();
+        SDLAudio::Config cfg = read_config();
+        if (!SDL_Init(SDL_INIT_NEEDED)) throw std::runtime_error(SDL_GetError());
         g_backend.emplace(std::move(cfg)); // TODO: add config dialog
     }
     catch (std::exception &e)

--- a/src/Plugins.Win32.TASAudio/Main.hpp
+++ b/src/Plugins.Win32.TASAudio/Main.hpp
@@ -14,6 +14,7 @@
 
 extern core_plugin_extended_funcs *g_ef;
 extern std::filesystem::path g_dll_path;
+extern std::filesystem::path g_config_path;
 extern std::optional<SDLAudio::SDLBackend> g_backend;
 
 SDLAudio::Config read_config();

--- a/src/Plugins.Win32.TASAudio/Main_Win32.cpp
+++ b/src/Plugins.Win32.TASAudio/Main_Win32.cpp
@@ -59,11 +59,11 @@ EXPORT void CALL DllAbout(void *hParent)
 
 EXPORT void CALL DllConfig(void *hParent)
 {
-    SDLAudio::Config cfg = win32_read_config();
+    SDLAudio::Config cfg = read_config();
     if (SDLAudio::win32_show_config((HWND)hParent, cfg))
     {
         if (g_ef) g_ef->log_info(L"Saving config...");
-        win32_write_config(cfg);
+        write_config(cfg);
         if (g_backend.has_value()) g_backend->merge_cfg_live(cfg);
     }
 }

--- a/src/Plugins.Win32.TASInput/CMakeLists.txt
+++ b/src/Plugins.Win32.TASInput/CMakeLists.txt
@@ -37,6 +37,7 @@ target_include_directories(Mupen64RR.Plugins.Win32.TASInput PRIVATE ".")
 target_link_libraries(Mupen64RR.Plugins.Win32.TASInput PRIVATE 
     Mupen64RR.Plugins.Win32.Common
     SDL3::SDL3
+    nlohmann_json::nlohmann_json
 )
 target_link_libraries(Mupen64RR.Plugins.Win32.TASInput PRIVATE
     setupapi

--- a/src/Plugins.Win32.TASInput/Main.cpp
+++ b/src/Plugins.Win32.TASInput/Main.cpp
@@ -13,6 +13,8 @@
 #define EXPORT __declspec(dllexport)
 #define CALL _cdecl
 
+std::filesystem::path g_config_path;
+
 static void log_shim(const wchar_t *str)
 {
     wprintf(str);
@@ -43,4 +45,14 @@ int WINAPI DllMain(const HINSTANCE h_instance, const DWORD fdw_reason, PVOID)
 EXPORT void CALL ReceiveExtendedFuncs(core_plugin_extended_funcs *funcs)
 {
     g_ef = funcs;
+
+    // CONFIG PATH
+    // get length
+    size_t len = g_ef->config_path(nullptr, 0);
+    // copy string
+    std::string path_temp(len, '\0');
+    g_ef->config_path(path_temp.data(), path_temp.size());
+    // drop the terminating null
+    path_temp.pop_back();
+    g_config_path = std::filesystem::absolute(path_temp);
 }

--- a/src/Plugins.Win32.TASInput/Main.cpp
+++ b/src/Plugins.Win32.TASInput/Main.cpp
@@ -45,14 +45,5 @@ int WINAPI DllMain(const HINSTANCE h_instance, const DWORD fdw_reason, PVOID)
 EXPORT void CALL ReceiveExtendedFuncs(core_plugin_extended_funcs *funcs)
 {
     g_ef = funcs;
-
-    // CONFIG PATH
-    // get length
-    size_t len = g_ef->config_path(nullptr, 0);
-    // copy string
-    std::string path_temp(len, '\0');
-    g_ef->config_path(path_temp.data(), path_temp.size());
-    // drop the terminating null
-    path_temp.pop_back();
-    g_config_path = std::filesystem::absolute(path_temp);
+    g_config_path = ViewPluginHelpers::get_config_path(g_ef);
 }

--- a/src/Plugins.Win32.TASInput/Main.h
+++ b/src/Plugins.Win32.TASInput/Main.h
@@ -6,8 +6,13 @@
 
 #pragma once
 
+#include <Windows.h>
+#include <Views.Win32/ViewPlugin.h>
+#include <filesystem>
+
 extern HINSTANCE g_inst;
 extern core_plugin_extended_funcs *g_ef;
+extern std::filesystem::path g_config_path;
 
 #define PLUGIN_NAME VERSION_NAME_HELPER_GEN_NAME(L"TAS Input", L"2.0.5")
 

--- a/src/Plugins.Win32.TASInput/NewConfig.cpp
+++ b/src/Plugins.Win32.TASInput/NewConfig.cpp
@@ -15,34 +15,35 @@
 const t_config default_config{};
 t_config new_config{};
 
-static std::filesystem::path get_config_path() {
+static std::filesystem::path get_config_path()
+{
     return g_config_path / CONFIG_FILE_NAME;
 }
 
-// void save_registry_config()
-// {
-//     g_ef->log_trace(L"Saving config...");
+static void save_registry_config()
+{
+    g_ef->log_trace(L"Saving config...");
 
-//     HKEY h_key{};
+    HKEY h_key{};
 
-//     if (RegCreateKeyEx(HKEY_CURRENT_USER, SUBKEY, 0, NULL, 0, KEY_WRITE, NULL, &h_key, NULL) != ERROR_SUCCESS)
-//     {
-//         g_ef->log_error(L"RegCreateKeyEx failed");
-//         return;
-//     }
+    if (RegCreateKeyEx(HKEY_CURRENT_USER, REG_SUBKEY, 0, NULL, 0, KEY_WRITE, NULL, &h_key, NULL) != ERROR_SUCCESS)
+    {
+        g_ef->log_error(L"RegCreateKeyEx failed");
+        return;
+    }
 
-//     if (RegSetValueEx(h_key, CONFIG_VALUE, 0, REG_BINARY, reinterpret_cast<const BYTE *>(&new_config),
-//                       sizeof(t_config)) != ERROR_SUCCESS)
-//     {
-//         g_ef->log_error(L"RegSetValueEx failed");
-//         RegCloseKey(h_key);
-//         return;
-//     }
+    if (RegSetValueEx(h_key, REG_CONFIG_VALUE, 0, REG_BINARY, reinterpret_cast<const BYTE *>(&new_config),
+                      sizeof(t_config)) != ERROR_SUCCESS)
+    {
+        g_ef->log_error(L"RegSetValueEx failed");
+        RegCloseKey(h_key);
+        return;
+    }
 
-//     RegCloseKey(h_key);
-// }
+    RegCloseKey(h_key);
+}
 
-void load_registry_config()
+static void load_registry_config()
 {
     g_ef->log_trace(L"Loading config...");
 
@@ -92,20 +93,24 @@ void load_config()
 
     auto json_path = get_config_path();
 
-    if (std::filesystem::exists(json_path)) {
+    if (std::filesystem::exists(json_path))
+    {
         std::ifstream ifs(json_path);
-        
+
         nlohmann::json j;
         ifs >> j;
-        try {
+        try
+        {
             nlohmann::from_json(j, new_config);
         }
-        catch (const std::exception& e) {
+        catch (const std::exception &e)
+        {
             g_ef->log_warn(L"Config load failed, using defaults...");
             new_config = default_config;
         }
     }
-    else {
+    else
+    {
         g_ef->log_warn(L"No JSON config was present, attempting to load from registry");
         load_registry_config();
 

--- a/src/Plugins.Win32.TASInput/NewConfig.cpp
+++ b/src/Plugins.Win32.TASInput/NewConfig.cpp
@@ -96,11 +96,11 @@ void load_config()
     if (std::filesystem::exists(json_path))
     {
         std::ifstream ifs(json_path);
-
         nlohmann::json j;
-        ifs >> j;
+
         try
         {
+            ifs >> j;
             nlohmann::from_json(j, new_config);
         }
         catch (const std::exception &e)

--- a/src/Plugins.Win32.TASInput/NewConfig.cpp
+++ b/src/Plugins.Win32.TASInput/NewConfig.cpp
@@ -9,42 +9,47 @@
 #include <MiscHelpers.h>
 #include <Main.h>
 
-#define CONFIG_VALUE L"Config"
+#define REG_SUBKEY L"Software\\N64 Emulation\\DLL\\TASDI"
+#define REG_CONFIG_VALUE L"Config"
 
 const t_config default_config{};
 t_config new_config{};
 
-void save_config()
-{
-    g_ef->log_trace(L"Saving config...");
-
-    HKEY h_key{};
-
-    if (RegCreateKeyEx(HKEY_CURRENT_USER, SUBKEY, 0, NULL, 0, KEY_WRITE, NULL, &h_key, NULL) != ERROR_SUCCESS)
-    {
-        g_ef->log_error(L"RegCreateKeyEx failed");
-        return;
-    }
-
-    if (RegSetValueEx(h_key, CONFIG_VALUE, 0, REG_BINARY, reinterpret_cast<const BYTE *>(&new_config),
-                      sizeof(t_config)) != ERROR_SUCCESS)
-    {
-        g_ef->log_error(L"RegSetValueEx failed");
-        RegCloseKey(h_key);
-        return;
-    }
-
-    RegCloseKey(h_key);
+static std::filesystem::path get_config_path() {
+    return g_config_path / CONFIG_FILE_NAME;
 }
 
-void load_config()
+// void save_registry_config()
+// {
+//     g_ef->log_trace(L"Saving config...");
+
+//     HKEY h_key{};
+
+//     if (RegCreateKeyEx(HKEY_CURRENT_USER, SUBKEY, 0, NULL, 0, KEY_WRITE, NULL, &h_key, NULL) != ERROR_SUCCESS)
+//     {
+//         g_ef->log_error(L"RegCreateKeyEx failed");
+//         return;
+//     }
+
+//     if (RegSetValueEx(h_key, CONFIG_VALUE, 0, REG_BINARY, reinterpret_cast<const BYTE *>(&new_config),
+//                       sizeof(t_config)) != ERROR_SUCCESS)
+//     {
+//         g_ef->log_error(L"RegSetValueEx failed");
+//         RegCloseKey(h_key);
+//         return;
+//     }
+
+//     RegCloseKey(h_key);
+// }
+
+void load_registry_config()
 {
     g_ef->log_trace(L"Loading config...");
 
     HKEY h_key{};
     DWORD size = sizeof(t_config);
 
-    if (RegOpenKeyEx(HKEY_CURRENT_USER, SUBKEY, 0, KEY_READ, &h_key) != ERROR_SUCCESS)
+    if (RegOpenKeyEx(HKEY_CURRENT_USER, REG_SUBKEY, 0, KEY_READ, &h_key) != ERROR_SUCCESS)
     {
         g_ef->log_error(L"RegCreateKeyEx failed");
         return;
@@ -52,7 +57,7 @@ void load_config()
 
     t_config loaded_config{};
 
-    if (RegQueryValueEx(h_key, CONFIG_VALUE, nullptr, nullptr, reinterpret_cast<BYTE *>(&loaded_config), &size) !=
+    if (RegQueryValueEx(h_key, REG_CONFIG_VALUE, nullptr, nullptr, reinterpret_cast<BYTE *>(&loaded_config), &size) !=
             ERROR_SUCCESS ||
         size != sizeof(t_config))
     {
@@ -70,4 +75,40 @@ void load_config()
     }
 
     new_config = loaded_config;
+}
+
+void save_config()
+{
+    g_ef->log_trace(L"Saving config...");
+
+    nlohmann::json j = new_config;
+    std::ofstream ofs(get_config_path());
+    ofs << std::setw(2) << j;
+}
+
+void load_config()
+{
+    g_ef->log_trace(L"Loading config...");
+
+    auto json_path = get_config_path();
+
+    if (std::filesystem::exists(json_path)) {
+        std::ifstream ifs(json_path);
+        
+        nlohmann::json j;
+        ifs >> j;
+        try {
+            nlohmann::from_json(j, new_config);
+        }
+        catch (const std::exception& e) {
+            g_ef->log_warn(L"Config load failed, using defaults...");
+            new_config = default_config;
+        }
+    }
+    else {
+        g_ef->log_warn(L"No JSON config was present, attempting to load from registry");
+        load_registry_config();
+
+        save_config();
+    }
 }

--- a/src/Plugins.Win32.TASInput/NewConfig.h
+++ b/src/Plugins.Win32.TASInput/NewConfig.h
@@ -6,15 +6,40 @@
 
 #pragma once
 
-#define SUBKEY L"Software\\N64 Emulation\\DLL\\TASDI"
+#include <SDL3/SDL_gamepad.h>
+#include <nlohmann/json.hpp>
+
+#define CONFIG_FILE_NAME "TASInput.json"
 
 const auto AXIS_THRESHOLD = 16000;
+
+
 
 struct t_axis_mapping
 {
     int32_t axis = SDL_GAMEPAD_AXIS_INVALID;
     int32_t key_negative = 0;
     int32_t key_positive = 0;
+
+    friend void to_json(nlohmann::json& j, const t_axis_mapping& self) {
+        #define TASINPUT_FIELD(field) {#field, self.field}
+        j = nlohmann::json::object({
+            TASINPUT_FIELD(axis),
+            TASINPUT_FIELD(key_negative),
+            TASINPUT_FIELD(key_positive),
+        });
+        #undef TASINPUT_FIELD
+    }
+
+    friend void from_json(const nlohmann::json& j, t_axis_mapping& self) {
+        #define TASINPUT_FIELD(field) .field = j[#field]
+        self = {
+            TASINPUT_FIELD(axis),
+            TASINPUT_FIELD(key_negative),
+            TASINPUT_FIELD(key_positive),
+        };
+        #undef TASINPUT_FIELD
+    }
 };
 
 struct t_button_mapping
@@ -22,6 +47,26 @@ struct t_button_mapping
     int32_t button = SDL_GAMEPAD_BUTTON_INVALID;
     int32_t axis = SDL_GAMEPAD_AXIS_INVALID;
     int32_t key = 0;
+
+    friend void to_json(nlohmann::json& j, const t_button_mapping& self) {
+        #define TASINPUT_FIELD(field) {#field, self.field}
+        j = nlohmann::json::object({
+            TASINPUT_FIELD(button),
+            TASINPUT_FIELD(axis),
+            TASINPUT_FIELD(key),
+        });
+        #undef TASINPUT_FIELD
+    }
+
+    friend void from_json(const nlohmann::json& j, t_button_mapping& self) {
+        #define TASINPUT_FIELD(field) .field = j[#field]
+        self = {
+            TASINPUT_FIELD(button),
+            TASINPUT_FIELD(axis),
+            TASINPUT_FIELD(key),
+        };
+        #undef TASINPUT_FIELD
+    }
 };
 
 struct t_controller_config
@@ -70,9 +115,59 @@ struct t_controller_config
         config.y = {.key_negative = 'I', .key_positive = 'K'};
         return config;
     }
+
+    friend void to_json(nlohmann::json& j, const t_controller_config& self) {
+        #define TASINPUT_FIELD(field) {#field, self.field}
+        j = nlohmann::json::object({
+            TASINPUT_FIELD(dpad_right),
+            TASINPUT_FIELD(dpad_left),
+            TASINPUT_FIELD(dpad_down),
+            TASINPUT_FIELD(dpad_up),
+            TASINPUT_FIELD(c_right),
+            TASINPUT_FIELD(c_left),
+            TASINPUT_FIELD(c_down),
+            TASINPUT_FIELD(c_up),
+            TASINPUT_FIELD(a),
+            TASINPUT_FIELD(b),
+            TASINPUT_FIELD(z),
+            TASINPUT_FIELD(start),
+            TASINPUT_FIELD(l),
+            TASINPUT_FIELD(r),
+            TASINPUT_FIELD(x),
+            TASINPUT_FIELD(y),
+            TASINPUT_FIELD(x_scale),
+            TASINPUT_FIELD(y_scale),
+        });
+        #undef TASINPUT_FIELD
+    }
+
+    friend void from_json(const nlohmann::json& j, t_controller_config& self) {
+        #define TASINPUT_FIELD(field) .field = j[#field]
+        self = {
+            TASINPUT_FIELD(dpad_right),
+            TASINPUT_FIELD(dpad_left),
+            TASINPUT_FIELD(dpad_down),
+            TASINPUT_FIELD(dpad_up),
+            TASINPUT_FIELD(c_right),
+            TASINPUT_FIELD(c_left),
+            TASINPUT_FIELD(c_down),
+            TASINPUT_FIELD(c_up),
+            TASINPUT_FIELD(a),
+            TASINPUT_FIELD(b),
+            TASINPUT_FIELD(z),
+            TASINPUT_FIELD(start),
+            TASINPUT_FIELD(l),
+            TASINPUT_FIELD(r),
+            TASINPUT_FIELD(x),
+            TASINPUT_FIELD(y),
+            TASINPUT_FIELD(x_scale),
+            TASINPUT_FIELD(y_scale),
+        };
+        #undef TASINPUT_FIELD
+    }
 };
 
-typedef struct s_config
+struct t_config
 {
     int32_t version = 6;
     int32_t always_on_top = false;
@@ -88,7 +183,50 @@ typedef struct s_config
     int32_t relative_mode = false;
     int32_t approach_mode = false;
     t_controller_config controller_config[4]{};
-} t_config;
+
+    friend void to_json(nlohmann::json& j, const t_config& self) {
+        #define TASINPUT_FIELD(field) {#field, self.field}
+        #define TASINPUT_ARRAY_FIELD(field) nlohmann::to_json(j[#field], self.field)
+        j = nlohmann::json::object({
+            TASINPUT_FIELD(version),
+            TASINPUT_FIELD(always_on_top),
+            TASINPUT_FIELD(float_from_parent),
+            TASINPUT_FIELD(titlebar),
+            TASINPUT_FIELD(client_drag),
+            TASINPUT_FIELD(loop_combo),
+            TASINPUT_FIELD(relative_mode),
+            TASINPUT_FIELD(approach_mode),
+        });
+        TASINPUT_ARRAY_FIELD(dialog_expanded);
+        TASINPUT_ARRAY_FIELD(controller_active);
+        TASINPUT_ARRAY_FIELD(controller_mempak);
+        TASINPUT_ARRAY_FIELD(controller_rumblepak);
+        TASINPUT_ARRAY_FIELD(controller_config);
+        #undef TASINPUT_FIELD
+        #undef TASINPUT_ARRAY_FIELD
+    }
+
+    friend void from_json(const nlohmann::json& j, t_config& self) {
+        #define TASINPUT_FIELD(field) nlohmann::from_json(j.at(#field), self.field)
+        self = {};
+        TASINPUT_FIELD(version);
+        if (self.version >= 6) {
+            TASINPUT_FIELD(always_on_top);
+            TASINPUT_FIELD(float_from_parent);
+            TASINPUT_FIELD(titlebar);
+            TASINPUT_FIELD(client_drag);
+            TASINPUT_FIELD(loop_combo);
+            TASINPUT_FIELD(relative_mode);
+            TASINPUT_FIELD(approach_mode);
+            TASINPUT_FIELD(dialog_expanded);
+            TASINPUT_FIELD(controller_active);
+            TASINPUT_FIELD(controller_mempak);
+            TASINPUT_FIELD(controller_rumblepak);
+            TASINPUT_FIELD(controller_config);
+        }
+        #undef TASINPUT_FIELD
+    }
+};
 
 extern t_config new_config;
 

--- a/src/Plugins.Win32.TASInput/NewConfig.h
+++ b/src/Plugins.Win32.TASInput/NewConfig.h
@@ -13,32 +13,32 @@
 
 const auto AXIS_THRESHOLD = 16000;
 
-
-
 struct t_axis_mapping
 {
     int32_t axis = SDL_GAMEPAD_AXIS_INVALID;
     int32_t key_negative = 0;
     int32_t key_positive = 0;
 
-    friend void to_json(nlohmann::json& j, const t_axis_mapping& self) {
-        #define TASINPUT_FIELD(field) {#field, self.field}
+    friend void to_json(nlohmann::json &j, const t_axis_mapping &self)
+    {
+#define TASINPUT_FIELD(field) {#field, self.field}
         j = nlohmann::json::object({
             TASINPUT_FIELD(axis),
             TASINPUT_FIELD(key_negative),
             TASINPUT_FIELD(key_positive),
         });
-        #undef TASINPUT_FIELD
+#undef TASINPUT_FIELD
     }
 
-    friend void from_json(const nlohmann::json& j, t_axis_mapping& self) {
-        #define TASINPUT_FIELD(field) .field = j[#field]
+    friend void from_json(const nlohmann::json &j, t_axis_mapping &self)
+    {
+#define TASINPUT_FIELD(field) .field = j[#field]
         self = {
             TASINPUT_FIELD(axis),
             TASINPUT_FIELD(key_negative),
             TASINPUT_FIELD(key_positive),
         };
-        #undef TASINPUT_FIELD
+#undef TASINPUT_FIELD
     }
 };
 
@@ -48,24 +48,26 @@ struct t_button_mapping
     int32_t axis = SDL_GAMEPAD_AXIS_INVALID;
     int32_t key = 0;
 
-    friend void to_json(nlohmann::json& j, const t_button_mapping& self) {
-        #define TASINPUT_FIELD(field) {#field, self.field}
+    friend void to_json(nlohmann::json &j, const t_button_mapping &self)
+    {
+#define TASINPUT_FIELD(field) {#field, self.field}
         j = nlohmann::json::object({
             TASINPUT_FIELD(button),
             TASINPUT_FIELD(axis),
             TASINPUT_FIELD(key),
         });
-        #undef TASINPUT_FIELD
+#undef TASINPUT_FIELD
     }
 
-    friend void from_json(const nlohmann::json& j, t_button_mapping& self) {
-        #define TASINPUT_FIELD(field) .field = j[#field]
+    friend void from_json(const nlohmann::json &j, t_button_mapping &self)
+    {
+#define TASINPUT_FIELD(field) .field = j[#field]
         self = {
             TASINPUT_FIELD(button),
             TASINPUT_FIELD(axis),
             TASINPUT_FIELD(key),
         };
-        #undef TASINPUT_FIELD
+#undef TASINPUT_FIELD
     }
 };
 
@@ -116,8 +118,9 @@ struct t_controller_config
         return config;
     }
 
-    friend void to_json(nlohmann::json& j, const t_controller_config& self) {
-        #define TASINPUT_FIELD(field) {#field, self.field}
+    friend void to_json(nlohmann::json &j, const t_controller_config &self)
+    {
+#define TASINPUT_FIELD(field) {#field, self.field}
         j = nlohmann::json::object({
             TASINPUT_FIELD(dpad_right),
             TASINPUT_FIELD(dpad_left),
@@ -138,32 +141,20 @@ struct t_controller_config
             TASINPUT_FIELD(x_scale),
             TASINPUT_FIELD(y_scale),
         });
-        #undef TASINPUT_FIELD
+#undef TASINPUT_FIELD
     }
 
-    friend void from_json(const nlohmann::json& j, t_controller_config& self) {
-        #define TASINPUT_FIELD(field) .field = j[#field]
+    friend void from_json(const nlohmann::json &j, t_controller_config &self)
+    {
+#define TASINPUT_FIELD(field) .field = j[#field]
         self = {
-            TASINPUT_FIELD(dpad_right),
-            TASINPUT_FIELD(dpad_left),
-            TASINPUT_FIELD(dpad_down),
-            TASINPUT_FIELD(dpad_up),
-            TASINPUT_FIELD(c_right),
-            TASINPUT_FIELD(c_left),
-            TASINPUT_FIELD(c_down),
-            TASINPUT_FIELD(c_up),
-            TASINPUT_FIELD(a),
-            TASINPUT_FIELD(b),
-            TASINPUT_FIELD(z),
-            TASINPUT_FIELD(start),
-            TASINPUT_FIELD(l),
-            TASINPUT_FIELD(r),
-            TASINPUT_FIELD(x),
-            TASINPUT_FIELD(y),
-            TASINPUT_FIELD(x_scale),
-            TASINPUT_FIELD(y_scale),
+            TASINPUT_FIELD(dpad_right), TASINPUT_FIELD(dpad_left), TASINPUT_FIELD(dpad_down), TASINPUT_FIELD(dpad_up),
+            TASINPUT_FIELD(c_right),    TASINPUT_FIELD(c_left),    TASINPUT_FIELD(c_down),    TASINPUT_FIELD(c_up),
+            TASINPUT_FIELD(a),          TASINPUT_FIELD(b),         TASINPUT_FIELD(z),         TASINPUT_FIELD(start),
+            TASINPUT_FIELD(l),          TASINPUT_FIELD(r),         TASINPUT_FIELD(x),         TASINPUT_FIELD(y),
+            TASINPUT_FIELD(x_scale),    TASINPUT_FIELD(y_scale),
         };
-        #undef TASINPUT_FIELD
+#undef TASINPUT_FIELD
     }
 };
 
@@ -184,9 +175,10 @@ struct t_config
     int32_t approach_mode = false;
     t_controller_config controller_config[4]{};
 
-    friend void to_json(nlohmann::json& j, const t_config& self) {
-        #define TASINPUT_FIELD(field) {#field, self.field}
-        #define TASINPUT_ARRAY_FIELD(field) nlohmann::to_json(j[#field], self.field)
+    friend void to_json(nlohmann::json &j, const t_config &self)
+    {
+#define TASINPUT_FIELD(field) {#field, self.field}
+#define TASINPUT_ARRAY_FIELD(field) nlohmann::to_json(j[#field], self.field)
         j = nlohmann::json::object({
             TASINPUT_FIELD(version),
             TASINPUT_FIELD(always_on_top),
@@ -202,15 +194,18 @@ struct t_config
         TASINPUT_ARRAY_FIELD(controller_mempak);
         TASINPUT_ARRAY_FIELD(controller_rumblepak);
         TASINPUT_ARRAY_FIELD(controller_config);
-        #undef TASINPUT_FIELD
-        #undef TASINPUT_ARRAY_FIELD
+#undef TASINPUT_FIELD
+#undef TASINPUT_ARRAY_FIELD
     }
 
-    friend void from_json(const nlohmann::json& j, t_config& self) {
-        #define TASINPUT_FIELD(field) nlohmann::from_json(j.at(#field), self.field)
+    friend void from_json(const nlohmann::json &j, t_config &self)
+    {
+        if (!j.is_object()) throw std::domain_error("t_config expected JSON object");
+#define TASINPUT_FIELD(field) nlohmann::from_json(j.at(#field), self.field)
         self = {};
         TASINPUT_FIELD(version);
-        if (self.version >= 6) {
+        if (self.version >= 6)
+        {
             TASINPUT_FIELD(always_on_top);
             TASINPUT_FIELD(float_from_parent);
             TASINPUT_FIELD(titlebar);
@@ -224,7 +219,7 @@ struct t_config
             TASINPUT_FIELD(controller_rumblepak);
             TASINPUT_FIELD(controller_config);
         }
-        #undef TASINPUT_FIELD
+#undef TASINPUT_FIELD
     }
 };
 

--- a/src/Plugins.Win32.TASRSP/CMakeLists.txt
+++ b/src/Plugins.Win32.TASRSP/CMakeLists.txt
@@ -30,7 +30,10 @@ set_target_properties(Mupen64RR.Plugins.Win32.TASRSP PROPERTIES
     PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 target_include_directories(Mupen64RR.Plugins.Win32.TASRSP PRIVATE ".")
-target_link_libraries(Mupen64RR.Plugins.Win32.TASRSP PRIVATE Mupen64RR.Plugins.Win32.Common)
+target_link_libraries(Mupen64RR.Plugins.Win32.TASRSP PRIVATE 
+    Mupen64RR.Plugins.Win32.Common
+    nlohmann_json::nlohmann_json
+)
 
 target_link_libraries(Mupen64RR.Plugins.Win32.TASRSP PRIVATE
     Comctl32

--- a/src/Plugins.Win32.TASRSP/Config.cpp
+++ b/src/Plugins.Win32.TASRSP/Config.cpp
@@ -9,10 +9,16 @@
 
 #define SUBKEY L"Software\\N64 Emulation\\DLL\\TAS RSP"
 #define CONFIG_VALUE L"Config"
+#define CONFIG_FILE_NAME "TASRSP.json"
 
 t_config config = {};
 t_config default_config = {};
 t_config prev_config = {};
+
+static std::filesystem::path get_config_path()
+{
+    return g_config_path / CONFIG_FILE_NAME;
+}
 
 INT_PTR CALLBACK ConfigDlgProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 {
@@ -50,7 +56,7 @@ INT_PTR CALLBACK ConfigDlgProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lP
     return FALSE;
 }
 
-void config_save()
+static void save_registry_config()
 {
     g_ef->log_trace(L"Saving config...");
 
@@ -73,7 +79,7 @@ void config_save()
     RegCloseKey(h_key);
 }
 
-void config_load()
+static void load_registry_config()
 {
     g_ef->log_trace(L"Loading config...");
 
@@ -106,6 +112,46 @@ void config_load()
     }
 
     config = loaded_config;
+}
+
+void config_save()
+{
+    g_ef->log_trace(L"Saving config...");
+
+    nlohmann::json j = config;
+    std::ofstream ofs(get_config_path());
+    ofs << std::setw(2) << j;
+}
+
+void config_load()
+{
+    g_ef->log_trace(L"Loading config...");
+
+    auto json_path = get_config_path();
+
+    if (std::filesystem::exists(json_path))
+    {
+        std::ifstream ifs(json_path);
+
+        nlohmann::json j;
+        ifs >> j;
+        try
+        {
+            nlohmann::from_json(j, config);
+        }
+        catch (const std::exception &e)
+        {
+            g_ef->log_warn(L"Config load failed, using defaults...");
+            config = default_config;
+        }
+    }
+    else
+    {
+        g_ef->log_warn(L"No JSON config was present, attempting to load from registry");
+        load_registry_config();
+
+        config_save();
+    }
 }
 
 void config_show_dialog(HWND hwnd)

--- a/src/Plugins.Win32.TASRSP/Config.cpp
+++ b/src/Plugins.Win32.TASRSP/Config.cpp
@@ -132,11 +132,11 @@ void config_load()
     if (std::filesystem::exists(json_path))
     {
         std::ifstream ifs(json_path);
-
         nlohmann::json j;
-        ifs >> j;
+
         try
         {
+            ifs >> j;
             nlohmann::from_json(j, config);
         }
         catch (const std::exception &e)

--- a/src/Plugins.Win32.TASRSP/Config.h
+++ b/src/Plugins.Win32.TASRSP/Config.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <nlohmann/json.hpp>
+
 struct t_config
 {
     int32_t version = 2;
@@ -14,6 +16,25 @@ struct t_config
      * changes.
      */
     int32_t ucode_cache_verify = false;
+
+    friend void to_json(nlohmann::json &j, const t_config &self)
+    {
+#define TASRSP_FIELD(field) {#field, self.field}
+        j = nlohmann::json::object({
+            TASRSP_FIELD(version),
+            TASRSP_FIELD(ucode_cache_verify),
+        });
+#undef TASRSP_FIELD
+    }
+
+    friend void from_json(const nlohmann::json &j, t_config &self)
+    {
+        if (!j.is_object()) throw std::domain_error("t_config expected JSON object");
+#define TASRSP_FIELD(field) nlohmann::from_json(j.at(#field), self.field)
+        TASRSP_FIELD(version);
+        TASRSP_FIELD(ucode_cache_verify);
+#undef TASRSP_FIELD
+    }
 };
 
 extern t_config config;

--- a/src/Plugins.Win32.TASRSP/Main.cpp
+++ b/src/Plugins.Win32.TASRSP/Main.cpp
@@ -25,6 +25,7 @@ uint32_t inst2;
 static void (*g_audio_ucode_func)() = nullptr;
 HINSTANCE g_instance;
 std::filesystem::path g_app_path;
+std::filesystem::path g_config_path;
 // PlatformService g_platform_service;
 static uint8_t fake_header[0x1000];
 static uint32_t fake_AI_DRAM_ADDR_REG;
@@ -383,4 +384,14 @@ EXPORT uint32_t CALL DoRspCycles(uint32_t Cycles)
 EXPORT void CALL ReceiveExtendedFuncs(core_plugin_extended_funcs *funcs)
 {
     g_ef = funcs;
+
+    // CONFIG PATH
+    // get length
+    size_t len = g_ef->config_path(nullptr, 0);
+    // copy string
+    std::string path_temp(len, '\0');
+    g_ef->config_path(path_temp.data(), path_temp.size());
+    // drop the terminating null
+    path_temp.pop_back();
+    g_config_path = std::filesystem::absolute(path_temp);
 }

--- a/src/Plugins.Win32.TASRSP/Main.cpp
+++ b/src/Plugins.Win32.TASRSP/Main.cpp
@@ -384,14 +384,5 @@ EXPORT uint32_t CALL DoRspCycles(uint32_t Cycles)
 EXPORT void CALL ReceiveExtendedFuncs(core_plugin_extended_funcs *funcs)
 {
     g_ef = funcs;
-
-    // CONFIG PATH
-    // get length
-    size_t len = g_ef->config_path(nullptr, 0);
-    // copy string
-    std::string path_temp(len, '\0');
-    g_ef->config_path(path_temp.data(), path_temp.size());
-    // drop the terminating null
-    path_temp.pop_back();
-    g_config_path = std::filesystem::absolute(path_temp);
+    g_config_path = ViewPluginHelpers::get_config_path(g_ef);
 }

--- a/src/Plugins.Win32.TASRSP/Main.h
+++ b/src/Plugins.Win32.TASRSP/Main.h
@@ -16,6 +16,7 @@
 
 extern HINSTANCE g_instance;
 extern std::filesystem::path g_app_path;
+extern std::filesystem::path g_config_path;
 extern core_plugin_extended_funcs *g_ef;
 
 extern void (*ABI1[0x20])();

--- a/src/Plugins.Win32.TASVideo/CMakeLists.txt
+++ b/src/Plugins.Win32.TASVideo/CMakeLists.txt
@@ -82,6 +82,7 @@ target_link_libraries(Mupen64RR.Plugins.Win32.TASVideo PRIVATE
     Mupen64RR.Plugins.Win32.Common
     vendor::hqx
     vendor::xbrz
+    nlohmann_json::nlohmann_json
     GLEW::GLEW
     SDL3::SDL3
 )

--- a/src/Plugins.Win32.TASVideo/Config.cpp
+++ b/src/Plugins.Win32.TASVideo/Config.cpp
@@ -161,7 +161,7 @@ void Config_LoadConfig()
             OGL.textureFilter = j["texture_filter"];
             OGL.filterScale = j["filter_scale"];
             OGL.fog = j["enable_fog"];
-            cache.maxBytes = (int) j["texture_cache_size"] * 1048576;
+            cache.maxBytes = (int)j["texture_cache_size"] * 1048576;
             OGL.usePolygonStipple = j["dithered_alpha_testing"];
             OGL.ignoreScissor = j["ignore_scissor"];
             OGL.clear_override = j["clear_override"];

--- a/src/Plugins.Win32.TASVideo/Config.cpp
+++ b/src/Plugins.Win32.TASVideo/Config.cpp
@@ -6,9 +6,14 @@
 #include "Textures.h"
 #include "OpenGL.h"
 
+#include <nlohmann/json.hpp>
+
 HWND hConfigDlg;
 
 #define numWindowedModes 12
+#define CONFIG_FILE_NAME "TASVideo.json"
+
+using nlohmann::json;
 
 struct
 {
@@ -21,13 +26,29 @@ struct
     {1024, 768, L"1024 x 768"},   {1152, 864, L"1152 x 864"},   {1280, 960, L"1280 x 960"},
     {1280, 1024, L"1280 x 1024"}, {1440, 1080, L"1440 x 1080"}, {1600, 1200, L"1600 x 1200"}};
 
+static std::filesystem::path get_config_path()
+{
+    return g_tas_ctx.config_directory / CONFIG_FILE_NAME;
+}
+
 void EnableCustom(HWND hWndDlg, BOOL enable)
 {
     EnableWindow(GetDlgItem(hWndDlg, IDC_WINDOWED_X), enable);
     EnableWindow(GetDlgItem(hWndDlg, IDC_WINDOWED_Y), enable);
 }
 
-void Config_LoadConfig()
+static void Config_SetDefaults()
+{
+    OGL.fog = TRUE;
+    OGL.windowedWidth = 640;
+    OGL.windowedHeight = 480;
+    OGL.forceBilinear = FALSE;
+    cache.maxBytes = 32 * 1048576;
+    OGL.textureFilter = TextureFilter::None;
+    OGL.usePolygonStipple = FALSE;
+}
+
+void Config_LoadRegistryConfig()
 {
     DWORD value, size;
 
@@ -80,17 +101,11 @@ void Config_LoadConfig()
     }
     else
     {
-        OGL.fog = TRUE;
-        OGL.windowedWidth = 640;
-        OGL.windowedHeight = 480;
-        OGL.forceBilinear = FALSE;
-        cache.maxBytes = 32 * 1048576;
-        OGL.textureFilter = TextureFilter::None;
-        OGL.usePolygonStipple = FALSE;
+        Config_SetDefaults();
     }
 }
 
-void Config_SaveConfig()
+void Config_SaveRegistryConfig()
 {
     DWORD value;
     HKEY hKey;
@@ -126,6 +141,63 @@ void Config_SaveConfig()
     RegSetValueEx(hKey, L"Clear Override", 0, REG_DWORD, (BYTE *)&value, 4);
 
     RegCloseKey(hKey);
+}
+
+void Config_LoadConfig()
+{
+    auto json_path = get_config_path();
+
+    if (std::filesystem::exists(json_path))
+    {
+        std::ifstream ifs(json_path);
+
+        nlohmann::json j;
+        ifs >> j;
+        try
+        {
+            OGL.windowedWidth = j["windowed_width"];
+            OGL.windowedHeight = j["windowed_height"];
+            OGL.forceBilinear = j["force_bilinear"];
+            OGL.textureFilter = j["texture_filter"];
+            OGL.filterScale = j["filter_scale"];
+            OGL.fog = j["enable_fog"];
+            cache.maxBytes = (int) j["texture_cache_size"] * 1048576;
+            OGL.usePolygonStipple = j["dithered_alpha_testing"];
+            OGL.ignoreScissor = j["ignore_scissor"];
+            OGL.clear_override = j["clear_override"];
+        }
+        catch (const std::exception &e)
+        {
+            g_ef->log_warn(L"Config load failed, using defaults...");
+            Config_SetDefaults();
+        }
+    }
+    else
+    {
+        g_ef->log_warn(L"No JSON config was present, attempting to load from registry");
+        Config_LoadRegistryConfig();
+
+        Config_SaveConfig();
+    }
+}
+
+void Config_SaveConfig()
+{
+    json j = json::object({
+        {"windowed_width", OGL.windowedWidth},
+        {"windowed_height", OGL.windowedHeight},
+        {"force_bilinear", (bool)OGL.forceBilinear},
+        {"texture_filter", OGL.textureFilter},
+        {"filter_scale", OGL.filterScale},
+        {"enable_fog", (bool)OGL.fog},
+        {"texture_cache_size", cache.maxBytes / 1048576},
+        {"dithered_alpha_testing", (bool)OGL.usePolygonStipple},
+        {"ignore_scissor", (bool)OGL.ignoreScissor},
+        {"clear_override", (bool)OGL.clear_override},
+    });
+
+    std::ofstream ofs(get_config_path());
+    ofs << std::setw(2) << j;
 }
 
 void Config_ApplyDlgConfig(HWND hWndDlg)

--- a/src/Plugins.Win32.TASVideo/Config.cpp
+++ b/src/Plugins.Win32.TASVideo/Config.cpp
@@ -152,9 +152,9 @@ void Config_LoadConfig()
         std::ifstream ifs(json_path);
 
         nlohmann::json j;
-        ifs >> j;
         try
         {
+            ifs >> j;
             OGL.windowedWidth = j["windowed_width"];
             OGL.windowedHeight = j["windowed_height"];
             OGL.forceBilinear = j["force_bilinear"];

--- a/src/Plugins.Win32.TASVideo/Config.h
+++ b/src/Plugins.Win32.TASVideo/Config.h
@@ -1,4 +1,5 @@
 #pragma once
 
 void Config_LoadConfig();
+void Config_SaveConfig();
 void Config_Show(HWND parent);

--- a/src/Plugins.Win32.TASVideo/glN64.cpp
+++ b/src/Plugins.Win32.TASVideo/glN64.cpp
@@ -130,16 +130,7 @@ EXPORT BOOL CALL InitiateGFX(core_gfx_info Gfx_Info)
 EXPORT void CALL ReceiveExtendedFuncs(core_plugin_extended_funcs *funcs)
 {
     g_ef = funcs;
-
-    // CONFIG PATH
-    // get length
-    size_t len = g_ef->config_path(nullptr, 0);
-    // copy string
-    std::string path_temp(len, '\0');
-    g_ef->config_path(path_temp.data(), path_temp.size());
-    // drop the terminating null
-    path_temp.pop_back();
-    g_tas_ctx.config_directory = std::filesystem::absolute(path_temp);
+    g_tas_ctx.config_directory = ViewPluginHelpers::get_config_path(g_ef);
 }
 
 EXPORT void CALL ProcessDList(void)

--- a/src/Plugins.Win32.TASVideo/glN64.cpp
+++ b/src/Plugins.Win32.TASVideo/glN64.cpp
@@ -130,6 +130,16 @@ EXPORT BOOL CALL InitiateGFX(core_gfx_info Gfx_Info)
 EXPORT void CALL ReceiveExtendedFuncs(core_plugin_extended_funcs *funcs)
 {
     g_ef = funcs;
+
+    // CONFIG PATH
+    // get length
+    size_t len = g_ef->config_path(nullptr, 0);
+    // copy string
+    std::string path_temp(len, '\0');
+    g_ef->config_path(path_temp.data(), path_temp.size());
+    // drop the terminating null
+    path_temp.pop_back();
+    g_tas_ctx.config_directory = std::filesystem::absolute(path_temp);
 }
 
 EXPORT void CALL ProcessDList(void)

--- a/src/Plugins.Win32.TASVideo/glN64.h
+++ b/src/Plugins.Win32.TASVideo/glN64.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Views.Win32/ViewPlugin.h>
+
 struct TASVideoContext
 {
     HINSTANCE hinst;
@@ -7,6 +9,7 @@ struct TASVideoContext
     HWND statusbar_hwnd;
     void (*check_interrupts)(void);
     std::filesystem::path screenshot_directory;
+    std::filesystem::path config_directory;
 };
 
 extern TASVideoContext g_tas_ctx;

--- a/src/Views.Win32/Config.cpp
+++ b/src/Views.Win32/Config.cpp
@@ -541,28 +541,6 @@ static void migrate_config_ini(t_config &config, const mINI::INIStructure &ini)
 #pragma endregion
 
 #pragma region JSON file parsing
-/*
-ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                int32_t *value)
-
-ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                uint64_t *value)
-
-ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                std::wstring &value)
-
-ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                std::vector<std::wstring> &value)
-
-ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                std::map<std::wstring, std::wstring> &value)
-
-ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                std::map<std::wstring, Hotkey::t_hotkey> &value)
-
-ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                std::vector<int32_t> &value)
-*/
 
 // READING
 // ==================

--- a/src/Views.Win32/Config.cpp
+++ b/src/Views.Win32/Config.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+#include "IOUtils.h"
 #include "stdafx.h"
 #include <Config.h>
 #include <Messenger.h>
@@ -423,7 +424,7 @@ static void handle_config_ini(const bool is_reading, mINI::INIStructure &ini)
     HANDLE_VALUE(inital_hotkeys)
 }
 
-static std::filesystem::path get_config_path()
+static std::filesystem::path get_legacy_config_path()
 {
     return g_main_ctx.app_path / CONFIG_FILE_NAME;
 }
@@ -564,6 +565,11 @@ static void migrate_config(t_config &config, const mINI::INIStructure &ini)
     }
 }
 
+const std::string& Config::config_directory() {
+    static const std::string path = IOUtils::config_path().string();
+    return path;
+}
+
 void Config::init()
 {
 }
@@ -574,9 +580,9 @@ void Config::save()
 
     config_patch(g_config);
 
-    std::remove(get_config_path().string().c_str());
+    std::remove(get_legacy_config_path().string().c_str());
 
-    mINI::INIFile file(get_config_path().string());
+    mINI::INIFile file(get_legacy_config_path().string());
     mINI::INIStructure ini;
 
     handle_config_ini(false, ini);
@@ -598,14 +604,14 @@ void Config::apply_and_save()
 
 void Config::load()
 {
-    if (!std::filesystem::exists(get_config_path()))
+    if (!std::filesystem::exists(get_legacy_config_path()))
     {
         g_view_logger->info("[CONFIG] Default config file does not exist. Generating...");
         g_config = get_default_config();
         save();
     }
 
-    mINI::INIFile file(get_config_path().string());
+    mINI::INIFile file(get_legacy_config_path().string());
     mINI::INIStructure ini;
     file.read(ini);
 
@@ -619,25 +625,25 @@ void Config::load()
 
 std::filesystem::path Config::plugin_directory()
 {
-    return IOUtils::exe_path_cached().parent_path() / g_config.plugins_directory;
+    return IOUtils::exe_path().parent_path() / g_config.plugins_directory;
 }
 
 std::filesystem::path Config::save_directory()
 {
-    return IOUtils::exe_path_cached().parent_path() / g_config.saves_directory;
+    return IOUtils::exe_path().parent_path() / g_config.saves_directory;
 }
 
 std::filesystem::path Config::screenshot_directory()
 {
-    return IOUtils::exe_path_cached().parent_path() / g_config.screenshots_directory;
+    return IOUtils::exe_path().parent_path() / g_config.screenshots_directory;
 }
 
 std::filesystem::path Config::backup_directory()
 {
-    return IOUtils::exe_path_cached().parent_path() / g_config.backups_directory;
+    return IOUtils::exe_path().parent_path() / g_config.backups_directory;
 }
 
 std::filesystem::path Config::logs_directory()
 {
-    return IOUtils::exe_path_cached().parent_path() / L"logs";
+    return IOUtils::exe_path().parent_path() / L"logs";
 }

--- a/src/Views.Win32/Config.cpp
+++ b/src/Views.Win32/Config.cpp
@@ -10,15 +10,20 @@
 #include <Messenger.h>
 #include <ini.h>
 #include <action/AppActions.h>
+#include <nlohmann/json.hpp>
+
+using nlohmann::json;
 
 static t_config get_default_config();
 
 t_config g_config;
 
 #ifdef _M_X64
-#define CONFIG_FILE_NAME L"config-x64.ini"
+#define LEGACY_CONFIG_FILE_NAME L"config-x64.ini"
+#define CONFIG_FILE_NAME L"config-x64.json"
 #else
-#define CONFIG_FILE_NAME L"config.ini"
+#define LEGACY_CONFIG_FILE_NAME L"config.ini"
+#define CONFIG_FILE_NAME L"config.json"
 #endif
 
 constexpr auto FLAT_FIELD_KEY = "config";
@@ -60,7 +65,9 @@ static t_config get_default_config()
     return config;
 }
 
-static std::string process_field_name(const std::wstring &field_name)
+#pragma region ini file shenanigans
+
+static std::string ini_cleanup_field(const std::wstring &field_name)
 {
     std::string str = IOUtils::to_utf8_string(field_name);
 
@@ -74,10 +81,10 @@ static std::string process_field_name(const std::wstring &field_name)
     return str;
 }
 
-static void handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                int32_t *value)
+static void ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                    int32_t *value)
 {
-    const auto key = process_field_name(field_name);
+    const auto key = ini_cleanup_field(field_name);
 
     if (is_reading)
     {
@@ -95,10 +102,10 @@ static void handle_config_value(mINI::INIStructure &ini, const std::wstring &fie
     }
 }
 
-static void handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                uint64_t *value)
+static void ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                    uint64_t *value)
 {
-    const auto key = process_field_name(field_name);
+    const auto key = ini_cleanup_field(field_name);
 
     if (is_reading)
     {
@@ -116,10 +123,11 @@ static void handle_config_value(mINI::INIStructure &ini, const std::wstring &fie
     }
 }
 
-static void handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                std::wstring &value)
+// !!!
+static void ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                    std::wstring &value)
 {
-    const auto key = process_field_name(field_name);
+    const auto key = ini_cleanup_field(field_name);
 
     // BUG: Leading whitespace seems to be dropped by mINI after a roundtrip!!!
 
@@ -139,10 +147,11 @@ static void handle_config_value(mINI::INIStructure &ini, const std::wstring &fie
     }
 }
 
-static void handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                std::vector<std::wstring> &value)
+// !!!
+static void ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                    std::vector<std::wstring> &value)
 {
-    const auto key = process_field_name(field_name);
+    const auto key = ini_cleanup_field(field_name);
 
     if (is_reading)
     {
@@ -171,10 +180,11 @@ static void handle_config_value(mINI::INIStructure &ini, const std::wstring &fie
     }
 }
 
-static void handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                std::map<std::wstring, std::wstring> &value)
+// !!!
+static void ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                    std::map<std::wstring, std::wstring> &value)
 {
-    const auto key = process_field_name(field_name);
+    const auto key = ini_cleanup_field(field_name);
 
     if (is_reading)
     {
@@ -201,10 +211,11 @@ static void handle_config_value(mINI::INIStructure &ini, const std::wstring &fie
     }
 }
 
-static void handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                std::map<std::wstring, Hotkey::t_hotkey> &value)
+// !!!
+static void ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                    std::map<std::wstring, Hotkey::t_hotkey> &value)
 {
-    const auto key = process_field_name(field_name);
+    const auto key = ini_cleanup_field(field_name);
 
     // Structure:
     // [action_fullpath]
@@ -305,8 +316,8 @@ static void handle_config_value(mINI::INIStructure &ini, const std::wstring &fie
     }
 }
 
-static void handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
-                                std::vector<int32_t> &value)
+static void ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                    std::vector<int32_t> &value)
 {
     std::vector<std::wstring> string_values;
     for (const auto int_value : value)
@@ -314,7 +325,7 @@ static void handle_config_value(mINI::INIStructure &ini, const std::wstring &fie
         string_values.push_back(std::to_wstring(int_value));
     }
 
-    handle_config_value(ini, field_name, is_reading, string_values);
+    ini_handle_config_value(ini, field_name, is_reading, string_values);
 
     if (is_reading)
     {
@@ -327,8 +338,8 @@ static void handle_config_value(mINI::INIStructure &ini, const std::wstring &fie
 
 static void handle_config_ini(const bool is_reading, mINI::INIStructure &ini)
 {
-#define HANDLE_P_VALUE(x) handle_config_value(ini, L#x, is_reading, &g_config.x);
-#define HANDLE_VALUE(x) handle_config_value(ini, L#x, is_reading, g_config.x);
+#define HANDLE_P_VALUE(x) ini_handle_config_value(ini, L#x, is_reading, &g_config.x);
+#define HANDLE_VALUE(x) ini_handle_config_value(ini, L#x, is_reading, g_config.x);
 
     if (is_reading)
     {
@@ -470,7 +481,7 @@ static void config_patch(t_config &cfg)
 /**
  * \brief Migrates old values from the specified config to new ones if possible.
  */
-static void migrate_config(t_config &config, const mINI::INIStructure &ini)
+static void migrate_config_ini(t_config &config, const mINI::INIStructure &ini)
 {
     const auto migrate_hotkey = [&](const std::string &old_section_name, std::wstring action) {
         action = ActionManager::normalize_filter(action);
@@ -565,7 +576,349 @@ static void migrate_config(t_config &config, const mINI::INIStructure &ini)
     }
 }
 
-const std::string& Config::config_directory() {
+#pragma endregion
+
+#pragma region JSON file parsing
+/*
+ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                int32_t *value)
+
+ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                uint64_t *value)
+
+ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                std::wstring &value)
+
+ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                std::vector<std::wstring> &value)
+
+ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                std::map<std::wstring, std::wstring> &value)
+
+ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                std::map<std::wstring, Hotkey::t_hotkey> &value)
+
+ini_handle_config_value(mINI::INIStructure &ini, const std::wstring &field_name, const int32_t is_reading,
+                                std::vector<int32_t> &value)
+*/
+
+// READING
+// ==================
+
+/**
+ * @brief Ensures that the JSON matches the format expected by read/write functions.
+ */
+static void json_ensure_format(json &j)
+{
+    if (!j.is_object()) j = json::object();
+
+    // setup key namespaces
+    if (!j["core"].is_object()) j["core"] = json::object();
+    if (!j["frontend"].is_object()) j["frontend"] = json::object();
+}
+
+template <class T> static json convert_to_json(const T &value)
+{
+    return json(value);
+}
+
+static json convert_to_json(const std::wstring& value) {
+    return json(IOUtils::to_utf8_string(value));
+}
+
+static json convert_to_json(const std::vector<std::wstring> &value)
+{
+    return value | std::views::transform([](const std::wstring &ws) {
+               // convert elements to UTF-8, then wrap in JSON
+               return json(IOUtils::to_utf8_string(ws));
+           }) |
+           std::ranges::to<json::array_t>();
+}
+
+static json convert_to_json(const std::map<std::wstring, std::wstring> &value)
+{
+    return value | std::views::transform([](const std::pair<std::wstring, std::wstring> &ws_pair) {
+               // convert elements to UTF-8, wrap the value in JSON
+               return std::pair(IOUtils::to_utf8_string(ws_pair.first), json(IOUtils::to_utf8_string(ws_pair.second)));
+           }) |
+           std::ranges::to<json::object_t>();
+}
+
+static json convert_to_json(const std::map<std::wstring, Hotkey::t_hotkey> &value)
+{
+    return value | std::views::transform([](const std::pair<std::wstring, Hotkey::t_hotkey> &mapping) {
+               // translate name
+               auto name = IOUtils::to_utf8_string(mapping.first);
+               // translate hotkey
+               const auto &hotkey = mapping.second;
+               auto object = json::object({{"assigned", hotkey.assigned},
+                                           {"key", hotkey.key},
+                                           {"ctrl", hotkey.ctrl},
+                                           {"shift", hotkey.shift},
+                                           {"alt", hotkey.alt}});
+               return std::pair(std::move(name), std::move(object));
+           }) |
+           std::ranges::to<json::object_t>();
+}
+
+template <class T> static bool convert_from_json(const json &j, T &value)
+{
+    if (j.is_null()) return false;
+    value = j.get<T>();
+    return true;
+}
+
+static bool convert_from_json(const json& j, std::wstring& value) {
+    if (j.is_null()) return false;
+    value = IOUtils::to_wide_string(j.get<std::string>());
+    return true;
+}
+
+static bool convert_from_json(const json &j, std::vector<std::wstring> &value)
+{
+    if (!j.is_array()) return false;
+
+    value = j.get_ref<const json::array_t &>() |
+            std::views::transform([](const json &str) { return IOUtils::to_wide_string(str.get<std::string>()); }) |
+            std::ranges::to<std::vector>();
+    return true;
+}
+
+static bool convert_from_json(const json &j, std::map<std::wstring, std::wstring> &value)
+{
+    if (!j.is_object()) return false;
+
+    value = j.get_ref<const json::object_t &>() |
+            std::views::transform([](const std::pair<std::string, json> &str_pair) {
+                return std::pair(IOUtils::to_wide_string(str_pair.first),
+                                 IOUtils::to_wide_string(str_pair.second.get<std::string>()));
+            }) |
+            std::ranges::to<std::map>();
+    return true;
+}
+
+static bool convert_from_json(const json &j, std::map<std::wstring, Hotkey::t_hotkey> &value)
+{
+    if (!j.is_object()) return false;
+
+    value = j.get_ref<const json::object_t &>() |
+            std::views::transform([](const std::pair<std::string, json> &str_pair) {
+                auto name = IOUtils::to_wide_string(str_pair.first);
+                const auto &hotkey_json = str_pair.second;
+                auto hotkey = Hotkey::t_hotkey{};
+
+                hotkey.assigned = hotkey_json["assigned"];
+                hotkey.key = hotkey_json["key"];
+                hotkey.ctrl = hotkey_json["ctrl"];
+                hotkey.shift = hotkey_json["shift"];
+                hotkey.alt = hotkey_json["alt"];
+                return std::pair(std::move(name), hotkey);
+            }) |
+            std::ranges::to<std::map>();
+    return true;
+}
+
+static void json_read_file(const json& j) {
+    g_config = get_default_config();
+
+    #define CORE_VALUE(name) convert_from_json(j["core"][#name], g_config.core.name);
+    #define FRONTEND_VALUE(name) convert_from_json(j["frontend"][#name], g_config.name);
+
+    CORE_VALUE(total_rerecords)
+    CORE_VALUE(total_frames)
+    CORE_VALUE(core_type)
+    CORE_VALUE(fps_modifier)
+    CORE_VALUE(rom_cache_size)
+    CORE_VALUE(st_screenshot)
+    CORE_VALUE(is_movie_loop_enabled)
+    CORE_VALUE(counter_factor)
+    CORE_VALUE(is_reset_recording_enabled)
+    CORE_VALUE(seek_savestate_interval)
+    CORE_VALUE(seek_savestate_max_count)
+    CORE_VALUE(st_undo_load)
+    CORE_VALUE(use_summercart)
+    CORE_VALUE(wii_vc_emulation)
+    CORE_VALUE(float_exception_emulation)
+    CORE_VALUE(c_eq_s_nan_accurate)
+    CORE_VALUE(is_audio_delay_enabled)
+    CORE_VALUE(is_compiled_jump_enabled)
+    CORE_VALUE(pause_at_frame)
+    CORE_VALUE(pause_at_last_frame)
+    CORE_VALUE(vcr_readonly)
+    CORE_VALUE(vcr_backups)
+    CORE_VALUE(vcr_write_extended_format)
+    CORE_VALUE(wait_at_movie_end)
+    CORE_VALUE(max_lag)
+
+    FRONTEND_VALUE(ignored_version)
+    FRONTEND_VALUE(theme)
+    FRONTEND_VALUE(st_slot)
+    FRONTEND_VALUE(is_unfocused_pause_enabled)
+    FRONTEND_VALUE(is_statusbar_enabled)
+    FRONTEND_VALUE(statusbar_scale_up)
+    FRONTEND_VALUE(statusbar_layout)
+    FRONTEND_VALUE(rom_directory)
+    FRONTEND_VALUE(plugins_directory)
+    FRONTEND_VALUE(saves_directory)
+    FRONTEND_VALUE(screenshots_directory)
+    FRONTEND_VALUE(backups_directory)
+    FRONTEND_VALUE(recent_rom_paths)
+    FRONTEND_VALUE(is_recent_rom_paths_frozen)
+    FRONTEND_VALUE(recent_movie_paths)
+    FRONTEND_VALUE(is_recent_movie_paths_frozen)
+    FRONTEND_VALUE(is_rombrowser_recursion_enabled)
+    FRONTEND_VALUE(capture_mode)
+    FRONTEND_VALUE(stop_capture_at_movie_end)
+    FRONTEND_VALUE(presenter_type)
+    FRONTEND_VALUE(lazy_renderer_init)
+    FRONTEND_VALUE(encoder_type)
+    FRONTEND_VALUE(capture_delay)
+    FRONTEND_VALUE(ffmpeg_options)
+    FRONTEND_VALUE(ffmpeg_path)
+    FRONTEND_VALUE(synchronization_mode)
+    FRONTEND_VALUE(keep_default_working_directory)
+    FRONTEND_VALUE(lua_script_path)
+    FRONTEND_VALUE(recent_lua_script_paths)
+    FRONTEND_VALUE(is_recent_scripts_frozen)
+    FRONTEND_VALUE(piano_roll_constrain_edit_to_column)
+    FRONTEND_VALUE(piano_roll_undo_stack_size)
+    FRONTEND_VALUE(piano_roll_keep_selection_visible)
+    FRONTEND_VALUE(piano_roll_keep_playhead_visible)
+    FRONTEND_VALUE(selected_video_plugin)
+    FRONTEND_VALUE(selected_audio_plugin)
+    FRONTEND_VALUE(selected_input_plugin)
+    FRONTEND_VALUE(selected_rsp_plugin)
+    FRONTEND_VALUE(last_movie_type)
+    FRONTEND_VALUE(last_movie_author)
+    FRONTEND_VALUE(window_x)
+    FRONTEND_VALUE(window_y)
+    FRONTEND_VALUE(window_width)
+    FRONTEND_VALUE(window_height)
+    FRONTEND_VALUE(rombrowser_column_widths)
+    FRONTEND_VALUE(rombrowser_sort_ascending)
+    FRONTEND_VALUE(rombrowser_sorted_column)
+    FRONTEND_VALUE(persistent_folder_paths)
+    FRONTEND_VALUE(settings_tab)
+    FRONTEND_VALUE(vcr_0_index)
+    FRONTEND_VALUE(increment_slot)
+    FRONTEND_VALUE(automatic_update_checking)
+    FRONTEND_VALUE(silent_mode)
+    FRONTEND_VALUE(seeker_value)
+    FRONTEND_VALUE(multi_frame_advance_count)
+    FRONTEND_VALUE(silent_mode_dialog_choices)
+    FRONTEND_VALUE(trusted_lua_paths)
+    FRONTEND_VALUE(lua_paths)
+    FRONTEND_VALUE(hotkeys)
+    FRONTEND_VALUE(inital_hotkeys)
+
+    #undef CORE_VALUE
+    #undef FRONTEND_VALUE
+}
+
+static void json_write_file(json& j) {
+    #define CORE_VALUE(name) j["core"][#name] = convert_to_json(g_config.core.name);
+    #define FRONTEND_VALUE(name) j["frontend"][#name] = convert_to_json(g_config.name);
+
+    CORE_VALUE(total_rerecords)
+    CORE_VALUE(total_frames)
+    CORE_VALUE(core_type)
+    CORE_VALUE(fps_modifier)
+    CORE_VALUE(rom_cache_size)
+    CORE_VALUE(st_screenshot)
+    CORE_VALUE(is_movie_loop_enabled)
+    CORE_VALUE(counter_factor)
+    CORE_VALUE(is_reset_recording_enabled)
+    CORE_VALUE(seek_savestate_interval)
+    CORE_VALUE(seek_savestate_max_count)
+    CORE_VALUE(st_undo_load)
+    CORE_VALUE(use_summercart)
+    CORE_VALUE(wii_vc_emulation)
+    CORE_VALUE(float_exception_emulation)
+    CORE_VALUE(c_eq_s_nan_accurate)
+    CORE_VALUE(is_audio_delay_enabled)
+    CORE_VALUE(is_compiled_jump_enabled)
+    CORE_VALUE(pause_at_frame)
+    CORE_VALUE(pause_at_last_frame)
+    CORE_VALUE(vcr_readonly)
+    CORE_VALUE(vcr_backups)
+    CORE_VALUE(vcr_write_extended_format)
+    CORE_VALUE(wait_at_movie_end)
+    CORE_VALUE(max_lag)
+
+    FRONTEND_VALUE(ignored_version)
+    FRONTEND_VALUE(theme)
+    FRONTEND_VALUE(st_slot)
+    FRONTEND_VALUE(is_unfocused_pause_enabled)
+    FRONTEND_VALUE(is_statusbar_enabled)
+    FRONTEND_VALUE(statusbar_scale_up)
+    FRONTEND_VALUE(statusbar_layout)
+    FRONTEND_VALUE(rom_directory)
+    FRONTEND_VALUE(plugins_directory)
+    FRONTEND_VALUE(saves_directory)
+    FRONTEND_VALUE(screenshots_directory)
+    FRONTEND_VALUE(backups_directory)
+    FRONTEND_VALUE(recent_rom_paths)
+    FRONTEND_VALUE(is_recent_rom_paths_frozen)
+    FRONTEND_VALUE(recent_movie_paths)
+    FRONTEND_VALUE(is_recent_movie_paths_frozen)
+    FRONTEND_VALUE(is_rombrowser_recursion_enabled)
+    FRONTEND_VALUE(capture_mode)
+    FRONTEND_VALUE(stop_capture_at_movie_end)
+    FRONTEND_VALUE(presenter_type)
+    FRONTEND_VALUE(lazy_renderer_init)
+    FRONTEND_VALUE(encoder_type)
+    FRONTEND_VALUE(capture_delay)
+    FRONTEND_VALUE(ffmpeg_options)
+    FRONTEND_VALUE(ffmpeg_path)
+    FRONTEND_VALUE(synchronization_mode)
+    FRONTEND_VALUE(keep_default_working_directory)
+    FRONTEND_VALUE(lua_script_path)
+    FRONTEND_VALUE(recent_lua_script_paths)
+    FRONTEND_VALUE(is_recent_scripts_frozen)
+    FRONTEND_VALUE(piano_roll_constrain_edit_to_column)
+    FRONTEND_VALUE(piano_roll_undo_stack_size)
+    FRONTEND_VALUE(piano_roll_keep_selection_visible)
+    FRONTEND_VALUE(piano_roll_keep_playhead_visible)
+    FRONTEND_VALUE(selected_video_plugin)
+    FRONTEND_VALUE(selected_audio_plugin)
+    FRONTEND_VALUE(selected_input_plugin)
+    FRONTEND_VALUE(selected_rsp_plugin)
+    FRONTEND_VALUE(last_movie_type)
+    FRONTEND_VALUE(last_movie_author)
+    FRONTEND_VALUE(window_x)
+    FRONTEND_VALUE(window_y)
+    FRONTEND_VALUE(window_width)
+    FRONTEND_VALUE(window_height)
+    FRONTEND_VALUE(rombrowser_column_widths)
+    FRONTEND_VALUE(rombrowser_sort_ascending)
+    FRONTEND_VALUE(rombrowser_sorted_column)
+    FRONTEND_VALUE(persistent_folder_paths)
+    FRONTEND_VALUE(settings_tab)
+    FRONTEND_VALUE(vcr_0_index)
+    FRONTEND_VALUE(increment_slot)
+    FRONTEND_VALUE(automatic_update_checking)
+    FRONTEND_VALUE(silent_mode)
+    FRONTEND_VALUE(seeker_value)
+    FRONTEND_VALUE(multi_frame_advance_count)
+    FRONTEND_VALUE(silent_mode_dialog_choices)
+    FRONTEND_VALUE(trusted_lua_paths)
+    FRONTEND_VALUE(lua_paths)
+    FRONTEND_VALUE(hotkeys)
+    FRONTEND_VALUE(inital_hotkeys)
+
+    #undef CORE_VALUE
+    #undef FRONTEND_VALUE
+}
+
+#pragma endregion
+
+static std::filesystem::path get_config_path()
+{
+    return IOUtils::config_path() / CONFIG_FILE_NAME;
+}
+
+const std::string &Config::config_directory()
+{
     static const std::string path = IOUtils::config_path().string();
     return path;
 }
@@ -580,14 +933,12 @@ void Config::save()
 
     config_patch(g_config);
 
-    std::remove(get_legacy_config_path().string().c_str());
-
-    mINI::INIFile file(get_legacy_config_path().string());
-    mINI::INIStructure ini;
-
-    handle_config_ini(false, ini);
-
-    file.write(ini, true);
+    json j{};
+    json_ensure_format(j);
+    json_write_file(j);
+    
+    std::ofstream ofs_file(get_config_path());
+    ofs_file << std::setw(2) << j;
 }
 
 void Config::apply_and_save()
@@ -604,20 +955,30 @@ void Config::apply_and_save()
 
 void Config::load()
 {
-    if (!std::filesystem::exists(get_legacy_config_path()))
+    if (std::filesystem::exists(get_config_path())) {
+        json j;
+        {
+            std::ifstream ifs_file(get_config_path());
+            ifs_file >> j;
+        }
+        json_ensure_format(j);
+        json_read_file(j);
+    }
+    else if (std::filesystem::exists(get_legacy_config_path())) {
+        mINI::INIFile file(get_legacy_config_path().string());
+        mINI::INIStructure ini;
+        file.read(ini);
+
+        handle_config_ini(true, ini);
+        migrate_config_ini(g_config, ini);
+    }
+    else
     {
         g_view_logger->info("[CONFIG] Default config file does not exist. Generating...");
         g_config = get_default_config();
         save();
     }
 
-    mINI::INIFile file(get_legacy_config_path().string());
-    mINI::INIStructure ini;
-    file.read(ini);
-
-    handle_config_ini(true, ini);
-
-    migrate_config(g_config, ini);
     config_patch(g_config);
 
     Messenger::broadcast(Messenger::Message::ConfigLoaded, nullptr);

--- a/src/Views.Win32/Config.cpp
+++ b/src/Views.Win32/Config.cpp
@@ -437,7 +437,7 @@ static void handle_config_ini(const bool is_reading, mINI::INIStructure &ini)
 
 static std::filesystem::path get_legacy_config_path()
 {
-    return g_main_ctx.app_path / CONFIG_FILE_NAME;
+    return g_main_ctx.app_path / LEGACY_CONFIG_FILE_NAME;
 }
 
 /**
@@ -660,7 +660,7 @@ static bool convert_from_json(const json &j, std::map<std::wstring, Hotkey::t_ho
     return true;
 }
 
-static void json_read_file(const json &j)
+static void json_read_file(json &j)
 {
     g_config = get_default_config();
 
@@ -894,6 +894,9 @@ static void config_patch(t_config &cfg)
             cfg.silent_mode_dialog_choices[key] = std::to_wstring(pair.second);
         }
     }
+
+    // HACK: Wine doesn't implement DComp well enough yet, so force GDI
+    if (g_main_ctx.wine) cfg.presenter_type = (int32_t)t_config::PresenterType::GDI;
 }
 
 void Config::init()
@@ -930,13 +933,20 @@ void Config::load()
 {
     if (std::filesystem::exists(get_config_path()))
     {
-        std::ifstream ifs_file(get_config_path());
         json j;
+        try
         {
+            std::ifstream ifs_file(get_config_path());
             ifs_file >> j;
+            json_ensure_format(j);
+            json_read_file(j);
         }
-        json_ensure_format(j);
-        json_read_file(j);
+        catch (const std::exception &e)
+        {
+            g_view_logger->info("[CONFIG] Failed to load config, using defaults...");
+            g_config = get_default_config();
+            save();
+        }
     }
     else if (std::filesystem::exists(get_legacy_config_path()))
     {

--- a/src/Views.Win32/Config.cpp
+++ b/src/Views.Win32/Config.cpp
@@ -562,7 +562,8 @@ template <class T> static json convert_to_json(const T &value)
     return json(value);
 }
 
-static json convert_to_json(const std::wstring& value) {
+static json convert_to_json(const std::wstring &value)
+{
     return json(IOUtils::to_utf8_string(value));
 }
 
@@ -608,7 +609,8 @@ template <class T> static bool convert_from_json(const json &j, T &value)
     return true;
 }
 
-static bool convert_from_json(const json& j, std::wstring& value) {
+static bool convert_from_json(const json &j, std::wstring &value)
+{
     if (j.is_null()) return false;
     value = IOUtils::to_wide_string(j.get<std::string>());
     return true;
@@ -658,11 +660,12 @@ static bool convert_from_json(const json &j, std::map<std::wstring, Hotkey::t_ho
     return true;
 }
 
-static void json_read_file(const json& j) {
+static void json_read_file(const json &j)
+{
     g_config = get_default_config();
 
-    #define CORE_VALUE(name) convert_from_json(j["core"][#name], g_config.core.name);
-    #define FRONTEND_VALUE(name) convert_from_json(j["frontend"][#name], g_config.name);
+#define CORE_VALUE(name) convert_from_json(j["core"][#name], g_config.core.name);
+#define FRONTEND_VALUE(name) convert_from_json(j["frontend"][#name], g_config.name);
 
     CORE_VALUE(total_rerecords)
     CORE_VALUE(total_frames)
@@ -751,13 +754,14 @@ static void json_read_file(const json& j) {
     FRONTEND_VALUE(hotkeys)
     FRONTEND_VALUE(inital_hotkeys)
 
-    #undef CORE_VALUE
-    #undef FRONTEND_VALUE
+#undef CORE_VALUE
+#undef FRONTEND_VALUE
 }
 
-static void json_write_file(json& j) {
-    #define CORE_VALUE(name) j["core"][#name] = convert_to_json(g_config.core.name);
-    #define FRONTEND_VALUE(name) j["frontend"][#name] = convert_to_json(g_config.name);
+static void json_write_file(json &j)
+{
+#define CORE_VALUE(name) j["core"][#name] = convert_to_json(g_config.core.name);
+#define FRONTEND_VALUE(name) j["frontend"][#name] = convert_to_json(g_config.name);
 
     CORE_VALUE(total_rerecords)
     CORE_VALUE(total_frames)
@@ -846,8 +850,8 @@ static void json_write_file(json& j) {
     FRONTEND_VALUE(hotkeys)
     FRONTEND_VALUE(inital_hotkeys)
 
-    #undef CORE_VALUE
-    #undef FRONTEND_VALUE
+#undef CORE_VALUE
+#undef FRONTEND_VALUE
 }
 
 #pragma endregion
@@ -905,7 +909,7 @@ void Config::save()
     json j{};
     json_ensure_format(j);
     json_write_file(j);
-    
+
     std::ofstream ofs_file(get_config_path());
     ofs_file << std::setw(2) << j;
 }
@@ -924,7 +928,8 @@ void Config::apply_and_save()
 
 void Config::load()
 {
-    if (std::filesystem::exists(get_config_path())) {
+    if (std::filesystem::exists(get_config_path()))
+    {
         std::ifstream ifs_file(get_config_path());
         json j;
         {
@@ -933,7 +938,8 @@ void Config::load()
         json_ensure_format(j);
         json_read_file(j);
     }
-    else if (std::filesystem::exists(get_legacy_config_path())) {
+    else if (std::filesystem::exists(get_legacy_config_path()))
+    {
         mINI::INIFile file(get_legacy_config_path().string());
         mINI::INIStructure ini;
         file.read(ini);

--- a/src/Views.Win32/Config.cpp
+++ b/src/Views.Win32/Config.cpp
@@ -441,44 +441,6 @@ static std::filesystem::path get_legacy_config_path()
 }
 
 /**
- * \brief Modifies the config to apply value limits and other constraints.
- */
-static void config_patch(t_config &cfg)
-{
-    if (!MonitorFromPoint({cfg.window_x, cfg.window_y}, MONITOR_DEFAULTTONULL))
-    {
-        cfg.window_x = g_default_config.window_x;
-        cfg.window_y = g_default_config.window_y;
-    }
-
-    if (cfg.rombrowser_column_widths.size() < 4)
-    {
-        // something's malformed, fuck off and use default values
-        cfg.rombrowser_column_widths = g_default_config.rombrowser_column_widths;
-    }
-
-    // Causes too many issues
-    if (cfg.core.seek_savestate_interval == 1)
-    {
-        cfg.core.seek_savestate_interval = 2;
-    }
-
-    cfg.settings_tab = std::min(std::max(cfg.settings_tab, 0), 2);
-
-    for (const auto &pair : DIALOG_SILENT_MODE_CHOICES)
-    {
-        const auto key = IOUtils::to_wide_string(pair.first);
-        if (!cfg.silent_mode_dialog_choices.contains(key))
-        {
-            cfg.silent_mode_dialog_choices[key] = std::to_wstring(pair.second);
-        }
-    }
-
-    // Wine doesn't support DComp
-    if (g_main_ctx.wine) cfg.presenter_type = (int32_t)t_config::PresenterType::GDI;
-}
-
-/**
  * \brief Migrates old values from the specified config to new ones if possible.
  */
 static void migrate_config_ini(t_config &config, const mINI::INIStructure &ini)
@@ -917,10 +879,39 @@ static std::filesystem::path get_config_path()
     return IOUtils::config_path() / CONFIG_FILE_NAME;
 }
 
-const std::string &Config::config_directory()
+/**
+ * \brief Modifies the config to apply value limits and other constraints.
+ */
+static void config_patch(t_config &cfg)
 {
-    static const std::string path = IOUtils::config_path().string();
-    return path;
+    if (!MonitorFromPoint({cfg.window_x, cfg.window_y}, MONITOR_DEFAULTTONULL))
+    {
+        cfg.window_x = g_default_config.window_x;
+        cfg.window_y = g_default_config.window_y;
+    }
+
+    if (cfg.rombrowser_column_widths.size() < 4)
+    {
+        // something's malformed, fuck off and use default values
+        cfg.rombrowser_column_widths = g_default_config.rombrowser_column_widths;
+    }
+
+    // Causes too many issues
+    if (cfg.core.seek_savestate_interval == 1)
+    {
+        cfg.core.seek_savestate_interval = 2;
+    }
+
+    cfg.settings_tab = std::min(std::max(cfg.settings_tab, 0), 2);
+
+    for (const auto &pair : DIALOG_SILENT_MODE_CHOICES)
+    {
+        const auto key = IOUtils::to_wide_string(pair.first);
+        if (!cfg.silent_mode_dialog_choices.contains(key))
+        {
+            cfg.silent_mode_dialog_choices[key] = std::to_wstring(pair.second);
+        }
+    }
 }
 
 void Config::init()
@@ -956,9 +947,9 @@ void Config::apply_and_save()
 void Config::load()
 {
     if (std::filesystem::exists(get_config_path())) {
+        std::ifstream ifs_file(get_config_path());
         json j;
         {
-            std::ifstream ifs_file(get_config_path());
             ifs_file >> j;
         }
         json_ensure_format(j);

--- a/src/Views.Win32/Config.h
+++ b/src/Views.Win32/Config.h
@@ -343,14 +343,6 @@ namespace Config
 {
 
 /**
- * @brief Gets the path to the config directory.
- *
- * This is usually tied to `%LOCALAPPDATA%` on Windows, and `$XDG_CONFIG_HOME` or `~/.config`
- * on Linux. Note that this method returns a UTF-8 string to facilitate cross-platform work.
- */
-const std::string& config_directory();
-
-/**
  * \brief Initializes the subsystem.
  */
 void init();

--- a/src/Views.Win32/Config.h
+++ b/src/Views.Win32/Config.h
@@ -341,6 +341,15 @@ extern const t_config g_default_config;
 
 namespace Config
 {
+
+/**
+ * @brief Gets the path to the config directory.
+ *
+ * This is usually tied to `%LOCALAPPDATA%` on Windows, and `$XDG_CONFIG_HOME` or `~/.config`
+ * on Linux. Note that this method returns a UTF-8 string to facilitate cross-platform work.
+ */
+const std::string& config_directory();
+
 /**
  * \brief Initializes the subsystem.
  */

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -46,12 +46,12 @@ static size_t ext_fn_config_path(char* data, size_t size) {
     static const std::string config_path = IOUtils::config_path().string();
 
     if (data == nullptr)
-        return config_path.size();
+        return config_path.size() + 1;
     if (size < config_path.size() + 1)
         return 0;
 
     memcpy(data, config_path.c_str(), config_path.size() + 1);
-    return size;
+    return size + 1;
 }
 
 #pragma region Dummy Functions

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -44,7 +44,7 @@ plugin_funcs g_plugin_funcs{};
 
 static size_t ext_fn_config_path(char *data, size_t size)
 {
-    static const std::string config_path = IOUtils::config_path().string();
+    static const std::u8string config_path = IOUtils::config_path().u8string();
 
     if (data == nullptr) return config_path.size() + 1;
     if (size < config_path.size() + 1) return 0;

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -42,13 +42,12 @@ static std::jthread s_audio_thread;
 
 plugin_funcs g_plugin_funcs{};
 
-static size_t ext_fn_config_path(char* data, size_t size) {
+static size_t ext_fn_config_path(char *data, size_t size)
+{
     static const std::string config_path = IOUtils::config_path().string();
 
-    if (data == nullptr)
-        return config_path.size() + 1;
-    if (size < config_path.size() + 1)
-        return 0;
+    if (data == nullptr) return config_path.size() + 1;
+    if (size < config_path.size() + 1) return 0;
 
     memcpy(data, config_path.c_str(), config_path.size() + 1);
     return size + 1;
@@ -663,13 +662,12 @@ t_plugin_discovery_result PluginUtil::discover_plugins(const std::filesystem::pa
 #define GEN_EXTENDED_FUNCS(logger)                                                                                     \
     core_plugin_extended_funcs                                                                                         \
     {                                                                                                                  \
-        .size = sizeof(core_plugin_extended_funcs), \
-        .log_trace = [](const wchar_t *str) { logger->trace(str); },       \
+        .size = sizeof(core_plugin_extended_funcs), .log_trace = [](const wchar_t *str) { logger->trace(str); },       \
         .log_info = [](const wchar_t *str) { logger->info(str); },                                                     \
         .log_warn = [](const wchar_t *str) { logger->warn(str); },                                                     \
         .log_error = [](const wchar_t *str) { logger->error(str); },                                                   \
         .get_effective_speed_mode = [](void) { return g_main_ctx.core_ctx->vr_get_effective_speed_mode(); },           \
-        .config_path = ext_fn_config_path,\
+        .config_path = ext_fn_config_path,                                                                             \
     }
 
 void PluginUtil::init_dummy_and_extended_funcs()

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -42,6 +42,18 @@ static std::jthread s_audio_thread;
 
 plugin_funcs g_plugin_funcs{};
 
+static size_t ext_fn_config_path(char* data, size_t size) {
+    static const std::string config_path = IOUtils::config_path().string();
+
+    if (data == nullptr)
+        return config_path.size();
+    if (size < config_path.size() + 1)
+        return 0;
+
+    memcpy(data, config_path.c_str(), config_path.size() + 1);
+    return size;
+}
+
 #pragma region Dummy Functions
 
 static uint32_t CALL dummy_do_rsp_cycles(uint32_t Cycles)
@@ -651,11 +663,13 @@ t_plugin_discovery_result PluginUtil::discover_plugins(const std::filesystem::pa
 #define GEN_EXTENDED_FUNCS(logger)                                                                                     \
     core_plugin_extended_funcs                                                                                         \
     {                                                                                                                  \
-        .size = sizeof(core_plugin_extended_funcs), .log_trace = [](const wchar_t *str) { logger->trace(str); },       \
+        .size = sizeof(core_plugin_extended_funcs), \
+        .log_trace = [](const wchar_t *str) { logger->trace(str); },       \
         .log_info = [](const wchar_t *str) { logger->info(str); },                                                     \
         .log_warn = [](const wchar_t *str) { logger->warn(str); },                                                     \
         .log_error = [](const wchar_t *str) { logger->error(str); },                                                   \
         .get_effective_speed_mode = [](void) { return g_main_ctx.core_ctx->vr_get_effective_speed_mode(); },           \
+        .config_path = ext_fn_config_path,\
     }
 
 void PluginUtil::init_dummy_and_extended_funcs()

--- a/src/Views.Win32/action/AppActions.cpp
+++ b/src/Views.Win32/action/AppActions.cpp
@@ -668,7 +668,7 @@ static void show_ram_start()
 
     if (result == 0)
     {
-        auto exe_filename = IOUtils::exe_path_cached().stem();
+        auto exe_filename = IOUtils::exe_path().stem();
 
         const auto stroop_line = std::format(L"<Emulator name=\"Mupen 5.0 RR\" processName=\"{}\" ramStart=\"{}\" "
                                              L"endianness=\"little\" autoDetect=\"true\"/>",

--- a/src/Views.Win32/components/RomBrowser.cpp
+++ b/src/Views.Win32/components/RomBrowser.cpp
@@ -28,7 +28,7 @@ static t_rombrowser_context g_ctx{};
 std::vector<std::filesystem::path> discover_roms()
 {
     const auto abs_rom_directory =
-        std::filesystem::weakly_canonical(IOUtils::exe_path_cached().parent_path() / g_config.rom_directory);
+        std::filesystem::weakly_canonical(IOUtils::exe_path().parent_path() / g_config.rom_directory);
 
     if (!std::filesystem::exists(abs_rom_directory) || !std::filesystem::is_directory(abs_rom_directory))
     {

--- a/src/Views.Win32/include/Views.Win32/ViewPlugin.h
+++ b/src/Views.Win32/include/Views.Win32/ViewPlugin.h
@@ -61,6 +61,16 @@ extern "C"
          * \return The current effective speed mode.
          */
         CoreSpeedMode (*get_effective_speed_mode)();
+        /**
+         * @brief Gets the path to the configuration directory, as a UTF-8 string.
+         *
+         * Writes the path to the configuration directory to `data`, provided that there is 
+         * enough space for path and terminating null character (up to `len`). Returns the
+         * number of characters written, or 0 if the buffer wasn't big enough.
+         * 
+         * If `data` is null, returns the expected size of the buffer.
+         */
+        size_t (*config_path)(char* data, size_t len);
     };
 
     typedef void(CALL *CLOSEDLL)();

--- a/src/Views.Win32/include/Views.Win32/ViewPlugin.h
+++ b/src/Views.Win32/include/Views.Win32/ViewPlugin.h
@@ -65,13 +65,13 @@ extern "C"
         /**
          * @brief Gets the path to the configuration directory, as a UTF-8 string.
          *
-         * Writes the path to the configuration directory to `data`, provided that there is 
+         * Writes the path to the configuration directory to `data`, provided that there is
          * enough space for path and terminating null character (up to `len`). Returns the
          * number of characters written, or 0 if the buffer wasn't big enough.
-         * 
+         *
          * If `data` is null, returns the expected size of the buffer.
          */
-        size_t (*config_path)(char* data, size_t len);
+        size_t (*config_path)(char *data, size_t len);
     };
 
     typedef void(CALL *CLOSEDLL)();
@@ -198,14 +198,15 @@ inline core_plugin_extended_funcs get_core_plugin_extended_funcs_shim()
     funcs.log_warn = log;
     funcs.log_error = log;
     funcs.get_effective_speed_mode = []() { return CoreSpeedMode::Normal; };
-    funcs.config_path = [](char*, size_t) -> size_t { throw std::runtime_error("config_path not known yet"); };
+    funcs.config_path = [](char *, size_t) -> size_t { throw std::runtime_error("config_path not known yet"); };
     return funcs;
 }
 
 /**
  * @brief Gets the config path as a `std::filesystem::path` from a `core_plugin_extended_funcs`.
  */
-inline std::filesystem::path get_config_path(const core_plugin_extended_funcs* ef) {
+inline std::filesystem::path get_config_path(const core_plugin_extended_funcs *ef)
+{
     // get length
     size_t len = ef->config_path(nullptr, 0);
     // copy string

--- a/src/Views.Win32/include/Views.Win32/ViewPlugin.h
+++ b/src/Views.Win32/include/Views.Win32/ViewPlugin.h
@@ -67,7 +67,8 @@ extern "C"
          *
          * Writes the path to the configuration directory to `data`, provided that there is
          * enough space for path and terminating null character (up to `len`). Returns the
-         * number of characters written, or 0 if the buffer wasn't big enough.
+         * number of characters written (including the terminating null), or 0 if the buffer
+         * wasn't big enough.
          *
          * If `data` is null, returns the expected size of the buffer.
          */
@@ -198,7 +199,14 @@ inline core_plugin_extended_funcs get_core_plugin_extended_funcs_shim()
     funcs.log_warn = log;
     funcs.log_error = log;
     funcs.get_effective_speed_mode = []() { return CoreSpeedMode::Normal; };
-    funcs.config_path = [](char *, size_t) -> size_t { throw std::runtime_error("config_path not known yet"); };
+    funcs.config_path = [](char *data, size_t len) -> size_t {
+        // return the empty null-terminated string
+        if (data == nullptr) return 1;
+        if (len < 1) return 0;
+
+        data[0] = '\0';
+        return 1;
+    };
     return funcs;
 }
 
@@ -214,7 +222,9 @@ inline std::filesystem::path get_config_path(const core_plugin_extended_funcs *e
     ef->config_path(path_temp.data(), path_temp.size());
     // drop the terminating null
     path_temp.pop_back();
-    return std::filesystem::absolute(path_temp);
+    // force UTF-8 conversion
+    std::u8string_view utf8_path_temp{(char8_t *)path_temp.data(), path_temp.size()};
+    return std::filesystem::absolute(utf8_path_temp);
 }
 
 } // namespace ViewPluginHelpers

--- a/src/Views.Win32/include/Views.Win32/ViewPlugin.h
+++ b/src/Views.Win32/include/Views.Win32/ViewPlugin.h
@@ -61,6 +61,7 @@ extern "C"
          * \return The current effective speed mode.
          */
         CoreSpeedMode (*get_effective_speed_mode)();
+
         /**
          * @brief Gets the path to the configuration directory, as a UTF-8 string.
          *
@@ -197,6 +198,22 @@ inline core_plugin_extended_funcs get_core_plugin_extended_funcs_shim()
     funcs.log_warn = log;
     funcs.log_error = log;
     funcs.get_effective_speed_mode = []() { return CoreSpeedMode::Normal; };
+    funcs.config_path = [](char*, size_t) -> size_t { throw std::runtime_error("config_path not known yet"); };
     return funcs;
 }
+
+/**
+ * @brief Gets the config path as a `std::filesystem::path` from a `core_plugin_extended_funcs`.
+ */
+inline std::filesystem::path get_config_path(const core_plugin_extended_funcs* ef) {
+    // get length
+    size_t len = ef->config_path(nullptr, 0);
+    // copy string
+    std::string path_temp(len, '\0');
+    ef->config_path(path_temp.data(), path_temp.size());
+    // drop the terminating null
+    path_temp.pop_back();
+    return std::filesystem::absolute(path_temp);
+}
+
 } // namespace ViewPluginHelpers


### PR DESCRIPTION
Fixes #609, switching all config files over to JSON. Config files have also been moved to `%localappdata%\mupen64-rr-lua`, with `$XDG_CONFIG_HOME/mupen64-rr-lua` being provisionally set as the config location on Linux.