### PR TITLE
perf: optimize b3d85b81c0a693ac9a5a69a67795bdb2ce1ddac4

### DIFF
--- a/src/Core/Core.cpp
+++ b/src/Core/Core.cpp
@@ -100,6 +100,7 @@ core_result core_create(core_params *params, core_ctx **ctx)
     g_ctx.vr_get_speed_mode = vr_get_speed_mode;
     g_ctx.vr_get_effective_speed_mode = vr_get_effective_speed_mode;
     g_ctx.vr_set_speed_mode = vr_set_speed_mode;
+    g_ctx.vr_get_frame_skipped = vr_get_frame_skipped;
     g_ctx.vr_get_gs_button = vr_get_gs_button;
     g_ctx.vr_set_gs_button = vr_set_gs_button;
     g_ctx.vr_get_vis_per_second = rom_get_vis_per_second;

--- a/src/Core/R4300/R4300.cpp
+++ b/src/Core/R4300/R4300.cpp
@@ -89,6 +89,11 @@ void vr_invalidate_visuals()
     g_r4300.screen_invalidated_frame = true;
 }
 
+bool vr_get_frame_skipped()
+{
+    return g_r4300.frame_skipped;
+}
+
 std::filesystem::path get_sram_path()
 {
     auto filename = std::format("{} {}.sra", (const char *)ROM_HEADER.nom,

--- a/src/Core/R4300/R4300.hpp
+++ b/src/Core/R4300/R4300.hpp
@@ -99,6 +99,7 @@ void vr_set_speed_mode(CoreSpeedMode mode);
 bool vr_get_gs_button();
 void vr_set_gs_button(bool value);
 void vr_invalidate_visuals();
+bool vr_get_frame_skipped();
 
 #define jump_to(a)                                                                                                     \
     {                                                                                                                  \

--- a/src/Core/include/core_api.h
+++ b/src/Core/include/core_api.h
@@ -397,6 +397,12 @@ extern "C"
         std::function<void(CoreSpeedMode mode)> vr_set_speed_mode;
 
         /**
+         * \brief Gets whether the current frame is visually skipped.
+         * \remarks The return value of this function is only guaranteed to be valid during a `rsp_do_rsp_cycles` call.
+         */
+        std::function<bool()> vr_get_frame_skipped;
+
+        /**
          * \brief Gets the GS button state.
          */
         std::function<bool()> vr_get_gs_button;

--- a/src/Core/include/core_plugin.h
+++ b/src/Core/include/core_plugin.h
@@ -90,6 +90,11 @@ extern "C"
         CoreSpeedMode (*get_effective_speed_mode)();
 
         /**
+         * \brief See `core_ctx::vr_get_frame_skipped`.
+         */
+        bool (*frame_skipped)();
+
+        /**
          * @brief Gets the path to the configuration directory, as a UTF-8 string.
          *
          * Writes the path to the configuration directory to `data`, provided that there is

--- a/src/Plugins.Win32.TASRSP/Main.cpp
+++ b/src/Plugins.Win32.TASRSP/Main.cpp
@@ -78,7 +78,7 @@ static int audio_ucode_detect_type(const OSTask_t *task)
     return 2;
 }
 
-static int audio_ucode(OSTask_t *task)
+static void audio_ucode(OSTask_t *task)
 {
     const auto ucode_type = audio_ucode_detect_type(task);
 
@@ -95,7 +95,6 @@ static int audio_ucode(OSTask_t *task)
         break;
     default:
         std::terminate();
-        return -1;
     }
 
     const auto p_alist = (uint32_t *)(rsp.rdram + task->data_ptr);
@@ -106,8 +105,6 @@ static int audio_ucode(OSTask_t *task)
         inst2 = p_alist[i + 1];
         ABI[inst1 >> 24]();
     }
-
-    return 0;
 }
 
 bool rsp_alive()
@@ -126,7 +123,11 @@ void on_rom_closed()
 uint32_t do_rsp_cycles(uint32_t Cycles)
 {
     OSTask_t *task = (OSTask_t *)(rsp.dmem + 0xFC0);
-    const auto skip = g_ef->get_effective_speed_mode() == CoreSpeedMode::UltraFastForward;
+
+    const auto effective_speed_mode = g_ef->get_effective_speed_mode();
+
+    const auto skip_audio = effective_speed_mode == CoreSpeedMode::UltraFastForward;
+    const auto skip_video = g_ef->frame_skipped() || skip_audio;
 
     uint32_t i, sum = 0;
 
@@ -134,10 +135,8 @@ uint32_t do_rsp_cycles(uint32_t Cycles)
 
     if (task->type == 1 && task->data_ptr != 0)
     {
-        if (rsp.process_dlist_list)
-        {
-            rsp.process_dlist_list();
-        }
+        if (rsp.process_dlist_list && !skip_video) rsp.process_dlist_list();
+
         *rsp.sp_status_reg |= 0x0203;
         if ((*rsp.sp_status_reg & 0x40) != 0)
         {
@@ -199,22 +198,21 @@ uint32_t do_rsp_cycles(uint32_t Cycles)
     {
         switch (task->type)
         {
-        case 2: // audio
-            if (skip) return Cycles;
-            if (audio_ucode(task) == 0) return Cycles;
-            break;
-        case 4: // jpeg
+        case 2:
+            if (skip_audio) return Cycles;
+            audio_ucode(task);
+            return Cycles;
+        case 4:
             switch (sum)
             {
-            case 0x278: // used by zelda during boot
+            case 0x278:
                 *rsp.sp_status_reg |= 0x200;
                 return Cycles;
-            case 0x2e4fc: // uncompress
+            case 0x2e4fc:
                 jpg_uncompress(task);
                 return Cycles;
             default:
-                MessageBox(NULL, std::format(L"unknown jpeg: sum: {}", sum).c_str(), L"Error", MB_OK | MB_ICONERROR);
-                break;
+                std::terminate();
             }
             break;
         }

--- a/src/Plugins.Win32.TASRSP/Main.cpp
+++ b/src/Plugins.Win32.TASRSP/Main.cpp
@@ -125,9 +125,7 @@ uint32_t do_rsp_cycles(uint32_t Cycles)
     OSTask_t *task = (OSTask_t *)(rsp.dmem + 0xFC0);
 
     const auto effective_speed_mode = g_ef->get_effective_speed_mode();
-
     const auto skip_audio = effective_speed_mode == CoreSpeedMode::UltraFastForward;
-    const auto skip_video = g_ef->frame_skipped() || skip_audio;
 
     uint32_t i, sum = 0;
 
@@ -135,7 +133,7 @@ uint32_t do_rsp_cycles(uint32_t Cycles)
 
     if (task->type == 1 && task->data_ptr != 0)
     {
-        if (rsp.process_dlist_list && !skip_video) rsp.process_dlist_list();
+        if (rsp.process_dlist_list) rsp.process_dlist_list();
 
         *rsp.sp_status_reg |= 0x0203;
         if ((*rsp.sp_status_reg & 0x40) != 0)

--- a/src/Plugins.Win32.TASVideo/GBI.cpp
+++ b/src/Plugins.Win32.TASVideo/GBI.cpp
@@ -88,6 +88,10 @@ void GBI_Unknown(u32 w0, u32 w1)
     DebugMsg(L"UNKNOWN GBI COMMAND 0x%02X", _SHIFTR(w0, 24, 8));
 }
 
+void GBI_Nop(u32 w0, u32 w1)
+{
+}
+
 INT_PTR CALLBACK MicrocodeDlgProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
@@ -343,6 +347,24 @@ void GBI_MakeCurrent(MicrocodeInfo *current)
             F3DPD_Init();
             break;
         }
+
+        for (int i = 0; i <= 0xFF; i++)
+        {
+            GBI.cmd_headless[i] = GBI.cmd[i];
+        }
+
+        GBI.cmd_headless[G_TRI1] = GBI_Nop;
+        GBI.cmd_headless[G_TRI2] = GBI_Nop;
+        GBI.cmd_headless[G_TRI4] = GBI_Nop;
+        GBI.cmd_headless[G_QUAD] = GBI_Nop;
+        GBI.cmd_headless[G_LINE3D] = GBI_Nop;
+
+        GBI.cmd_headless[G_FILLRECT] = GBI_Nop;
+        GBI.cmd_headless[G_TEXRECT] = GBI_Nop;
+        GBI.cmd_headless[G_TEXRECTFLIP] = GBI_Nop;
+        GBI.cmd_headless[G_OBJ_RECTANGLE] = GBI_Nop;
+        GBI.cmd_headless[G_OBJ_RECTANGLE_R] = GBI_Nop;
+        GBI.cmd_headless[G_OBJ_SPRITE] = GBI_Nop;
     }
 
     GBI.current = current;

--- a/src/Plugins.Win32.TASVideo/GBI.cpp
+++ b/src/Plugins.Win32.TASVideo/GBI.cpp
@@ -365,6 +365,10 @@ void GBI_MakeCurrent(MicrocodeInfo *current)
         GBI.cmd_headless[G_OBJ_RECTANGLE] = GBI_Nop;
         GBI.cmd_headless[G_OBJ_RECTANGLE_R] = GBI_Nop;
         GBI.cmd_headless[G_OBJ_SPRITE] = GBI_Nop;
+
+        GBI.cmd_headless[G_SETCOMBINE] = GBI_Nop;
+        GBI.cmd_headless[G_SETTILE] = GBI_Nop;
+        GBI.cmd_headless[G_SETTILESIZE] = GBI_Nop;
     }
 
     GBI.current = current;

--- a/src/Plugins.Win32.TASVideo/GBI.hpp
+++ b/src/Plugins.Win32.TASVideo/GBI.hpp
@@ -632,6 +632,7 @@ struct MicrocodeInfo
 struct GBIInfo
 {
     GBIFunc cmd[256];
+    GBIFunc cmd_headless[256];
 
     u32 PCStackSize, numMicrocodes;
     MicrocodeInfo *current, *top, *bottom;

--- a/src/Plugins.Win32.TASVideo/RSP.cpp
+++ b/src/Plugins.Win32.TASVideo/RSP.cpp
@@ -90,16 +90,21 @@ DWORD WINAPI RSP_ThreadProc(LPVOID)
 
 void RSP_ProcessDList()
 {
-    VI_UpdateSize();
-    OGL_UpdateScale();
+    const auto headless = g_ef->frame_skipped();
 
-    if (OGL.clear_override)
+    if (!headless)
     {
-        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-        glPushAttrib(GL_ENABLE_BIT);
-        glDisable(GL_SCISSOR_TEST);
-        glClear(GL_COLOR_BUFFER_BIT);
-        glPopAttrib();
+        VI_UpdateSize();
+        OGL_UpdateScale();
+
+        if (OGL.clear_override)
+        {
+            glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+            glPushAttrib(GL_ENABLE_BIT);
+            glDisable(GL_SCISSOR_TEST);
+            glClear(GL_COLOR_BUFFER_BIT);
+            glPopAttrib();
+        }
     }
 
     RSP.PC[0] = *(u32 *)&DMEM[0x0FF0];
@@ -142,6 +147,7 @@ void RSP_ProcessDList()
     gDPSetCycleType(G_CYC_1CYCLE);
     gDPPipelineMode(G_PM_NPRIMITIVE);
 
+    const auto cmds = headless ? GBI.cmd_headless : GBI.cmd;
     while (!RSP.halt)
     {
         if (RSP.PC[RSP.PCi] + 8 > RDRAMSize)
@@ -154,12 +160,10 @@ void RSP_ProcessDList()
         u32 w1 = *(u32 *)&RDRAM[RSP.PC[RSP.PCi] + 4];
         RSP.cmd = _SHIFTR(w0, 24, 8);
 
-        DebugMsg(L"0x%08lX: CMD=0x%02lX W0=0x%08lX W1=0x%08lX\n", RSP.PC[RSP.PCi], _SHIFTR(w0, 24, 8), w0, w1);
-
         RSP.PC[RSP.PCi] += 8;
         RSP.nextCmd = _SHIFTR(*(u32 *)&RDRAM[RSP.PC[RSP.PCi]], 24, 8);
 
-        GBI.cmd[RSP.cmd](w0, w1);
+        cmds[RSP.cmd](w0, w1);
     }
 
     RSP.busy = FALSE;

--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -233,6 +233,7 @@ static void start_audio_thread()
         .log_warn = [](const wchar_t *str) { logger->warn(str); },                                                     \
         .log_error = [](const wchar_t *str) { logger->error(str); },                                                   \
         .get_effective_speed_mode = [](void) { return g_main_ctx.core_ctx->vr_get_effective_speed_mode(); },           \
+        .frame_skipped = [](void) { return g_main_ctx.core_ctx->vr_get_frame_skipped(); },                             \
         .config_path = ext_fn_config_path,                                                                             \
     }
 


### PR DESCRIPTION
Optimizes the previous fix somewhat.

As it turns out, our previous optimization was desync-prone due to it not advancing RSP state as expected.

The aforementioned fix forces us through the full RSP+RDP business every frame, which ruins performance again (it's just undoing the optimization).

This PR improves performance again - but not to the initially optimized levl - and restores all the correct RSP advancing behavior.

changelog: skip