### PR TITLE
fix: plugin discovery dedupe logic being too strict

### DIFF
--- a/src/Views.Win32/Plugin.cpp
+++ b/src/Views.Win32/Plugin.cpp
@@ -709,7 +709,10 @@ t_plugin_discovery_result PluginUtil::discover_plugins(const std::filesystem::pa
     for (const auto &file : {g_config.selected_video_plugin, g_config.selected_audio_plugin,
                              g_config.selected_input_plugin, g_config.selected_rsp_plugin})
     {
-        auto it = std::find_if(results.begin(), results.end(), [&](const auto &pair) { return pair.first == file; });
+        auto it = std::find_if(results.begin(), results.end(), [&](const auto &pair) {
+            std::error_code ec;
+            return std::filesystem::equivalent(pair.first, file, ec);
+        });
         if (it != results.end()) continue;
 
         auto [result, plugin] = Plugin::create(file);


### PR DESCRIPTION
changelog: skip