### PR TITLE
fix: seek during capture mangling output

### DIFF
--- a/src/Core/Core.cpp
+++ b/src/Core/Core.cpp
@@ -108,6 +108,7 @@ core_result core_create(core_params *params, core_ctx **ctx)
     g_ctx.vr_get_rom_header = rom_get_rom_header;
     g_ctx.vr_country_code_to_country_name = rom_country_code_to_country_name;
     g_ctx.vr_on_speed_modifier_changed = timer_on_speed_modifier_changed;
+    g_ctx.vr_on_render_throttling_changed = vr_update_effective_speed_mode;
     g_ctx.vr_invalidate_visuals = vr_invalidate_visuals;
     g_ctx.vr_recompile = vr_recompile;
     g_ctx.vr_get_timings = timer_get_timings;

--- a/src/Core/R4300/R4300.cpp
+++ b/src/Core/R4300/R4300.cpp
@@ -209,7 +209,8 @@ void vr_update_effective_speed_mode()
         std::unique_lock lock(vcr_mtx);
         if (vcr.seek_to_frame.has_value())
         {
-            g_r4300.effective_speed_mode = CoreSpeedMode::UltraFastForward;
+            g_r4300.effective_speed_mode =
+                g_core->cfg->render_throttling ? CoreSpeedMode::UltraFastForward : CoreSpeedMode::FastForward;
             return;
         }
     }

--- a/src/Core/include/core_api.h
+++ b/src/Core/include/core_api.h
@@ -436,6 +436,12 @@ extern "C"
         std::function<void()> vr_on_speed_modifier_changed;
 
         /**
+         * \brief Updates internal state after `cfg->render_throttling` changes.
+         * Must be called from a thread that's not coupled to the emulator thread (or the emulator thread itself).
+         */
+        std::function<void()> vr_on_render_throttling_changed;
+
+        /**
          * \brief Invalidates the visuals, allowing an updateScreen call to happen.
          */
         std::function<void()> vr_invalidate_visuals;

--- a/src/Views.Win32/capture/CaptureManager.cpp
+++ b/src/Views.Win32/capture/CaptureManager.cpp
@@ -299,6 +299,7 @@ bool stop_capture_impl()
 
     m_capturing = false;
     g_config.core.render_throttling = true;
+    g_main_ctx.core_ctx->vr_on_render_throttling_changed();
 
     Messenger::broadcast(Messenger::Message::CapturingChanged, false);
 
@@ -374,6 +375,7 @@ bool start_capture_impl(std::filesystem::path path, t_config::EncoderType encode
 
     m_capturing = true;
     g_config.core.render_throttling = false;
+    g_main_ctx.core_ctx->vr_on_render_throttling_changed();
 
     Messenger::broadcast(Messenger::Message::CapturingChanged, true);
 


### PR DESCRIPTION
It now behaves the same as ff during capture (i.e. when render throttling is disabled).