### PR TITLE
build: add x64 build presets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x86]
+        arch: [x86, x64]
 
     steps:
       - uses: actions/checkout@v6
@@ -69,7 +69,7 @@ jobs:
 
       - name: CMake Setup
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: cmake --preset vcpkg-win64-x86
+        run: cmake --preset vcpkg-win64-${{ matrix.arch }}
 
       - name: CMake Build
         working-directory: ${{env.GITHUB_WORKSPACE}}
@@ -87,7 +87,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x86]
+        arch: [x86, x64]
 
     steps:
       - uses: actions/checkout@v6
@@ -138,7 +138,7 @@ jobs:
 
       - name: CMake Setup
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: cmake --preset vcpkg-win64-x86-release
+        run: cmake --preset vcpkg-win64-${{ matrix.arch }}-release
 
       - name: CMake Build
         working-directory: ${{env.GITHUB_WORKSPACE}}
@@ -162,7 +162,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x86]
+        arch: [x86, x64]
 
     steps:
       - uses: actions/checkout@v6
@@ -201,7 +201,7 @@ jobs:
 
       - name: CMake Setup
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: cmake --preset vcpkg-win64-x86-release
+        run: cmake --preset vcpkg-win64-${{ matrix.arch }}-release
 
       - name: CMake Build
         working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x86]
+        arch: [x86, x64]
 
     steps:
       - uses: actions/checkout@v6
@@ -52,7 +52,7 @@ jobs:
 
       - name: CMake Setup
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: cmake --preset vcpkg-win64-x86-release
+        run: cmake --preset vcpkg-win64-${{ matrix.arch }}-release
 
       - name: CMake Build
         working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.vscode/build-x64.bat
+++ b/.vscode/build-x64.bat
@@ -1,0 +1,14 @@
+@echo off
+
+for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -property installationPath`) do (
+    set "VSPATH=%%i"
+)
+
+if not defined VSPATH (
+    echo ERROR: Could not find Visual Studio installation
+    exit /b 1
+)
+
+call "%VSPATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 -host_arch=x64
+
+cmake --build build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,14 @@
             "program": "${workspaceFolder}/build/out/mupen64.exe",
             "cwd": "${workspaceFolder}",
             "preLaunchTask": "Build Project"
+        },
+        {
+            "type": "cppvsdbg",
+            "request": "launch",
+            "name": "mupen64.exe (x64, VS)",
+            "program": "${workspaceFolder}/build/out/mupen64.exe",
+            "cwd": "${workspaceFolder}",
+            "preLaunchTask": "Build Project (x64)"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,6 +23,26 @@
                 "showReuseMessage": false,
                 "clear": false
             }
+        },
+        {
+            "type": "shell",
+            "label": "Build Project (x64)",
+            "command": "${workspaceFolder}\\.vscode\\build-x64.bat",
+            "options": {
+                "shell": {
+                    "executable": "cmd.exe",
+                    "args": ["/c"]
+                }
+            },
+            "group": "build",
+            "problemMatcher": ["$msCompile"],
+            "presentation": {
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            }
         }
     ]
 }

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -12,6 +12,18 @@
     ]
   },
   {
+    "label": "delete cache and reconfigure (x64)",
+    "reveal": "no_focus",
+    "save": "all",
+    "command": "./vsdev-x64.cmd",
+    "args": [
+      "cmake",
+      "--fresh",
+      "--preset",
+      "vcpkg-win64-x64"
+    ]
+  },
+  {
     "label": "switch to debug",
     "reveal": "no_focus",
     "save": "all",
@@ -20,6 +32,17 @@
       "cmake",
       "--preset",
       "vcpkg-win64-x86"
+    ]
+  },
+  {
+    "label": "switch to debug (x64)",
+    "reveal": "no_focus",
+    "save": "all",
+    "command": "./vsdev-x64.cmd",
+    "args": [
+      "cmake",
+      "--preset",
+      "vcpkg-win64-x64"
     ]
   },
   {
@@ -34,21 +57,10 @@
     ]
   },
   {
-    "label": "switch to debug (x64)",
-    "reveal": "no_focus",
-    "save": "all",
-    "command": "./vsdev.cmd",
-    "args": [
-      "cmake",
-      "--preset",
-      "vcpkg-win64-x64"
-    ]
-  },
-  {
     "label": "switch to release (x64)",
     "reveal": "no_focus",
     "save": "all",
-    "command": "./vsdev.cmd",
+    "command": "./vsdev-x64.cmd",
     "args": [
       "cmake",
       "--preset",
@@ -60,6 +72,17 @@
     "reveal": "no_focus",
     "save": "all",
     "command": "./vsdev.cmd",
+    "args": [
+      "cmake",
+      "--build",
+      "build"
+    ]
+  },
+  {
+    "label": "build (x64)",
+    "reveal": "no_focus",
+    "save": "all",
+    "command": "./vsdev-x64.cmd",
     "args": [
       "cmake",
       "--build",
@@ -79,10 +102,33 @@
     ]
   },
   {
+    "label": "clean rebuild (x64)",
+    "reveal": "no_focus",
+    "save": "all",
+    "command": "./vsdev-x64.cmd",
+    "args": [
+      "cmake",
+      "--build",
+      "build",
+      "--clean-first"
+    ]
+  },
+  {
     "label": "test",
     "reveal": "no_focus",
     "save": "all",
     "command": "./vsdev.cmd",
+    "args": [
+      "ctest",
+      "--test-dir",
+      "build"
+    ]
+  },
+  {
+    "label": "test (x64)",
+    "reveal": "no_focus",
+    "save": "all",
+    "command": "./vsdev-x64.cmd",
     "args": [
       "ctest",
       "--test-dir",

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -34,6 +34,28 @@
     ]
   },
   {
+    "label": "switch to debug (x64)",
+    "reveal": "no_focus",
+    "save": "all",
+    "command": "./vsdev.cmd",
+    "args": [
+      "cmake",
+      "--preset",
+      "vcpkg-win64-x64"
+    ]
+  },
+  {
+    "label": "switch to release (x64)",
+    "reveal": "no_focus",
+    "save": "all",
+    "command": "./vsdev.cmd",
+    "args": [
+      "cmake",
+      "--preset",
+      "vcpkg-win64-x64-release"
+    ]
+  },
+  {
     "label": "build",
     "reveal": "no_focus",
     "save": "all",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,6 +43,37 @@
       }
     },
     {
+      "name": "vcpkg-win64-x64",
+      "description": "64-bit debug build on 64-bit Windows",
+      "inherits": "common",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/toolchains/vcpkg-win64.cmake",
+        "CMAKE_C_COMPILER": "clang-cl",
+        "CMAKE_CXX_COMPILER": "clang-cl"
+      },
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "vcpkg-win64-x64-release",
+      "description": "64-bit release build on 64-bit Windows",
+      "inherits": "vcpkg-win64-x64",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
       "name": "sys-linux64-x64",
       "description": "64-bit debug build on 64-bit Linux",
       "inherits": "common",
@@ -67,6 +98,14 @@
       "configurePreset": "vcpkg-win64-x86-release"
     },
     {
+      "name": "vcpkg-win64-x64",
+      "configurePreset": "vcpkg-win64-x64"
+    },
+    {
+      "name": "vcpkg-win64-x64-release",
+      "configurePreset": "vcpkg-win64-x64-release"
+    },
+    {
       "name": "sys-linux64-x64",
       "configurePreset": "sys-linux64-x64"
     }
@@ -75,6 +114,10 @@
     {
       "name": "vcpkg-win64-x86-all",
       "configurePreset": "vcpkg-win64-x86"
+    },
+    {
+      "name": "vcpkg-win64-x64-all",
+      "configurePreset": "vcpkg-win64-x64"
     },
     {
       "name": "sys-linux64-x64-all",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,17 @@ Only Windows is supported for now, though the CMake infrastructure is intended t
 You'll need:
 - Visual Studio 2026 (for the compiler, CMake, Ninja and vcpkg)
 
-In order for the compiler to work, you'll need to be in a VS developer environment. Then, simply use the provided `vcpkg-win64-x86` preset to compile and build. If you want to change any settings, do so on the command line or via `CMakeUserPresets.json`.
+In order for the compiler to work, you'll need to be in a VS developer environment. Then, simply use one of the provided presets to compile and build. If you want to change any settings, do so on the command line or via `CMakeUserPresets.json`.
+
+For a 32-bit build:
 ```sh
 cmake --preset vcpkg-win64-x86
