### PR TITLE
fix(FFmpegEncoder): `vf` option being overwritten

### DIFF
--- a/src/Views.Win32/Config.h
+++ b/src/Views.Win32/Config.h
@@ -146,7 +146,7 @@ struct t_config
     /// <summary>
     /// FFmpeg options.
     /// </summary>
-    std::wstring ffmpeg_options = L"-c:v libx264 -preset veryfast -crf 23 -c:a aac -b:a 128k";
+    std::wstring ffmpeg_options = L"-c:v libx264 -preset veryfast -crf 23 -c:a aac -b:a 128k -vf vflip";
 
     /// <summary>
     /// FFmpeg binary path

--- a/src/Views.Win32/capture/encoders/FFmpegEncoder.cpp
+++ b/src/Views.Win32/capture/encoders/FFmpegEncoder.cpp
@@ -10,7 +10,7 @@
 #include <Config.h>
 
 const std::wstring NUT_PIPE_NAME = L"\\\\.\\pipe\\mupennut";
-const std::wstring FFMPEG_OPTIONS = L"-y -i {} {} -vf vflip {}";
+const std::wstring FFMPEG_OPTIONS = L"-y -i {} {} {}";
 
 struct PipeIO
 {


### PR DESCRIPTION
Needs a config reset to apply.