### PR TITLE
feat(DummyInput)!: always enable controller 1

### DIFF
--- a/src/Plugins.Win32.DummyInput/Main.cpp
+++ b/src/Plugins.Win32.DummyInput/Main.cpp
@@ -26,5 +26,4 @@ EXPORT void CALL InitiateControllers(core_input_info ControlInfo)
     }
 
     controllers[0].Present = 1;
-    controllers[0].Plugin = ce_mempak;
 }

--- a/src/Plugins.Win32.DummyInput/Main.cpp
+++ b/src/Plugins.Win32.DummyInput/Main.cpp
@@ -10,6 +10,21 @@
 #include <core_api.h>
 #include <Views.Win32/ViewPlugin.h>
 
-#define PLUGIN_NAME VERSION_NAME_HELPER_GEN_NAME(L"No Input", L"1.0.0")
+#define PLUGIN_NAME VERSION_NAME_HELPER_GEN_NAME(L"No Input", L"1.0.1")
 
 DUMMY_PLUGIN_STUB_IMPL(plugin_input)
+
+EXPORT void CALL InitiateControllers(core_input_info ControlInfo)
+{
+    auto *controllers = ControlInfo.controllers;
+
+    for (int i = 0; i < 4; ++i)
+    {
+        controllers[i].Present = 0;
+        controllers[i].RawData = 0;
+        controllers[i].Plugin = ce_none;
+    }
+
+    controllers[0].Present = 1;
+    controllers[0].Plugin = ce_mempak;
+}


### PR DESCRIPTION
Makes controller 1 enabled to avoid issues with missing input polls.

Bumps version to 1.0.1.