### PR TITLE
fix(TASVideo): inconsistent clearing behavior

### DIFF
--- a/src/Plugins.Win32.TASVideo/RSP.cpp
+++ b/src/Plugins.Win32.TASVideo/RSP.cpp
@@ -90,10 +90,6 @@ void RSP_ProcessDList()
     if (OGL.clear_override)
     {
         glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-        // Force the clear to cover the entire framebuffer, ignoring any
-        // scissor region left over from the previous frame. Without this,
-        // letterbox bars and other out-of-scissor areas can retain garbage
-        // when the N64 does not issue a full-screen clear itself.
         glPushAttrib(GL_ENABLE_BIT);
         glDisable(GL_SCISSOR_TEST);
         glClear(GL_COLOR_BUFFER_BIT);

--- a/src/Plugins.Win32.TASVideo/RSP.cpp
+++ b/src/Plugins.Win32.TASVideo/RSP.cpp
@@ -90,7 +90,14 @@ void RSP_ProcessDList()
     if (OGL.clear_override)
     {
         glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        // Force the clear to cover the entire framebuffer, ignoring any
+        // scissor region left over from the previous frame. Without this,
+        // letterbox bars and other out-of-scissor areas can retain garbage
+        // when the N64 does not issue a full-screen clear itself.
+        glPushAttrib(GL_ENABLE_BIT);
+        glDisable(GL_SCISSOR_TEST);
         glClear(GL_COLOR_BUFFER_BIT);
+        glPopAttrib();
     }
 
     RSP.PC[0] = *(u32 *)&DMEM[0x0FF0];


### PR DESCRIPTION
## Summary

This PR fixes #719.

The "Clear every frame" option in the TASVideo plugin occasionally failed to fully clear the framebuffer. This was most noticeable on the SM64 title screen (Mario head intro), where the letterbox bars sometimes retained garbage instead of staying black.

## Proposed change

In `RSP_ProcessDList()`, the forced framebuffer clear is now performed with `GL_SCISSOR_TEST` temporarily disabled. The previous enable state is saved with `glPushAttrib` / `glPopAttrib`.

Rationale: if the previous frame left scissoring enabled (e.g. after `OGL_DrawRect`, or during an active capture), the forced `glClear(GL_COLOR_BUFFER_BIT)` would only touch the scissor region, leaving the letterbox bars uncleared. By disabling scissor for the clear, we ensure the entire back buffer is cleared to black.

## Testing

- Tested by @hugou74130 while actively capturing.
- Before the fix: black bars were occasionally drawn over during the SM64 intro.
- After the fix: black bars stay clean consistently.

Closes #719
