### PR TITLE
fix(Core): crash when compiling cheats with empty lines

### DIFF
--- a/src/Core/Cheats.cpp
+++ b/src/Core/Cheats.cpp
@@ -27,7 +27,7 @@ bool cht_compile(std::string_view code, core_cheat &cheat)
 
     for (auto line : MiscHelpers::split_string(code, "\n"))
     {
-        if (line[0] == '$' || line[0] == '-' || line.size() < 13)
+        if (line.size() < 13 || line[0] == '$' || line[0] == '-')
         {
             g_core->log_info("[GS] Line skipped");
             continue;


### PR DESCRIPTION
`cht_compile` reads `line[0]` before the `line.size() < 13` check in the same `if`. When the cheat code contains a blank line, `split_string` yields an empty `string_view` and `line[0]` reads out of bounds, which crashes the emulator on compile.

Moving the size check to the front of the `||` short-circuits on empty and too-short lines before any indexing, so blank lines are skipped as intended. Valid lines still reach the parse path unchanged. Fixes #843.
