### PR TITLE
feat(Core): support ROMs up to 128MB 

### DIFF
--- a/src/Core/Memory/DMA.cpp
+++ b/src/Core/Memory/DMA.cpp
@@ -160,7 +160,7 @@ void dma_pi_write()
         return;
     }
 
-    i = (pi_register.pi_cart_addr_reg - 0x10000000) & 0x3FFFFFF;
+    i = (pi_register.pi_cart_addr_reg - 0x10000000) & 0x7FFFFFF;
     longueur = (i + longueur) > rom_size ? (rom_size - i) : longueur;
     longueur =
         (pi_register.pi_dram_addr_reg + longueur) > 0x7FFFFF ? (0x7FFFFF - pi_register.pi_dram_addr_reg) : longueur;
@@ -181,7 +181,7 @@ void dma_pi_write()
             uint32_t rdram_address2 = pi_register.pi_dram_addr_reg + i + 0xa0000000;
 
             ((unsigned char *)rdram)[(pi_register.pi_dram_addr_reg + i) ^ S8] =
-                rom[(((pi_register.pi_cart_addr_reg - 0x10000000) & 0x3FFFFFF) + i) ^ S8];
+                rom[(((pi_register.pi_cart_addr_reg - 0x10000000) & 0x7FFFFFF) + i) ^ S8];
 
             if (!invalid_code[rdram_address1 >> 12])
                 if (blocks[rdram_address1 >> 12]->block[(rdram_address1 & 0xFFF) / 4].ops != NOTCOMPILED)
@@ -197,7 +197,7 @@ void dma_pi_write()
         for (i = 0; i < longueur; i++)
         {
             ((unsigned char *)rdram)[(pi_register.pi_dram_addr_reg + i) ^ S8] =
-                rom[(((pi_register.pi_cart_addr_reg - 0x10000000) & 0x3FFFFFF) + i) ^ S8];
+                rom[(((pi_register.pi_cart_addr_reg - 0x10000000) & 0x7FFFFFF) + i) ^ S8];
         }
     }
 

--- a/src/Core/Memory/Memory.cpp
+++ b/src/Core/Memory/Memory.cpp
@@ -3240,23 +3240,23 @@ void read_rom()
         lastwrite = 0;
     }
     else
-        *rdword = *((uint32_t *)(rom + (address & 0x03FFFFFF)));
+        *rdword = *((uint32_t *)(rom + (address & 0x07FFFFFF)));
 }
 
 void read_romb()
 {
-    *rdword = *(rom + ((address ^ S8) & 0x03FFFFFF));
+    *rdword = *(rom + ((address ^ S8) & 0x07FFFFFF));
 }
 
 void read_romh()
 {
-    *rdword = *((uint16_t *)(rom + ((address ^ S16) & 0x03FFFFFF)));
+    *rdword = *((uint16_t *)(rom + ((address ^ S16) & 0x07FFFFFF)));
 }
 
 void read_romd()
 {
-    *rdword = ((uint64_t)(*((uint32_t *)(rom + (address & 0x03FFFFFF)))) << 32) |
-              *((uint32_t *)(rom + ((address + 4) & 0x03FFFFFF)));
+    *rdword = ((uint64_t)(*((uint32_t *)(rom + (address & 0x07FFFFFF)))) << 32) |
+              *((uint32_t *)(rom + ((address + 4) & 0x07FFFFFF)));
 }
 
 void write_rom()


### PR DESCRIPTION
This pull request updates the ROM address masking logic in both DMA and ROM read routines to expand supported ROM sizes from 64MB to 128MB. This ensures that memory accesses correctly handle larger ROM images, preventing out-of-bounds errors and improving compatibility with bigger games.

**ROM address masking updates:**

* Increased the ROM address mask from `0x3FFFFFF` (64MB) to `0x7FFFFFF` (128MB) in all relevant calculations within `dma_pi_write()` to support larger ROM sizes. [[1]](diffhunk://#diff-465cd2022c61981b56b88984341c17f5d459a129058e32d12be1bd81dc9c228dL163-R163) [[2]](diffhunk://#diff-465cd2022c61981b56b88984341c17f5d459a129058e32d12be1bd81dc9c228dL184-R184) [[3]](diffhunk://#diff-465cd2022c61981b56b88984341c17f5d459a129058e32d12be1bd81dc9c228dL200-R200)
* Updated all ROM read functions in `Memory.cpp` (`read_rom`, `read_romb`, `read_romh`, `read_romd`) to use the new 128MB mask (`0x07FFFFFF`) for address calculations, ensuring consistent access across all ROM read operations.

These changes ensure the emulator can correctly access and manipulate ROM data up to 128MB in size.…rectly