### PR TITLE
fix(ConfigDialog): remove experimental label from FFmpeg encoder option

### DIFF
--- a/src/Views.Win32/components/ConfigDialog.cpp
+++ b/src/Views.Win32/components/ConfigDialog.cpp
@@ -827,7 +827,7 @@ std::vector<t_options_group> get_static_option_groups()
         .possible_values =
             {
                 std::make_pair(L"VFW", (int32_t)t_config::EncoderType::VFW),
-                std::make_pair(L"FFmpeg (experimental)", (int32_t)t_config::EncoderType::FFmpeg),
+                std::make_pair(L"FFmpeg", (int32_t)t_config::EncoderType::FFmpeg),
             },
         .is_readonly = [] { return CaptureManager::is_capturing(); },
     });


### PR DESCRIPTION
Testing required

## Summary

This PR removes the "(experimental)" label from the FFmpeg encoder option in the ConfigDialog.

## Changes

- Changed the display name from `FFmpeg (experimental)` to `FFmpeg` in `src/Views.Win32/components/ConfigDialog.cpp`

## Related

Closes #747