### PR TITLE
fix: crash loading ROMs with names that aren't valid UTF-8

### DIFF
--- a/src/Common/include/IOUtils.hpp
+++ b/src/Common/include/IOUtils.hpp
@@ -270,8 +270,6 @@ inline std::string to_utf8_string(std::wstring_view wstr)
  */
 inline std::wstring rom_name_to_wide_string(std::string_view str)
 {
-    assert(str.size() < INT_MAX / 2); // sanity check
-
     if (str.empty())
     {
         return {};
@@ -315,10 +313,6 @@ inline std::wstring rom_name_to_wide_string(std::string_view str)
 /**
  * \brief Converts a raw ROM header name into a path component.
  * \param str The raw header bytes.
- *
- * Handing header bytes to std::filesystem::path directly throws std::system_error (ERROR_NO_UNICODE_TRANSLATION) for
- * every ROM whose name isn't valid UTF-8, because the app manifest sets the process code page to UTF-8 and the STL
- * validates strictly when converting a narrow string to a path.
  */
 inline std::filesystem::path rom_name_to_path_component(const std::string_view str)
 {

--- a/src/Common/include/IOUtils.hpp
+++ b/src/Common/include/IOUtils.hpp
@@ -258,7 +258,76 @@ inline std::string to_utf8_string(std::wstring_view wstr)
     return output;
 }
 
+/**
+ * \brief Decodes a raw ROM header name into a wide string.
+ * \param str The raw header bytes.
+ *
+ * The N64 SDK specifies the header name field as JIS X 0201 / Shift-JIS. ASCII is a subset of it, so western ROM
+ * names decode byte-identically, while Japanese ROM names decode to the characters they actually contain.
+ *
+ * Unlike to_wide_string, this never fails: header bytes are unvalidated binary data and are frequently not valid
+ * UTF-8, so a strict conversion would either throw or silently yield an empty name.
+ */
+inline std::wstring rom_name_to_wide_string(std::string_view str)
+{
+    assert(str.size() < INT_MAX / 2); // sanity check
+
+    if (str.empty())
+    {
+        return {};
+    }
+
+    std::wstring output;
+
+    // Note the absence of MB_ERR_INVALID_CHARS: unmappable sequences have to degrade to the code page's default
+    // character instead of failing the call, since nothing guarantees the header is well-formed.
+    int rc = MultiByteToWideChar(932, 0, str.data(), str.size(), nullptr, 0);
+    if (rc > 0)
+    {
+        output.resize(static_cast<size_t>(rc), L'\0');
+
+        rc = MultiByteToWideChar(932, 0, str.data(), str.size(), output.data(), output.size());
+        if (rc <= 0)
+        {
+            output.clear();
+        }
+    }
+
+    if (output.empty())
+    {
+        // Code page 932 isn't available on this system. Map each byte to the codepoint of the same value, so that
+        // distinct ROMs still end up with distinct names.
+        output.reserve(str.size());
+        for (const char c : str)
+        {
+            output.push_back(static_cast<wchar_t>(static_cast<uint8_t>(c)));
+        }
+    }
+
+    return output;
+}
+
 #endif
+
+// ROM HEADER NAME CONVERSION
+// ==============================
+
+/**
+ * \brief Converts a raw ROM header name into a path component.
+ * \param str The raw header bytes.
+ *
+ * Handing header bytes to std::filesystem::path directly throws std::system_error (ERROR_NO_UNICODE_TRANSLATION) for
+ * every ROM whose name isn't valid UTF-8, because the app manifest sets the process code page to UTF-8 and the STL
+ * validates strictly when converting a narrow string to a path.
+ */
+inline std::filesystem::path rom_name_to_path_component(const std::string_view str)
+{
+#ifdef _WIN32
+    return {rom_name_to_wide_string(str)};
+#else
+    return {str};
+#endif
+}
 
 // PORTABLE EQUIVALENTS
 // ==============================

--- a/src/Core.Tests/CMakeLists.txt
+++ b/src/Core.Tests/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 add_executable(Mupen64RR.Core.Tests
     "stdafx.h"
+    "IOUtilsTests.cpp"
     "VCRTests.cpp"
     "VRTests.cpp"
 )

--- a/src/Core.Tests/IOUtilsTests.cpp
+++ b/src/Core.Tests/IOUtilsTests.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "stdafx.h"
+
+// Shift-JIS bytes, as found in the header name field of Japanese ROMs. These are not valid UTF-8: 0x83 can't start a
+// sequence, so converting them to a path with the strict STL conversion throws ERROR_NO_UNICODE_TRANSLATION.
+static constexpr char JAPANESE_NAME[] = "\x83\x65\x83\x58\x83\x67";               // テスト
+static constexpr char OTHER_JAPANESE_NAME[] = "\x83\x43\x83\x89\x83\x43\x83\x89"; // イライラ
+
+TEST_CASE("ascii_rom_name_is_unchanged", "rom_name_to_path_component")
+{
+    // Save files on disk are named after what this produced before, so ASCII names have to stay byte-identical.
+    REQUIRE(IOUtils::rom_name_to_path_component("SUPER MARIO 64") == std::filesystem::path("SUPER MARIO 64"));
+}
+
+TEST_CASE("empty_rom_name_yields_empty_component", "rom_name_to_path_component")
+{
+    REQUIRE(IOUtils::rom_name_to_path_component("").empty());
+}
+
+TEST_CASE("non_utf8_rom_name_does_not_throw", "rom_name_to_path_component")
+{
+    REQUIRE_NOTHROW(IOUtils::rom_name_to_path_component(JAPANESE_NAME));
+    REQUIRE(!IOUtils::rom_name_to_path_component(JAPANESE_NAME).empty());
+}
+
+TEST_CASE("distinct_non_utf8_rom_names_stay_distinct", "rom_name_to_path_component")
+{
+    // Otherwise two Japanese ROMs would share the same save files.
+    REQUIRE(IOUtils::rom_name_to_path_component(JAPANESE_NAME) !=
+            IOUtils::rom_name_to_path_component(OTHER_JAPANESE_NAME));
+}

--- a/src/Core/Memory/Savestates.cpp
+++ b/src/Core/Memory/Savestates.cpp
@@ -69,7 +69,7 @@ uint8_t g_first_block[0xA02BB4 - 32]{};
 std::vector<uint8_t> g_undo_savestate;
 void get_paths_for_task(const t_savestate_task &task, std::filesystem::path &st_path, std::filesystem::path &sd_path)
 {
-    sd_path = g_core->get_saves_directory() / (const char *)ROM_HEADER.nom;
+    sd_path = g_core->get_saves_directory() / IOUtils::rom_name_to_path_component((const char *)ROM_HEADER.nom);
     sd_path.replace_extension(".vhd");
 }
 

--- a/src/Core/R4300/R4300.cpp
+++ b/src/Core/R4300/R4300.cpp
@@ -100,9 +100,6 @@ bool vr_is_ceqs_effectively_accurate()
     return g_core->cfg->c_eq_s_nan_accurate;
 }
 
-// Builds "<saves directory>/<rom name> <country><extension>".
-// The ROM name goes through rom_name_to_path_component because it's raw header data: appending it to a path as a
-// narrow string throws for every ROM whose name isn't valid UTF-8, which is the case for Japanese ROMs.
 static std::filesystem::path get_save_path(const std::string_view extension)
 {
     auto filename = IOUtils::rom_name_to_path_component((const char *)ROM_HEADER.nom);

--- a/src/Core/R4300/R4300.cpp
+++ b/src/Core/R4300/R4300.cpp
@@ -100,32 +100,35 @@ bool vr_is_ceqs_effectively_accurate()
     return g_core->cfg->c_eq_s_nan_accurate;
 }
 
+// Builds "<saves directory>/<rom name> <country><extension>".
+// The ROM name goes through rom_name_to_path_component because it's raw header data: appending it to a path as a
+// narrow string throws for every ROM whose name isn't valid UTF-8, which is the case for Japanese ROMs.
+static std::filesystem::path get_save_path(const std::string_view extension)
+{
+    auto filename = IOUtils::rom_name_to_path_component((const char *)ROM_HEADER.nom);
+    filename += std::format(" {}{}", g_ctx.vr_country_code_to_country_name(ROM_HEADER.Country_code), extension);
+
+    return g_core->get_saves_directory() / filename;
+}
+
 std::filesystem::path get_sram_path()
 {
-    auto filename = std::format("{} {}.sra", (const char *)ROM_HEADER.nom,
-                                g_ctx.vr_country_code_to_country_name(ROM_HEADER.Country_code));
-    return g_core->get_saves_directory() / filename;
+    return get_save_path(".sra");
 }
 
 std::filesystem::path get_eeprom_path()
 {
-    auto filename = std::format("{} {}.eep", (const char *)ROM_HEADER.nom,
-                                g_ctx.vr_country_code_to_country_name(ROM_HEADER.Country_code));
-    return g_core->get_saves_directory() / filename;
+    return get_save_path(".eep");
 }
 
 std::filesystem::path get_flashram_path()
 {
-    auto filename = std::format("{} {}.fla", (const char *)ROM_HEADER.nom,
-                                g_ctx.vr_country_code_to_country_name(ROM_HEADER.Country_code));
-    return g_core->get_saves_directory() / filename;
+    return get_save_path(".fla");
 }
 
 std::filesystem::path get_mempak_path()
 {
-    auto filename = std::format("{} {}.mpk", (const char *)ROM_HEADER.nom,
-                                g_ctx.vr_country_code_to_country_name(ROM_HEADER.Country_code));
-    return g_core->get_saves_directory() / filename;
+    return get_save_path(".mpk");
 }
 
 void vr_resume_emu_impl(bool force)

--- a/src/Views.Win32/Main.cpp
+++ b/src/Views.Win32/Main.cpp
@@ -203,7 +203,7 @@ std::filesystem::path get_st_with_slot_path(const size_t slot)
 {
     const auto hdr = g_main_ctx.core_ctx->vr_get_rom_header();
     const auto fname =
-        std::format(L"{} {}.st{}", IOUtils::to_wide_string((const char *)hdr->nom),
+        std::format(L"{} {}.st{}", IOUtils::rom_name_to_wide_string((const char *)hdr->nom),
                     IOUtils::to_wide_string(g_main_ctx.core_ctx->vr_country_code_to_country_name(hdr->Country_code)),
                     std::to_wstring(slot));
     return Config::save_directory() / fname;
@@ -293,7 +293,8 @@ static std::wstring get_titlebar_text()
 
     if (g_main_ctx.core_ctx->vr_get_launched())
         text += std::format(
-            L" - {}", IOUtils::to_wide_string(reinterpret_cast<char *>(g_main_ctx.core_ctx->vr_get_rom_header()->nom)));
+            L" - {}",
+            IOUtils::rom_name_to_wide_string(reinterpret_cast<char *>(g_main_ctx.core_ctx->vr_get_rom_header()->nom)));
 
     if (g_main_ctx.core_ctx->vcr_get_task() != task_idle)
     {

--- a/src/Views.Win32/Main.cpp
+++ b/src/Views.Win32/Main.cpp
@@ -292,9 +292,8 @@ static std::wstring get_titlebar_text()
     if (g_emu_starting) text += L" - Starting...";
 
     if (g_main_ctx.core_ctx->vr_get_launched())
-        text += std::format(
-            L" - {}",
-            IOUtils::rom_name_to_wide_string(reinterpret_cast<char *>(g_main_ctx.core_ctx->vr_get_rom_header()->nom)));
+        text += std::format(L" - {}", IOUtils::rom_name_to_wide_string(
+                                          reinterpret_cast<char *>(g_main_ctx.core_ctx->vr_get_rom_header()->nom)));
 
     if (g_main_ctx.core_ctx->vcr_get_task() != task_idle)
     {

--- a/src/Views.Win32/components/RomBrowser.cpp
+++ b/src/Views.Win32/components/RomBrowser.cpp
@@ -365,7 +365,7 @@ notify(LPARAM lparam)
             {
                 g_view_logger->error("Failed to copy rom name");
             }
-            StrNCpy(plvdi->item.pszText, IOUtils::to_wide_string(str).c_str(), plvdi->item.cchTextMax);
+            StrNCpy(plvdi->item.pszText, IOUtils::rom_name_to_wide_string(str).c_str(), plvdi->item.cchTextMax);
             break;
         }
         case 2: {


### PR DESCRIPTION
### Problem
Loading a Japanese ROM crashes the emulator. WinDbg shows exception 0xceadbeef with a stack that always points at ThreadPool.cpp:25, which is the funnel that rethrows and destroys the original stack the real crash site was R4300.cpp in the save-path helpers.

### Root cause
The N64 header name field at 0x20 is JIS X 0201 / Shift-JIS, not UTF-8. get_eeprom_path() and friends built their path with std::format("{} {}{}", (const char*)ROM_HEADER.nom, country, ext), feeding those raw bytes straight into std::filesystem::path.

Because app.manifest sets <activeCodePage>UTF-8</activeCodePage>, MSVC's __std_fs_code_page() returns _Utf8, so the narrow-to-wide conversion runs MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, …). On a Shift-JIS name that fails with ERROR_NO_UNICODE_TRANSLATION (1113) and throws a bare std::system_error, which escapes into the thread pool.

The same silent truncation also affected the window title, the ROM browser and the savestate directory, so distinct Japanese ROMs could collapse onto the same savestate slots.

### Fix
Adds rom_name_to_wide_string() and rom_name_to_path_component() in IOUtils.hpp. They convert through code page 932 without MB_ERR_INVALID_CHARS nothing guarantees a ROM header is well-formed, so unmappable sequences must degrade to the code page's default character instead of throwing. If CP932 is unavailable, each byte maps to the codepoint of the same value so the name stays distinct rather than becoming empty.

The four duplicated save-path getters in R4300.cpp are folded into a single get_save_path(extension).

### Tests
Four Catch2 cases in Core.Tests/IOUtilsTests.cpp: ASCII names are unchanged, empty input yields empty output, non-UTF-8 input does not throw, and two distinct Japanese names stay distinct (this is the one that guards the savestate-slot collision).

### Scope
No emulation behaviour is changed this only touches how header bytes are turned into paths and display strings. No timing impact, so existing movies are unaffected.