### PR TITLE
chore(TASRSP): bump version to `1.1.0`

### DIFF
--- a/src/Plugins.Win32.TASRSP/Main.h
+++ b/src/Plugins.Win32.TASRSP/Main.h
@@ -12,7 +12,7 @@
 #include <Views.Win32/ViewPlugin.h>
 #include <Resource.h>
 
-#define PLUGIN_NAME VERSION_NAME_HELPER_GEN_NAME(L"TAS RSP", L"1.0.1")
+#define PLUGIN_NAME VERSION_NAME_HELPER_GEN_NAME(L"TAS RSP", L"1.1.0")
 
 extern HINSTANCE g_instance;
 extern std::filesystem::path g_app_path;


### PR DESCRIPTION
because of the core speed integration