+cmake --build build
+```
+
+For a 64-bit build:
+```sh
+cmake --preset vcpkg-win64-x64
 cmake --build build
 ```
 
@@ -31,7 +39,7 @@ You'll need to enable `"cmake.useVsDeveloperEnvironment": "always"` in your work
 
 ### CLion
 
-Make sure to set the CMake profile to use the `vcpkg-win64-x86` preset, enabling it if needed.
+Make sure to set the CMake profile to use the desired preset (`vcpkg-win64-x86` or `vcpkg-win64-x64`), enabling it if needed.
 
 If you aren't presented with a CMake profile selection dialog on startup, you can change the active profile by going to `File -> Settings -> Build, Execution, Deployment -> CMake`.
 

--- a/vsdev-x64.cmd
+++ b/vsdev-x64.cmd
@@ -1,0 +1,3 @@
+@echo off
+call "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\Tools\VsDevCmd.bat" -arch=x64 -host_arch=x64
+%*


### PR DESCRIPTION
This PR adds x64 build targets alongside the existing x86 targets, in preparation for future x64 dynarec support.

### Changes

- CMakePresets.json: added vcpkg-win64-x64 and vcpkg-win64-x64-release presets, plus matching build/test presets.

- .github/workflows/build.yml: CI now builds both x86 and x64 for debug nightly, release nightly and release stable.

- .github/workflows/test.yml: CI now runs tests on both x86 and x64.

- .vscode/: added build-x64.bat, an x64 launch configuration and a matching build task.

- .zed/tasks.json: added x64 configure tasks.

- CONTRIBUTING.md: documented both x86 and x64 presets.

### Notes
- Existing x86 presets and targets are preserved.

- The x64 build currently disables the dynarec via the existing CMAKE_SYSTEM_PROCESSOR check in CMakeLists.txt. This is expected until the dynarec itself is ported to x64.