### PR TITLE
build: make Linux builds work again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,20 +71,25 @@ endif()
 # Libraries
 # =======================================
 
-# pkg-config libraries
+# make sure pkg-config is available
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(speexdsp IMPORTED_TARGET GLOBAL "speexdsp")
-pkg_check_modules(libav IMPORTED_TARGET GLOBAL "libavformat" "libavcodec" "libavutil")
 
-# cmake libraries
-find_package(libdeflate CONFIG REQUIRED)
-find_package(nlohmann_json CONFIG REQUIRED)
-find_package(spdlog CONFIG REQUIRED)
+# Core cross-platform dependencies
 find_package(Catch2 CONFIG REQUIRED)
+find_package(libdeflate CONFIG REQUIRED)
+if (NOT WIN32)
+  pkg_check_modules(libsafec IMPORTED_TARGET GLOBAL "libsafec")
+endif()
 
+# Windows-only dependencies
 if(MUPEN64RR_BUILD_WIN32)
+  find_package(nlohmann_json CONFIG REQUIRED)
+  find_package(spdlog CONFIG REQUIRED)
   find_package(glew CONFIG REQUIRED)
   find_package(SDL3 CONFIG REQUIRED)
+
+  pkg_check_modules(speexdsp IMPORTED_TARGET GLOBAL "speexdsp")
+  pkg_check_modules(libav IMPORTED_TARGET GLOBAL "libavformat" "libavcodec" "libavutil")
 endif()
 
 # Lua, because Lua sucks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,10 @@ Only Windows is supported for now, though the CMake infrastructure is intended t
 |:-------------------------:|-----------------------------------------------------------------------|
 | `MUPEN64RR_USE_SANITIZER` | Specifies a sanitizer to compile with. [`{OFF, ASAN}`, default `OFF`] |
 
-## Windows/CMake
+## Windows
 You'll need:
 - Visual Studio 2026 (for the compiler, CMake, Ninja and vcpkg)
+  - Ensure the LLVM tools are installed (as we compile with Clang by default).
 
 In order for the compiler to work, you'll need to be in a VS developer environment. Then, simply use one of the provided presets to compile and build. If you want to change any settings, do so on the command line or via `CMakeUserPresets.json`.
 
@@ -48,6 +49,23 @@ If you aren't presented with a CMake profile selection dialog on startup, you ca
 All tasks required for development are available in the task panel.
 
 Visual Studio 2026 must be installed on the `C:` drive.
+
+## Linux
+You'll need:
+- A C/C++ compiler (`gcc` or `clang`)
+- `libdeflate`
+- `libsafec`
+
+> **NOTE:** 32-bit builds are not supported on Linux, as this would require far too many extra dependencies to be worth it.
+
+To build:
+```sh
+cmake --preset sys-linux64-x64
+cmake --build build
+```
+
+
+
 
 # Dependencies
 When adding CMake dependencies, ensure that dependencies specific to the frontend and/or plugins are wrapped inside an `if()` block. this will ensure cross-platform compatibility when the time comes for that.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,60 +1,52 @@
 
 # Compiling
 
-Only Windows is supported for now, though the CMake infrastructure is intended to ease the development of cross-platform code (for whoever decides to work on that).
+Only Windows supports compiling the full emulator. However, the core and VCR tests can be (experimentally) compiled on other platforms.
 
-## CMake Options
-| OPTION                    | DESCRIPTION                                                           |
-|:-------------------------:|-----------------------------------------------------------------------|
-| `MUPEN64RR_USE_SANITIZER` | Specifies a sanitizer to compile with. [`{OFF, ASAN}`, default `OFF`] |
+## Windows dependencies
 
-## Windows
 You'll need:
 - Visual Studio 2026 (for the compiler, CMake, Ninja and vcpkg)
   - Ensure the LLVM tools are installed (as we compile with Clang by default).
 
-In order for the compiler to work, you'll need to be in a VS developer environment. Then, simply use one of the provided presets to compile and build. If you want to change any settings, do so on the command line or via `CMakeUserPresets.json`.
+In order for the compiler to work, you'll need to be in a VS developer environment.
 
-For a 32-bit build:
-```sh
-cmake --preset vcpkg-win64-x86
-cmake --build build
-```
+## Linux dependencies
 
-For a 64-bit build:
-```sh
-cmake --preset vcpkg-win64-x64
-cmake --build build
-```
+You'll need:
+- A C/C++ compiler (`gcc` or `clang`)
+- `libdeflate`
+- `libsafec`
 
-The core VCR tests are integrated with CMake, so running the tests is easy:
-```sh
-ctest --test-dir build
-```
+`libsafec` is required outside of Windows as no other C/C++ library implements C11 Annex K, which specifies `strncpy_s` and similar functions.
 
-Presets have been provided for building and testing. These are intended for IDEs, so that they can properly autodetect things. Feel free to contribute IDE launch settings as appropriate.
+## CMake Presets
+Compiling is as easy as using one of the provided configure presets. All platforms generally use `clang` as the compiler and `Ninja` as the generator.
 
