### PR TITLE
fix(TASVideo): multiple context initialization causes crash

### DIFF
--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -161,6 +161,9 @@ bool OGL_InitContext()
 
     OGL_InitExtensions();
     OGL_InitStates();
+
+    OGL.context_initialized = TRUE;
+
     return TRUE;
 }
 


### PR DESCRIPTION
OGL_Start() guards context creation with OGL.context_initialized, but OGL_InitContext() never set it to TRUE. This caused the OpenGL context (and related SDL window/GL resources) to be recreated every time a movie was reloaded from start, leading to an access violation in TASVideo.dll.

Fixes #717