### PR TITLE
fix(TASVideo): incorrect clearing behavior in some situations

### DIFF
--- a/src/Plugins.Win32.TASVideo/gDP.cpp
+++ b/src/Plugins.Win32.TASVideo/gDP.cpp
@@ -599,7 +599,11 @@ void gDPFillRectangle(s32 ulx, s32 uly, s32 lrx, s32 lry)
 
     if (buffer) buffer->cleared = TRUE;
 
-    if (gDP.depthImageAddress == gDP.colorImage.address)
+    u32 fill_color = (u32)gDP.fillColor.r | ((u32)gDP.fillColor.g << 8) | ((u32)gDP.fillColor.b << 16) |
+                     ((u32)gDP.fillColor.a << 24);
+
+    if (gDP.depthImageAddress == gDP.colorImage.address ||
+        (gDP.otherMode.cycleType == G_CYC_FILL && fill_color == 0x01010100))
     {
         OGL_ClearDepthBuffer();
         return;
@@ -607,17 +611,8 @@ void gDPFillRectangle(s32 ulx, s32 uly, s32 lrx, s32 lry)
 
     if (gDP.otherMode.cycleType == G_CYC_FILL)
     {
-        // if (gDP.fillColor.a == 0.0f)
-        //	return;
-
         lrx++;
         lry++;
-
-        if ((ulx == 0) && (uly == 0) && (lrx == VI.width) && (lry == VI.height))
-        {
-            OGL_ClearColorBuffer(&gDP.fillColor.r);
-            return;
-        }
     }
 
     const auto is_sm64_border_rect =

--- a/src/Plugins.Win32.TASVideo/gDP.cpp
+++ b/src/Plugins.Win32.TASVideo/gDP.cpp
@@ -595,9 +595,6 @@ void gDPSetScissor(u32 mode, f32 ulx, f32 uly, f32 lrx, f32 lry)
 
 void gDPFillRectangle(s32 ulx, s32 uly, s32 lrx, s32 lry)
 {
-    DepthBuffer *buffer = DepthBuffer_FindBuffer(gDP.colorImage.address);
-
-    if (buffer) buffer->cleared = TRUE;
 
     u32 fill_color = (u32)gDP.fillColor.r | ((u32)gDP.fillColor.g << 8) | ((u32)gDP.fillColor.b << 16) |
                      ((u32)gDP.fillColor.a << 24);
@@ -606,6 +603,8 @@ void gDPFillRectangle(s32 ulx, s32 uly, s32 lrx, s32 lry)
         (gDP.otherMode.cycleType == G_CYC_FILL && fill_color == 0x01010100))
     {
         OGL_ClearDepthBuffer();
+        DepthBuffer *buffer = DepthBuffer_FindBuffer(gDP.colorImage.address);
+        if (buffer) buffer->cleared = TRUE;
         return;
     }
 

--- a/src/Plugins.Win32.TASVideo/gDP.cpp
+++ b/src/Plugins.Win32.TASVideo/gDP.cpp
@@ -595,6 +595,13 @@ void gDPSetScissor(u32 mode, f32 ulx, f32 uly, f32 lrx, f32 lry)
 
 void gDPFillRectangle(s32 ulx, s32 uly, s32 lrx, s32 lry)
 {
+    if (gDP.otherMode.cycleType == G_CYC_FILL)
+    {
+        lrx++;
+        lry++;
+    }
+    else if (lry == uly)
+        ++lry;
 
     u32 fill_color = (u32)gDP.fillColor.r | ((u32)gDP.fillColor.g << 8) | ((u32)gDP.fillColor.b << 16) |
                      ((u32)gDP.fillColor.a << 24);
@@ -606,12 +613,6 @@ void gDPFillRectangle(s32 ulx, s32 uly, s32 lrx, s32 lry)
         DepthBuffer *buffer = DepthBuffer_FindBuffer(gDP.colorImage.address);
         if (buffer) buffer->cleared = TRUE;
         return;
-    }
-
-    if (gDP.otherMode.cycleType == G_CYC_FILL)
-    {
-        lrx++;
-        lry++;
     }
 
     const auto is_sm64_border_rect =


### PR DESCRIPTION
Fixes busted depth buffer clearing behavior in some cases like TTC credits in SM64

Removes the need for the "clear every frame" option