### PR TITLE
chore: make copyright headers consistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,10 +89,13 @@ All development happens on `main`. We cherry-pick from `main` into release branc
 Every non-library file must contain a copyright header with this content:
 
 ```
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ```
+
+The header is the same everywhere; only the comment syntax changes per file type. Project-specific credits to
+original authors belong in the `NOTICE` file, not in per-file headers.
 
 # Commit Style
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,9 @@
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+
+SPDX-License-Identifier: GPL-2.0-or-later
+
+Source files carry that notice verbatim. The project-specific credits below record the prior authorship they build on.
+
 Original Authors
 ==================
 

--- a/docs/lua/examples/emu/atd2ddraw.lua
+++ b/docs/lua/examples/emu/atd2ddraw.lua
@@ -1,3 +1,9 @@
+--
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
 local brush = d2d.create_brush(1, 0, 0, 1)
 
 emu.atdrawd2d(function()

--- a/docs/lua/examples/emu/atinput.lua
+++ b/docs/lua/examples/emu/atinput.lua
@@ -1,3 +1,9 @@
+--
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
 local counter = 0;
 emu.atinput(function()
 	if counter % 2 == 0 then

--- a/docs/lua/examples/emu/atstop.lua
+++ b/docs/lua/examples/emu/atstop.lua
@@ -1,3 +1,9 @@
+--
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
 emu.atstop(function ()
 	
 end)

--- a/docs/lua/examples/emu/atupdatescreen.lua
+++ b/docs/lua/examples/emu/atupdatescreen.lua
@@ -1,3 +1,9 @@
+--
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
 -- every screen update
 emu.atupdatescreen(function()
 	-- draw a 30x30 red square at (10, 10)

--- a/docs/lua/examples/emu/atvi.lua
+++ b/docs/lua/examples/emu/atvi.lua
@@ -1,3 +1,9 @@
+--
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
 -- runs 60 times per second on Super Mario 64
 emu.atvi(function()
 	local vis = emu.framecount()

--- a/docs/lua/examples/emu/console.lua
+++ b/docs/lua/examples/emu/console.lua
@@ -1,3 +1,9 @@
+--
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
 ---@diagnostic disable: deprecated
 
 emu.console("some text\r\n")

--- a/docs/lua/examples/emu/statusbar.lua
+++ b/docs/lua/examples/emu/statusbar.lua
@@ -1,3 +1,9 @@
+--
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
 emu.statusbar("a cool statusbar message")
 
 emu.atinterval(function()

--- a/docs/lua/examples/global/print.lua
+++ b/docs/lua/examples/global/print.lua
@@ -1,3 +1,9 @@
+--
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
 -- prints numbers
 print(4)
 print(0.42)

--- a/docs/lua/examples/global/stop.lua
+++ b/docs/lua/examples/global/stop.lua
@@ -1,3 +1,9 @@
+--
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
 -- runs constantly
 emu.atinterval(function()
 	print("Script is running!")

--- a/docs/lua/examples/savestate/do_memory.lua
+++ b/docs/lua/examples/savestate/do_memory.lua
@@ -1,3 +1,9 @@
+--
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
 local savestate_buffer = ""
 
 savestate.do_memory("", "save", function (result, data)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Common.Win32/CMakeLists.txt
+++ b/src/Common.Win32/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Common.Win32/include/JoystickControl.hpp
+++ b/src/Common.Win32/include/JoystickControl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Common.Win32/include/WinFilePicker.hpp
+++ b/src/Common.Win32/include/WinFilePicker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Common/include/CommonPCH.hpp
+++ b/src/Common/include/CommonPCH.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #pragma warning(push, 0)

--- a/src/Common/include/DummyPluginStub.hpp
+++ b/src/Common/include/DummyPluginStub.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Common/include/FNV1A.hpp
+++ b/src/Common/include/FNV1A.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Common/include/IOUtils.hpp
+++ b/src/Common/include/IOUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Common/include/MiscHelpers.hpp
+++ b/src/Common/include/MiscHelpers.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Common/include/StrUtils.hpp
+++ b/src/Common/include/StrUtils.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include <string_view>

--- a/src/Common/include/VersionNameHelpers.hpp
+++ b/src/Common/include/VersionNameHelpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core.Tests/CMakeLists.txt
+++ b/src/Core.Tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Core.Tests/IOUtilsTests.cpp
+++ b/src/Core.Tests/IOUtilsTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core.Tests/VCRTests.cpp
+++ b/src/Core.Tests/VCRTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core.Tests/VRTests.cpp
+++ b/src/Core.Tests/VRTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core.Tests/stdafx.h
+++ b/src/Core.Tests/stdafx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Alloc.cpp
+++ b/src/Core/Alloc.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Alloc.hpp
+++ b/src/Core/Alloc.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Core/Cheats.cpp
+++ b/src/Core/Cheats.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Cheats.hpp
+++ b/src/Core/Cheats.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Core.cpp
+++ b/src/Core/Core.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Core.hpp
+++ b/src/Core/Core.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/DMA.cpp
+++ b/src/Core/Memory/DMA.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/DMA.hpp
+++ b/src/Core/Memory/DMA.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/FlashRAM.cpp
+++ b/src/Core/Memory/FlashRAM.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/FlashRAM.hpp
+++ b/src/Core/Memory/FlashRAM.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/Memory.cpp
+++ b/src/Core/Memory/Memory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/Memory.hpp
+++ b/src/Core/Memory/Memory.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/ParityChecker.cpp
+++ b/src/Core/Memory/ParityChecker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/ParityChecker.hpp
+++ b/src/Core/Memory/ParityChecker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/Pif.cpp
+++ b/src/Core/Memory/Pif.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/Pif.hpp
+++ b/src/Core/Memory/Pif.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/PifLut.cpp
+++ b/src/Core/Memory/PifLut.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/PifLut.hpp
+++ b/src/Core/Memory/PifLut.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/Savestates.cpp
+++ b/src/Core/Memory/Savestates.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/Savestates.hpp
+++ b/src/Core/Memory/Savestates.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/Summercart.cpp
+++ b/src/Core/Memory/Summercart.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/Summercart.hpp
+++ b/src/Core/Memory/Summercart.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/TLB.cpp
+++ b/src/Core/Memory/TLB.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/Memory/TLB.hpp
+++ b/src/Core/Memory/TLB.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/BC.cpp
+++ b/src/Core/R4300/BC.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Cop0.cpp
+++ b/src/Core/R4300/Cop0.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Cop1.cpp
+++ b/src/Core/R4300/Cop1.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Cop1D.cpp
+++ b/src/Core/R4300/Cop1D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Cop1Helpers.cpp
+++ b/src/Core/R4300/Cop1Helpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Cop1Helpers.hpp
+++ b/src/Core/R4300/Cop1Helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Cop1L.cpp
+++ b/src/Core/R4300/Cop1L.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Cop1S.cpp
+++ b/src/Core/R4300/Cop1S.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Cop1W.cpp
+++ b/src/Core/R4300/Cop1W.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Debug.cpp
+++ b/src/Core/R4300/Debug.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Debug.hpp
+++ b/src/Core/R4300/Debug.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Disasm.cpp
+++ b/src/Core/R4300/Disasm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Disasm.hpp
+++ b/src/Core/R4300/Disasm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Exception.cpp
+++ b/src/Core/R4300/Exception.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Exception.hpp
+++ b/src/Core/R4300/Exception.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Interrupt.cpp
+++ b/src/Core/R4300/Interrupt.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Interrupt.hpp
+++ b/src/Core/R4300/Interrupt.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Macros.hpp
+++ b/src/Core/R4300/Macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Ops.hpp
+++ b/src/Core/R4300/Ops.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/PureInterp.cpp
+++ b/src/Core/R4300/PureInterp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/R4300.cpp
+++ b/src/Core/R4300/R4300.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/R4300.hpp
+++ b/src/Core/R4300/R4300.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Recomp.cpp
+++ b/src/Core/R4300/Recomp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Recomp.hpp
+++ b/src/Core/R4300/Recomp.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Recomph.hpp
+++ b/src/Core/R4300/Recomph.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/RegImm.cpp
+++ b/src/Core/R4300/RegImm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Rom.cpp
+++ b/src/Core/R4300/Rom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Rom.hpp
+++ b/src/Core/R4300/Rom.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Special.cpp
+++ b/src/Core/R4300/Special.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Timers.cpp
+++ b/src/Core/R4300/Timers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Timers.hpp
+++ b/src/Core/R4300/Timers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Tracelog.cpp
+++ b/src/Core/R4300/Tracelog.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/Tracelog.hpp
+++ b/src/Core/R4300/Tracelog.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/VCR.cpp
+++ b/src/Core/R4300/VCR.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/VCR.hpp
+++ b/src/Core/R4300/VCR.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/Assemble.cpp
+++ b/src/Core/R4300/x86/Assemble.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/Assemble.hpp
+++ b/src/Core/R4300/x86/Assemble.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GBc.cpp
+++ b/src/Core/R4300/x86/GBc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GCop0.cpp
+++ b/src/Core/R4300/x86/GCop0.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GCop1.cpp
+++ b/src/Core/R4300/x86/GCop1.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GCop1D.cpp
+++ b/src/Core/R4300/x86/GCop1D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GCop1Helpers.cpp
+++ b/src/Core/R4300/x86/GCop1Helpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GCop1L.cpp
+++ b/src/Core/R4300/x86/GCop1L.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GCop1S.cpp
+++ b/src/Core/R4300/x86/GCop1S.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GCop1W.cpp
+++ b/src/Core/R4300/x86/GCop1W.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GR4300.cpp
+++ b/src/Core/R4300/x86/GR4300.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GRegImm.cpp
+++ b/src/Core/R4300/x86/GRegImm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GSpecial.cpp
+++ b/src/Core/R4300/x86/GSpecial.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/GTLB.cpp
+++ b/src/Core/R4300/x86/GTLB.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/Gcop1Helpers.hpp
+++ b/src/Core/R4300/x86/Gcop1Helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/RJump.cpp
+++ b/src/Core/R4300/x86/RJump.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/RegCache.cpp
+++ b/src/Core/R4300/x86/RegCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86/RegCache.hpp
+++ b/src/Core/R4300/x86/RegCache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/Assemble.cpp
+++ b/src/Core/R4300/x86_64/Assemble.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/Assemble.hpp
+++ b/src/Core/R4300/x86_64/Assemble.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GBc.cpp
+++ b/src/Core/R4300/x86_64/GBc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GCop0.cpp
+++ b/src/Core/R4300/x86_64/GCop0.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GCop1.cpp
+++ b/src/Core/R4300/x86_64/GCop1.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GCop1D.cpp
+++ b/src/Core/R4300/x86_64/GCop1D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GCop1Helpers.cpp
+++ b/src/Core/R4300/x86_64/GCop1Helpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GCop1L.cpp
+++ b/src/Core/R4300/x86_64/GCop1L.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GCop1S.cpp
+++ b/src/Core/R4300/x86_64/GCop1S.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GCop1W.cpp
+++ b/src/Core/R4300/x86_64/GCop1W.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GR4300.cpp
+++ b/src/Core/R4300/x86_64/GR4300.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GRegImm.cpp
+++ b/src/Core/R4300/x86_64/GRegImm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GSpecial.cpp
+++ b/src/Core/R4300/x86_64/GSpecial.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/GTLB.cpp
+++ b/src/Core/R4300/x86_64/GTLB.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/Gcop1Helpers.hpp
+++ b/src/Core/R4300/x86_64/Gcop1Helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/RJump.cpp
+++ b/src/Core/R4300/x86_64/RJump.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/RegCache.cpp
+++ b/src/Core/R4300/x86_64/RegCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/R4300/x86_64/RegCache.hpp
+++ b/src/Core/R4300/x86_64/RegCache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/include/m64rr/API.hpp
+++ b/src/Core/include/m64rr/API.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Core/include/m64rr/Types.hpp
+++ b/src/Core/include/m64rr/Types.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Lua.TestLib/CMakeLists.txt
+++ b/src/Lua.TestLib/CMakeLists.txt
@@ -1,3 +1,9 @@
+#[===[
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+
+SPDX-License-Identifier: GPL-2.0-or-later
+]===]
+
 add_library(Mupen64RR.Lua.TestLib MODULE "main.cpp")
 set_target_properties(Mupen64RR.Lua.TestLib PROPERTIES
     CXX_STANDARD 23

--- a/src/Lua.TestLib/main.cpp
+++ b/src/Lua.TestLib/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Lua/api.lua
+++ b/src/Lua/api.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/302.lua
+++ b/src/Lua/manual/302.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/336.lua
+++ b/src/Lua/manual/336.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/420.lua
+++ b/src/Lua/manual/420.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/action_system.lua
+++ b/src/Lua/manual/action_system.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/atkey.lua
+++ b/src/Lua/manual/atkey.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/atkey_received_when_hotkeys_locked.lua
+++ b/src/Lua/manual/atkey_received_when_hotkeys_locked.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/atmouse.lua
+++ b/src/Lua/manual/atmouse.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/base_manual_test.lua
+++ b/src/Lua/manual/base_manual_test.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/d2d_drawimage2_tint.lua
+++ b/src/Lua/manual/d2d_drawimage2_tint.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/debugger.lua
+++ b/src/Lua/manual/debugger.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/empty.lua
+++ b/src/Lua/manual/empty.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/env_usage_in_atstop_after_error.lua
+++ b/src/Lua/manual/env_usage_in_atstop_after_error.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/hotkey_prompt.lua
+++ b/src/Lua/manual/hotkey_prompt.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/input.prompt.lua
+++ b/src/Lua/manual/input.prompt.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/os.exit.lua
+++ b/src/Lua/manual/os.exit.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/print_in_atstop.lua
+++ b/src/Lua/manual/print_in_atstop.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/print_in_global.lua
+++ b/src/Lua/manual/print_in_global.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/manual/savestate_fastforward_concurrency.lua
+++ b/src/Lua/manual/savestate_fastforward_concurrency.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/sandbox.lua
+++ b/src/Lua/sandbox.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/shims.lua
+++ b/src/Lua/shims.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/test_prelude.lua
+++ b/src/Lua/test_prelude.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Lua/tests.lua
+++ b/src/Lua/tests.lua
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+-- Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 --
 -- SPDX-License-Identifier: GPL-2.0-or-later
 --

--- a/src/Plugins.Common.cmake
+++ b/src/Plugins.Common.cmake
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Plugins.Win32.DummyAudio/CMakeLists.txt
+++ b/src/Plugins.Win32.DummyAudio/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Plugins.Win32.DummyAudio/Main.cpp
+++ b/src/Plugins.Win32.DummyAudio/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.DummyInput/CMakeLists.txt
+++ b/src/Plugins.Win32.DummyInput/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Plugins.Win32.DummyInput/Main.cpp
+++ b/src/Plugins.Win32.DummyInput/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.DummyVideo/CMakeLists.txt
+++ b/src/Plugins.Win32.DummyVideo/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Plugins.Win32.DummyVideo/Main.cpp
+++ b/src/Plugins.Win32.DummyVideo/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/CMakeLists.txt
+++ b/src/Plugins.Win32.TASAudio/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Plugins.Win32.TASAudio/Config.cpp
+++ b/src/Plugins.Win32.TASAudio/Config.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/Config.hpp
+++ b/src/Plugins.Win32.TASAudio/Config.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/Config_Win32.cpp
+++ b/src/Plugins.Win32.TASAudio/Config_Win32.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/Config_Win32.hpp
+++ b/src/Plugins.Win32.TASAudio/Config_Win32.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/Main.cpp
+++ b/src/Plugins.Win32.TASAudio/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/Main.hpp
+++ b/src/Plugins.Win32.TASAudio/Main.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/Main_Win32.cpp
+++ b/src/Plugins.Win32.TASAudio/Main_Win32.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/Main_Win32.hpp
+++ b/src/Plugins.Win32.TASAudio/Main_Win32.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/Resource.h
+++ b/src/Plugins.Win32.TASAudio/Resource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/Resource.rc
+++ b/src/Plugins.Win32.TASAudio/Resource.rc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/SDLBackend.cpp
+++ b/src/Plugins.Win32.TASAudio/SDLBackend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASAudio/SDLBackend.hpp
+++ b/src/Plugins.Win32.TASAudio/SDLBackend.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/CMakeLists.txt
+++ b/src/Plugins.Win32.TASInput/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Plugins.Win32.TASInput/Combo.cpp
+++ b/src/Plugins.Win32.TASInput/Combo.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/Combo.hpp
+++ b/src/Plugins.Win32.TASInput/Combo.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/Common.hpp
+++ b/src/Plugins.Win32.TASInput/Common.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/ConfigDialog.cpp
+++ b/src/Plugins.Win32.TASInput/ConfigDialog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/ConfigDialog.hpp
+++ b/src/Plugins.Win32.TASInput/ConfigDialog.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/GamepadManager.cpp
+++ b/src/Plugins.Win32.TASInput/GamepadManager.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/GamepadManager.hpp
+++ b/src/Plugins.Win32.TASInput/GamepadManager.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/Helpers.hpp
+++ b/src/Plugins.Win32.TASInput/Helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/Main.cpp
+++ b/src/Plugins.Win32.TASInput/Main.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/Main.hpp
+++ b/src/Plugins.Win32.TASInput/Main.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/NewConfig.cpp
+++ b/src/Plugins.Win32.TASInput/NewConfig.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/NewConfig.hpp
+++ b/src/Plugins.Win32.TASInput/NewConfig.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/Resource.h
+++ b/src/Plugins.Win32.TASInput/Resource.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 //{{NO_DEPENDENCIES}}
 // Von Microsoft Visual C++ generierte Includedatei.
 // Verwendet durch Resource.rc

--- a/src/Plugins.Win32.TASInput/Resource.rc
+++ b/src/Plugins.Win32.TASInput/Resource.rc
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
  // Microsoft Visual C++ generated resource script.
 //
 #include "resource.h"

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASInput/TASInput.hpp
+++ b/src/Plugins.Win32.TASInput/TASInput.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, TASInput maintainers, contributors, and original authors (nitsuja, Deflection).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASRSP/CMakeLists.txt
+++ b/src/Plugins.Win32.TASRSP/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Plugins.Win32.TASRSP/Config.cpp
+++ b/src/Plugins.Win32.TASRSP/Config.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASRSP/Config.hpp
+++ b/src/Plugins.Win32.TASRSP/Config.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASRSP/HLE.hpp
+++ b/src/Plugins.Win32.TASRSP/HLE.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASRSP/JPEG.cpp
+++ b/src/Plugins.Win32.TASRSP/JPEG.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASRSP/MP3.cpp
+++ b/src/Plugins.Win32.TASRSP/MP3.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASRSP/Main.cpp
+++ b/src/Plugins.Win32.TASRSP/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASRSP/Main.hpp
+++ b/src/Plugins.Win32.TASRSP/Main.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASRSP/UCode1.cpp
+++ b/src/Plugins.Win32.TASRSP/UCode1.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASRSP/UCode2.cpp
+++ b/src/Plugins.Win32.TASRSP/UCode2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASRSP/UCode3.cpp
+++ b/src/Plugins.Win32.TASRSP/UCode3.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Plugins.Win32.TASVideo/2xSAI.cpp
+++ b/src/Plugins.Win32.TASVideo/2xSAI.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "Types.hpp"
 #include "GBI.hpp"

--- a/src/Plugins.Win32.TASVideo/2xSAI.hpp
+++ b/src/Plugins.Win32.TASVideo/2xSAI.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 void _2xSaI8888(u32 *srcPtr, u32 *destPtr, u16 width, u16 height, s32 clampS, s32 clampT);

--- a/src/Plugins.Win32.TASVideo/3DMath.hpp
+++ b/src/Plugins.Win32.TASVideo/3DMath.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 static void mat_cpy(float m0[4][4], float m1[4][4])

--- a/src/Plugins.Win32.TASVideo/CMakeLists.txt
+++ b/src/Plugins.Win32.TASVideo/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Plugins.Win32.TASVideo/CRC.cpp
+++ b/src/Plugins.Win32.TASVideo/CRC.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 
 #define CRC32_POLYNOMIAL 0x04C11DB7

--- a/src/Plugins.Win32.TASVideo/CRC.hpp
+++ b/src/Plugins.Win32.TASVideo/CRC.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 void CRC_BuildTable();

--- a/src/Plugins.Win32.TASVideo/Combiner.cpp
+++ b/src/Plugins.Win32.TASVideo/Combiner.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "OpenGL.hpp"
 #include "Combiner.hpp"

--- a/src/Plugins.Win32.TASVideo/Combiner.hpp
+++ b/src/Plugins.Win32.TASVideo/Combiner.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "glN64.hpp"

--- a/src/Plugins.Win32.TASVideo/Config.cpp
+++ b/src/Plugins.Win32.TASVideo/Config.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "Config.hpp"
 #include "glN64.hpp"

--- a/src/Plugins.Win32.TASVideo/Config.hpp
+++ b/src/Plugins.Win32.TASVideo/Config.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 void Config_LoadConfig();

--- a/src/Plugins.Win32.TASVideo/DepthBuffer.cpp
+++ b/src/Plugins.Win32.TASVideo/DepthBuffer.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "DepthBuffer.hpp"
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/DepthBuffer.hpp
+++ b/src/Plugins.Win32.TASVideo/DepthBuffer.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 struct DepthBuffer

--- a/src/Plugins.Win32.TASVideo/F3D.cpp
+++ b/src/Plugins.Win32.TASVideo/F3D.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "F3D.hpp"

--- a/src/Plugins.Win32.TASVideo/F3D.hpp
+++ b/src/Plugins.Win32.TASVideo/F3D.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/F3DDKR.cpp
+++ b/src/Plugins.Win32.TASVideo/F3DDKR.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "F3D.hpp"

--- a/src/Plugins.Win32.TASVideo/F3DDKR.hpp
+++ b/src/Plugins.Win32.TASVideo/F3DDKR.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #define F3DDKR_VTX_APPEND 0x00010000

--- a/src/Plugins.Win32.TASVideo/F3DEX.cpp
+++ b/src/Plugins.Win32.TASVideo/F3DEX.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "F3D.hpp"

--- a/src/Plugins.Win32.TASVideo/F3DEX.hpp
+++ b/src/Plugins.Win32.TASVideo/F3DEX.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #define F3DEX_MTX_STACKSIZE 18

--- a/src/Plugins.Win32.TASVideo/F3DEX2.cpp
+++ b/src/Plugins.Win32.TASVideo/F3DEX2.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "F3D.hpp"

--- a/src/Plugins.Win32.TASVideo/F3DEX2.hpp
+++ b/src/Plugins.Win32.TASVideo/F3DEX2.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #define F3DEX2_MTX_STACKSIZE 18

--- a/src/Plugins.Win32.TASVideo/F3DPD.cpp
+++ b/src/Plugins.Win32.TASVideo/F3DPD.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "F3D.hpp"

--- a/src/Plugins.Win32.TASVideo/F3DPD.hpp
+++ b/src/Plugins.Win32.TASVideo/F3DPD.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #define F3DPD_VTXCOLORBASE 0x07

--- a/src/Plugins.Win32.TASVideo/F3DWRUS.cpp
+++ b/src/Plugins.Win32.TASVideo/F3DWRUS.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "F3D.hpp"

--- a/src/Plugins.Win32.TASVideo/F3DWRUS.hpp
+++ b/src/Plugins.Win32.TASVideo/F3DWRUS.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #define F3DWRUS_TRI2 0xB1

--- a/src/Plugins.Win32.TASVideo/FrameBuffer.cpp
+++ b/src/Plugins.Win32.TASVideo/FrameBuffer.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "OpenGL.hpp"
 #include "FrameBuffer.hpp"

--- a/src/Plugins.Win32.TASVideo/FrameBuffer.hpp
+++ b/src/Plugins.Win32.TASVideo/FrameBuffer.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/GBI.cpp
+++ b/src/Plugins.Win32.TASVideo/GBI.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "GBI.hpp"

--- a/src/Plugins.Win32.TASVideo/GBI.hpp
+++ b/src/Plugins.Win32.TASVideo/GBI.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/L3D.cpp
+++ b/src/Plugins.Win32.TASVideo/L3D.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "F3D.hpp"

--- a/src/Plugins.Win32.TASVideo/L3D.hpp
+++ b/src/Plugins.Win32.TASVideo/L3D.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/L3DEX.cpp
+++ b/src/Plugins.Win32.TASVideo/L3DEX.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "F3D.hpp"

--- a/src/Plugins.Win32.TASVideo/L3DEX.hpp
+++ b/src/Plugins.Win32.TASVideo/L3DEX.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/L3DEX2.cpp
+++ b/src/Plugins.Win32.TASVideo/L3DEX2.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "F3D.hpp"

--- a/src/Plugins.Win32.TASVideo/L3DEX2.hpp
+++ b/src/Plugins.Win32.TASVideo/L3DEX2.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/N64.cpp
+++ b/src/Plugins.Win32.TASVideo/N64.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "N64.hpp"
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/N64.hpp
+++ b/src/Plugins.Win32.TASVideo/N64.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "OpenGL.hpp"

--- a/src/Plugins.Win32.TASVideo/OpenGL.hpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "gSP.hpp"

--- a/src/Plugins.Win32.TASVideo/RDP.cpp
+++ b/src/Plugins.Win32.TASVideo/RDP.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "N64.hpp"
 #include "RSP.hpp"

--- a/src/Plugins.Win32.TASVideo/RDP.hpp
+++ b/src/Plugins.Win32.TASVideo/RDP.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 void RDP_Init();

--- a/src/Plugins.Win32.TASVideo/RSP.cpp
+++ b/src/Plugins.Win32.TASVideo/RSP.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "OpenGL.hpp"

--- a/src/Plugins.Win32.TASVideo/RSP.hpp
+++ b/src/Plugins.Win32.TASVideo/RSP.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/Resource.rc
+++ b/src/Plugins.Win32.TASVideo/Resource.rc
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 // Microsoft Visual C++ generated resource script.
 //
 #include "resource.h"

--- a/src/Plugins.Win32.TASVideo/S2DEX.cpp
+++ b/src/Plugins.Win32.TASVideo/S2DEX.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "OpenGL.hpp"
 #include "S2DEX.hpp"

--- a/src/Plugins.Win32.TASVideo/S2DEX.hpp
+++ b/src/Plugins.Win32.TASVideo/S2DEX.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #define G_BGLT_LOADBLOCK 0x0033

--- a/src/Plugins.Win32.TASVideo/S2DEX2.cpp
+++ b/src/Plugins.Win32.TASVideo/S2DEX2.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "OpenGL.hpp"
 #include "S2DEX.hpp"

--- a/src/Plugins.Win32.TASVideo/S2DEX2.hpp
+++ b/src/Plugins.Win32.TASVideo/S2DEX2.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 void S2DEX2_Init();

--- a/src/Plugins.Win32.TASVideo/Textures.cpp
+++ b/src/Plugins.Win32.TASVideo/Textures.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "OpenGL.hpp"
 #include "Textures.h"

--- a/src/Plugins.Win32.TASVideo/Textures.h
+++ b/src/Plugins.Win32.TASVideo/Textures.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "convert.hpp"

--- a/src/Plugins.Win32.TASVideo/Types.hpp
+++ b/src/Plugins.Win32.TASVideo/Types.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 using u8 = uint8_t;   /* unsigned  8-bit */

--- a/src/Plugins.Win32.TASVideo/VI.cpp
+++ b/src/Plugins.Win32.TASVideo/VI.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "VI.hpp"

--- a/src/Plugins.Win32.TASVideo/VI.hpp
+++ b/src/Plugins.Win32.TASVideo/VI.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/convert.hpp
+++ b/src/Plugins.Win32.TASVideo/convert.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include <tmmintrin.h>

--- a/src/Plugins.Win32.TASVideo/gDP.cpp
+++ b/src/Plugins.Win32.TASVideo/gDP.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "N64.hpp"

--- a/src/Plugins.Win32.TASVideo/gDP.hpp
+++ b/src/Plugins.Win32.TASVideo/gDP.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "FrameBuffer.hpp"

--- a/src/Plugins.Win32.TASVideo/gSP.cpp
+++ b/src/Plugins.Win32.TASVideo/gSP.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "Types.hpp"

--- a/src/Plugins.Win32.TASVideo/gSP.hpp
+++ b/src/Plugins.Win32.TASVideo/gSP.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include "GBI.hpp"

--- a/src/Plugins.Win32.TASVideo/glN64.cpp
+++ b/src/Plugins.Win32.TASVideo/glN64.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "glN64.hpp"
 #include "OpenGL.hpp"

--- a/src/Plugins.Win32.TASVideo/glN64.hpp
+++ b/src/Plugins.Win32.TASVideo/glN64.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 #include <m64rr/Plugin.hpp>

--- a/src/Plugins.Win32.TASVideo/resource.h
+++ b/src/Plugins.Win32.TASVideo/resource.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #define IDC_STATIC -1
 
 #define IDC_WINDOWEDRES 1000

--- a/src/Plugins.Win32.TASVideo/stdafx.cpp
+++ b/src/Plugins.Win32.TASVideo/stdafx.cpp
@@ -1,1 +1,7 @@
-﻿#include "stdafx.h"
+﻿/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "stdafx.h"

--- a/src/Plugins.Win32.TASVideo/stdafx.h
+++ b/src/Plugins.Win32.TASVideo/stdafx.h
@@ -1,4 +1,10 @@
-﻿#pragma once
+﻿/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
 
 #include <CommonPCH.hpp>
 #include <VersionNameHelpers.hpp>

--- a/src/Plugins.Win32.TASVideo/unified_combiner.cpp
+++ b/src/Plugins.Win32.TASVideo/unified_combiner.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #include "stdafx.h"
 #include "OpenGL.hpp"
 #include "Combiner.hpp"

--- a/src/Plugins.Win32.TASVideo/unified_combiner.hpp
+++ b/src/Plugins.Win32.TASVideo/unified_combiner.hpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 #pragma once
 
 struct Combiner;

--- a/src/Views.Win32/CMakeLists.txt
+++ b/src/Views.Win32/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/src/Views.Win32/Config.cpp
+++ b/src/Views.Win32/Config.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/Config.hpp
+++ b/src/Views.Win32/Config.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/DialogService.cpp
+++ b/src/Views.Win32/DialogService.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/DialogService.hpp
+++ b/src/Views.Win32/DialogService.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/Hotkey.cpp
+++ b/src/Views.Win32/Hotkey.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/Hotkey.hpp
+++ b/src/Views.Win32/Hotkey.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/Loggers.cpp
+++ b/src/Views.Win32/Loggers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/Loggers.hpp
+++ b/src/Views.Win32/Loggers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/Main.cpp
+++ b/src/Views.Win32/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/Main.hpp
+++ b/src/Views.Win32/Main.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/Messenger.cpp
+++ b/src/Views.Win32/Messenger.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/Messenger.hpp
+++ b/src/Views.Win32/Messenger.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/ResizeAnchor.cpp
+++ b/src/Views.Win32/ResizeAnchor.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/ResizeAnchor.hpp
+++ b/src/Views.Win32/ResizeAnchor.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/Resource.rc
+++ b/src/Views.Win32/Resource.rc
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 // Microsoft Visual C++ generated resource script.
 //
 #pragma code_page(65001)

--- a/src/Views.Win32/ThreadPool.cpp
+++ b/src/Views.Win32/ThreadPool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/ThreadPool.hpp
+++ b/src/Views.Win32/ThreadPool.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/ViewHelpers.hpp
+++ b/src/Views.Win32/ViewHelpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/action/ActionManager.cpp
+++ b/src/Views.Win32/action/ActionManager.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/action/ActionManager.hpp
+++ b/src/Views.Win32/action/ActionManager.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/action/ActionMenu.cpp
+++ b/src/Views.Win32/action/ActionMenu.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/action/ActionMenu.hpp
+++ b/src/Views.Win32/action/ActionMenu.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/action/AppActions.cpp
+++ b/src/Views.Win32/action/AppActions.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/action/AppActions.hpp
+++ b/src/Views.Win32/action/AppActions.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/capture/CaptureManager.cpp
+++ b/src/Views.Win32/capture/CaptureManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/capture/CaptureManager.hpp
+++ b/src/Views.Win32/capture/CaptureManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/capture/Resampler.cpp
+++ b/src/Views.Win32/capture/Resampler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/capture/Resampler.hpp
+++ b/src/Views.Win32/capture/Resampler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/capture/encoders/Encoder.hpp
+++ b/src/Views.Win32/capture/encoders/Encoder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/capture/encoders/FFmpegEncoder.cpp
+++ b/src/Views.Win32/capture/encoders/FFmpegEncoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/capture/encoders/FFmpegEncoder.hpp
+++ b/src/Views.Win32/capture/encoders/FFmpegEncoder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/capture/encoders/VFWEncoder.cpp
+++ b/src/Views.Win32/capture/encoders/VFWEncoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/capture/encoders/VFWEncoder.hpp
+++ b/src/Views.Win32/capture/encoders/VFWEncoder.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/CLI.cpp
+++ b/src/Views.Win32/components/CLI.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/CLI.hpp
+++ b/src/Views.Win32/components/CLI.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/Cheats.cpp
+++ b/src/Views.Win32/components/Cheats.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/Cheats.hpp
+++ b/src/Views.Win32/components/Cheats.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/CommandPalette.cpp
+++ b/src/Views.Win32/components/CommandPalette.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/CommandPalette.hpp
+++ b/src/Views.Win32/components/CommandPalette.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/ConfigDialog.cpp
+++ b/src/Views.Win32/components/ConfigDialog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/ConfigDialog.hpp
+++ b/src/Views.Win32/components/ConfigDialog.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/CoreUtils.cpp
+++ b/src/Views.Win32/components/CoreUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/CoreUtils.hpp
+++ b/src/Views.Win32/components/CoreUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/CrashManager.cpp
+++ b/src/Views.Win32/components/CrashManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/CrashManager.hpp
+++ b/src/Views.Win32/components/CrashManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/Dispatcher.cpp
+++ b/src/Views.Win32/components/Dispatcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/Dispatcher.hpp
+++ b/src/Views.Win32/components/Dispatcher.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/FilePicker.cpp
+++ b/src/Views.Win32/components/FilePicker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/FilePicker.hpp
+++ b/src/Views.Win32/components/FilePicker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/HotkeyTracker.cpp
+++ b/src/Views.Win32/components/HotkeyTracker.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/HotkeyTracker.hpp
+++ b/src/Views.Win32/components/HotkeyTracker.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/MGECompositor.cpp
+++ b/src/Views.Win32/components/MGECompositor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/MGECompositor.hpp
+++ b/src/Views.Win32/components/MGECompositor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/MovieDialog.cpp
+++ b/src/Views.Win32/components/MovieDialog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/MovieDialog.hpp
+++ b/src/Views.Win32/components/MovieDialog.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/ParameterPalette.cpp
+++ b/src/Views.Win32/components/ParameterPalette.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/ParameterPalette.hpp
+++ b/src/Views.Win32/components/ParameterPalette.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/PianoRoll.cpp
+++ b/src/Views.Win32/components/PianoRoll.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/PianoRoll.hpp
+++ b/src/Views.Win32/components/PianoRoll.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/RecentItems.cpp
+++ b/src/Views.Win32/components/RecentItems.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/RecentItems.hpp
+++ b/src/Views.Win32/components/RecentItems.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/ReorderableListView.cpp
+++ b/src/Views.Win32/components/ReorderableListView.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/ReorderableListView.hpp
+++ b/src/Views.Win32/components/ReorderableListView.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/RomBrowser.cpp
+++ b/src/Views.Win32/components/RomBrowser.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors
- * (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/RomBrowser.hpp
+++ b/src/Views.Win32/components/RomBrowser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/Seeker.cpp
+++ b/src/Views.Win32/components/Seeker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/Seeker.hpp
+++ b/src/Views.Win32/components/Seeker.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/SettingsListView.cpp
+++ b/src/Views.Win32/components/SettingsListView.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/SettingsListView.hpp
+++ b/src/Views.Win32/components/SettingsListView.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/Statusbar.cpp
+++ b/src/Views.Win32/components/Statusbar.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/Statusbar.hpp
+++ b/src/Views.Win32/components/Statusbar.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/TextEditDialog.cpp
+++ b/src/Views.Win32/components/TextEditDialog.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/TextEditDialog.hpp
+++ b/src/Views.Win32/components/TextEditDialog.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/UpdateChecker.cpp
+++ b/src/Views.Win32/components/UpdateChecker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/UpdateChecker.hpp
+++ b/src/Views.Win32/components/UpdateChecker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/Validators.cpp
+++ b/src/Views.Win32/components/Validators.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/components/Validators.hpp
+++ b/src/Views.Win32/components/Validators.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/include/Views.Win32/ZESpec.h
+++ b/src/Views.Win32/include/Views.Win32/ZESpec.h
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaCallbacks.cpp
+++ b/src/Views.Win32/lua/LuaCallbacks.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaCallbacks.hpp
+++ b/src/Views.Win32/lua/LuaCallbacks.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaDialog.cpp
+++ b/src/Views.Win32/lua/LuaDialog.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaDialog.hpp
+++ b/src/Views.Win32/lua/LuaDialog.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaHelpers.cpp
+++ b/src/Views.Win32/lua/LuaHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaHelpers.hpp
+++ b/src/Views.Win32/lua/LuaHelpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaManager.cpp
+++ b/src/Views.Win32/lua/LuaManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaManager.hpp
+++ b/src/Views.Win32/lua/LuaManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaRegistry.cpp
+++ b/src/Views.Win32/lua/LuaRegistry.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaRegistry.hpp
+++ b/src/Views.Win32/lua/LuaRegistry.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/LuaRenderer.cpp
+++ b/src/Views.Win32/lua/LuaRenderer.cpp
@@ -1,4 +1,10 @@
-﻿#include "stdafx.h"
+﻿/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "stdafx.h"
 #include <DialogService.hpp>
 #include <components/Statusbar.hpp>
 #include <lua/LuaManager.hpp>

--- a/src/Views.Win32/lua/LuaRenderer.hpp
+++ b/src/Views.Win32/lua/LuaRenderer.hpp
@@ -1,4 +1,10 @@
-﻿#pragma once
+﻿/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
 
 /**
  * \brief A module responsible for implementing Lua rendering-related functionality.

--- a/src/Views.Win32/lua/LuaTypes.hpp
+++ b/src/Views.Win32/lua/LuaTypes.hpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/AVI.hpp
+++ b/src/Views.Win32/lua/modules/AVI.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Action.hpp
+++ b/src/Views.Win32/lua/modules/Action.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Clipboard.hpp
+++ b/src/Views.Win32/lua/modules/Clipboard.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/D2D.hpp
+++ b/src/Views.Win32/lua/modules/D2D.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Debugger.h
+++ b/src/Views.Win32/lua/modules/Debugger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Emu.hpp
+++ b/src/Views.Win32/lua/modules/Emu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Global.hpp
+++ b/src/Views.Win32/lua/modules/Global.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Hotkey.hpp
+++ b/src/Views.Win32/lua/modules/Hotkey.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/IOHelper.hpp
+++ b/src/Views.Win32/lua/modules/IOHelper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Input.hpp
+++ b/src/Views.Win32/lua/modules/Input.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Joypad.hpp
+++ b/src/Views.Win32/lua/modules/Joypad.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Memory.hpp
+++ b/src/Views.Win32/lua/modules/Memory.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Movie.hpp
+++ b/src/Views.Win32/lua/modules/Movie.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/Savestate.hpp
+++ b/src/Views.Win32/lua/modules/Savestate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/modules/WGUI.hpp
+++ b/src/Views.Win32/lua/modules/WGUI.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/presenters/DCompPresenter.cpp
+++ b/src/Views.Win32/lua/presenters/DCompPresenter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/presenters/DCompPresenter.hpp
+++ b/src/Views.Win32/lua/presenters/DCompPresenter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/presenters/GDIPresenter.cpp
+++ b/src/Views.Win32/lua/presenters/GDIPresenter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/presenters/GDIPresenter.hpp
+++ b/src/Views.Win32/lua/presenters/GDIPresenter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/lua/presenters/Presenter.hpp
+++ b/src/Views.Win32/lua/presenters/Presenter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/plugin/M64RRPlugin.cpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/plugin/M64RRPlugin.hpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/plugin/Plugin.cpp
+++ b/src/Views.Win32/plugin/Plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/plugin/Plugin.hpp
+++ b/src/Views.Win32/plugin/Plugin.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/plugin/ZEPlugin.cpp
+++ b/src/Views.Win32/plugin/ZEPlugin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/plugin/ZEPlugin.hpp
+++ b/src/Views.Win32/plugin/ZEPlugin.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/Views.Win32/resource.h
+++ b/src/Views.Win32/resource.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 //{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
 // Used by Resource.rc

--- a/src/Views.Win32/stdafx.h
+++ b/src/Views.Win32/stdafx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/toolchains/vcpkg-triplets/x64-windows-static-asan.cmake
+++ b/toolchains/vcpkg-triplets/x64-windows-static-asan.cmake
@@ -1,3 +1,9 @@
+#[===[
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+
+SPDX-License-Identifier: GPL-2.0-or-later
+]===]
+
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)

--- a/toolchains/vcpkg-triplets/x86-windows-static-asan.cmake
+++ b/toolchains/vcpkg-triplets/x86-windows-static-asan.cmake
@@ -1,3 +1,9 @@
+#[===[
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+
+SPDX-License-Identifier: GPL-2.0-or-later
+]===]
+
 set(VCPKG_TARGET_ARCHITECTURE x86)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)

--- a/toolchains/vcpkg-win64.cmake
+++ b/toolchains/vcpkg-win64.cmake
@@ -1,5 +1,5 @@
 #[===[
-Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 
 SPDX-License-Identifier: GPL-2.0-or-later
 ]===]

--- a/tools/parity_check.py
+++ b/tools/parity_check.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2026, Mupen64 maintainers, contributors, and original authors (Hacktarux, ShadowPrince, linker).
+#  Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
 #
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #


### PR DESCRIPTION
This pull request updates the copyright and licensing headers across the project to standardize them under the "Mupen64 Organization" and clarifies the handling of author credits. It also ensures that all example and source files include the correct SPDX license identifier and moves individual author credits to the `NOTICE` file.

**Header and License Standardization**

* Updated copyright headers in all source files (including `CMakeLists.txt`, `.hpp` headers, and Lua example scripts) to use "Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)" and the SPDX identifier "GPL-2.0-or-later". [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R2) [[2]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L2-R2) [[3]](diffhunk://#diff-759c8b80d7b7dd20c4566d422eec886b42c590d7f1c741d6547512dfe4465360L2-R2) [[4]](diffhunk://#diff-29098087176919215c3a862255e79082b0b0240c241afb8eab6a8682bd2e034aL2-R2) [[5]](diffhunk://#diff-15f2c28798ad8afb94e82afc3ae7b0310331a5d62b22d98f8f65c7a343247a75L2-R2) [[6]](diffhunk://#diff-58cde6120aba53d6b4df88a2f8ca2dab6b1ded8892226886327d12b4ed252ac8L2-R2) [[7]](diffhunk://#diff-a69b3f7393507ab0e939779737a00f3302207e7f980e6ec687d8cfc2ca6c431dL2-R2) [[8]](diffhunk://#diff-ff6222ab85415f14c2038cdcf4db1c3b78bd9c844d63443a1f07ffd632d3f331R1-R6) [[9]](diffhunk://#diff-62dd2a4ad796bd3ce86e4521b3fabac87d60ab33cdce32e792a53e13aec1a71dR1-R6) [[10]](diffhunk://#diff-615d49447b06b2dc4d4710117726b2fe593caaa46251a7747ca076c4db4bb8b0R1-R6) [[11]](diffhunk://#diff-d2106eb69bd6866fe485bf28f7b2dfc896ab21e723752c366acc07ad1b927e33R1-R6) [[12]](diffhunk://#diff-2b83a63c07d2ef1aaf580e8e26f660d35ac84517591640cf09dc72e75504d97bR1-R6) [[13]](diffhunk://#diff-78606ccea53c31f37fac35aceeebd5f46170f254d7754708aa5f53e65f877dfeR1-R6) [[14]](diffhunk://#diff-12cf07cfb644796d04056a83b8731bd5c2b3d584c96dda6c463f4cb050455a09R1-R6) [[15]](diffhunk://#diff-6a97920a3b17d52fc12bffb4d17358b33db18dfe00848db2eaecce4d646ed011R1-R6) [[16]](diffhunk://#diff-c06bc0e15b9b5644676e20052b006cd2b77505a1d6bab32f3cfc946c21b6183cR1-R6) [[17]](diffhunk://#diff-a4600b69710de0d5ff4617563cfdb883aec69a525e540945ef4362330142edabR1-R6) [[18]](diffhunk://#diff-48fc72d3cd34e239d91d1e2aa2d492ab3cc5eb8cb27f706a13bf6c03e89ac010R1-R6)

* Added missing license headers to Lua example files in `docs/lua/examples`. [[1]](diffhunk://#diff-62dd2a4ad796bd3ce86e4521b3fabac87d60ab33cdce32e792a53e13aec1a71dR1-R6) [[2]](diffhunk://#diff-615d49447b06b2dc4d4710117726b2fe593caaa46251a7747ca076c4db4bb8b0R1-R6) [[3]](diffhunk://#diff-d2106eb69bd6866fe485bf28f7b2dfc896ab21e723752c366acc07ad1b927e33R1-R6) [[4]](diffhunk://#diff-2b83a63c07d2ef1aaf580e8e26f660d35ac84517591640cf09dc72e75504d97bR1-R6) [[5]](diffhunk://#diff-78606ccea53c31f37fac35aceeebd5f46170f254d7754708aa5f53e65f877dfeR1-R6) [[6]](diffhunk://#diff-12cf07cfb644796d04056a83b8731bd5c2b3d584c96dda6c463f4cb050455a09R1-R6) [[7]](diffhunk://#diff-6a97920a3b17d52fc12bffb4d17358b33db18dfe00848db2eaecce4d646ed011R1-R6) [[8]](diffhunk://#diff-c06bc0e15b9b5644676e20052b006cd2b77505a1d6bab32f3cfc946c21b6183cR1-R6) [[9]](diffhunk://#diff-a4600b69710de0d5ff4617563cfdb883aec69a525e540945ef4362330142edabR1-R6) [[10]](diffhunk://#diff-48fc72d3cd34e239d91d1e2aa2d492ab3cc5eb8cb27f706a13bf6c03e89ac010R1-R6)

**Documentation and Credits Policy**

* Updated `CONTRIBUTING.md` to clarify that the copyright header is now standardized, and project-specific credits to original authors should be placed in the `NOTICE` file, not in per-file headers.

* Added a new standardized copyright and license notice to the top of the `NOTICE` file and clarified its purpose for recording prior authorship.