+|Preset|Platform|
+|:--|:--|
+|`vcpkg-win64-x86(-release)`|**32-bit** target on **64-bit Windows** host, dependencies via `vcpkg`|
+|`vcpkg-win64-x64(-release)`|**64-bit target** on **64-bit Windows** host, dependencies via `vcpkg`|
+|`sys-linux64-x64`|**64-bit** target, **64-bit Linux** host, dependencies from system|
 
 ### Visual Studio Code + CMake Tools
+Configure presets should be made available via CMake Tools, see above.
+
+#### Windows-only
 You'll need to enable `"cmake.useVsDeveloperEnvironment": "always"` in your workspace settings to convince CMake Tools to set up a VS developer environment.
 
 ### CLion
-
 Make sure to set the CMake profile to use the desired preset (`vcpkg-win64-x86` or `vcpkg-win64-x64`), enabling it if needed.
 
 If you aren't presented with a CMake profile selection dialog on startup, you can change the active profile by going to `File -> Settings -> Build, Execution, Deployment -> CMake`.
 
 ### Zed
-
 All tasks required for development are available in the task panel.
 
+#### Windows-only
 Visual Studio 2026 must be installed on the `C:` drive.
 
 ## Linux
-You'll need:
-- A C/C++ compiler (`gcc` or `clang`)
-- `libdeflate`
-- `libsafec`
 
 > **NOTE:** 32-bit builds are not supported on Linux, as this would require far too many extra dependencies to be worth it.
 
@@ -64,8 +56,10 @@ cmake --preset sys-linux64-x64
 cmake --build build
 ```
 
-
-
+The core VCR tests are integrated with CMake, so running the tests is easy:
+```sh
+ctest --test-dir build
+```
 
 # Dependencies
 When adding CMake dependencies, ensure that dependencies specific to the frontend and/or plugins are wrapped inside an `if()` block. this will ensure cross-platform compatibility when the time comes for that.

--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -20,6 +20,10 @@ target_include_directories(Mupen64RR.Common INTERFACE include)
 target_link_libraries(Mupen64RR.Common INTERFACE
     libdeflate::libdeflate_$<IF:$<TARGET_EXISTS:libdeflate::libdeflate_static>,static,shared>
     vendor::xxhash64
-    PkgConfig::libsafec
 )
 target_precompile_headers(Mupen64RR.Common INTERFACE "include/CommonPCH.hpp")
+
+# only MSVCRT implements C11 Annex K, libsafec is needed on other platforms
+if (NOT _WIN32)
+    target_link_libraries(Mupen64RR.Common INTERFACE PkgConfig::libsafec)
+endif()

--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -20,5 +20,6 @@ target_include_directories(Mupen64RR.Common INTERFACE include)
 target_link_libraries(Mupen64RR.Common INTERFACE
     libdeflate::libdeflate_$<IF:$<TARGET_EXISTS:libdeflate::libdeflate_static>,static,shared>
     vendor::xxhash64
+    PkgConfig::libsafec
 )
 target_precompile_headers(Mupen64RR.Common INTERFACE "include/CommonPCH.hpp")

--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -24,6 +24,6 @@ target_link_libraries(Mupen64RR.Common INTERFACE
 target_precompile_headers(Mupen64RR.Common INTERFACE "include/CommonPCH.hpp")
 
 # only MSVCRT implements C11 Annex K, libsafec is needed on other platforms
-if (NOT _WIN32)
+if (NOT WIN32)
     target_link_libraries(Mupen64RR.Common INTERFACE PkgConfig::libsafec)
 endif()

--- a/src/Common/include/CommonPCH.hpp
+++ b/src/Common/include/CommonPCH.hpp
@@ -41,15 +41,21 @@
 #include <variant>
 #include <vector>
 #include <latch>
+
+
 #if !defined(_WIN32)
+// Implementation of C11 Annex K for Linux
 #include <safe_str_lib.h>
 #endif
+
 #include <xxh64.h>
+
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_init.h>
 #include <SDL3/SDL_video.h>
 #include <SDL3/SDL_audio.h>
+
 #include "MiscHelpers.hpp"
 #include "StrUtils.hpp"
 #include "IOUtils.hpp"

--- a/src/Common/include/CommonPCH.hpp
+++ b/src/Common/include/CommonPCH.hpp
@@ -41,6 +41,9 @@
 #include <variant>
 #include <vector>
 #include <latch>
+#if !defined(_WIN32)
+#include <safe_str_lib.h>
+#endif
 #include <xxh64.h>
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_error.h>

--- a/src/Core/R4300/VCR.cpp
+++ b/src/Core/R4300/VCR.cpp
@@ -6,7 +6,6 @@
 
 #include "core_types.h"
 #include <CommonPCH.hpp>
-// #include <PlatformService.h>
 #include <Core.hpp>
 #include <cassert>
 #include <Cheats.hpp>


### PR DESCRIPTION
This also updates docs, but in general, the core builds on Linux again.

We will need to do more work once x64 dynarec is merged, as the context save/restore functions are incompatible with Linux.