### PR TITLE
fix(dynarec/x64): guard dyna_jump against pages with no compiled block

### DIFF
--- a/src/Core/R4300/x86_64/RJump.cpp
+++ b/src/Core/R4300/x86_64/RJump.cpp
@@ -114,7 +114,19 @@ void dyna_jump()
     // from the live compilation (mirrors jump_to_func). A freshly-invalidated block yields a
     // NOTCOMPILED stub (local_addr == 0), so we jump to block->code + 0 and recompilation kicks in.
     precomp_block *block = blocks[PC->addr >> 12];
-    precomp_instr *cur = block->block + ((PC->addr - block->start) >> 2);
+    precomp_instr *cur;
+    if (!block || !block->block)
+    {
+        // Page has no live block: nothing to re-derive from, and no newer compilation means PC
+        // can't be stale here. Fall back to the pair x86 uses (see x86/RJump.cpp). Keep going
+        // through the thunk below -- its `add rsp,8` is what balances call_reg64's `push r11`.
+        block = actual;
+        cur = PC;
+    }
+    else
+    {
+        cur = block->block + ((PC->addr - block->start) >> 2);
+    }
 
     int32_t need_map = cur->reg_cache_infos.need_map;
 


### PR DESCRIPTION
## Summary

`dyna_jump` dereferences `blocks[PC->addr >> 12]` without checking it. That entry can legitimately
be `NULL`: `blocks[]` starts zeroed and `jump_to_func` only allocates when `invalid_code` marks the
page as needing (re)compilation, so a `PC` advanced past a block boundary can land on an entry that
was never filled in.

The x86 recompiler never hits this — its `dyna_jump` uses `PC` and `actual` directly and never
indexes `blocks[]`.

Reproduced with a 96 MB ROM hack (b3313) on the x64 dynarec; entering the castle faults:

```text
mupen64!dyna_jump+0x26  [RJump.cpp @ 117]
00000001`40242336 488b0e  mov rcx, qword ptr [rsi]  ds:0000000000000000
rsi=0000000000000000
```

The failure is intermittent. Whether the page happens to be allocated already depends on execution
order, so the same build sometimes faults on entry and sometimes runs for billions of instructions
before locking up instead. Both symptoms have the same origin.

## Changes

- `dyna_jump` falls back to the block/instruction pair the x86 recompiler uses unconditionally —
  `actual` and `PC` — when the page has no live block.
- The fallback still routes through the thunk. Writing the target straight into `*return_address`
  would skip the `add rsp, 8` that undoes `call_reg64`'s `push r11`, leaving RSP 8 low for every
  later call into C. That surfaces far from its cause: a `#GP` in the first callee spilling an XMM
  register with `movaps` to a supposedly 16-byte-aligned slot, which Windows reports as an access
  violation at `0xFFFFFFFFFFFFFFFF`.

The existing re-derivation is untouched. It guards against a stale `PC` left by the deferred-free
list — a scenario that requires a *newer* compilation to have superseded it, hence `blocks[]` to be
populated, so it cannot arise on the path added here.

Scope: confined to `src/Core/R4300/x86_64/`. The interpreter and the x86 recompiler are unaffected.
The new branch only runs where the current code dereferences `NULL`, so every execution that works
today takes the identical path. `dyna_jump` writes only `*return_address`, a native code pointer —
it never touches emulated state, so it cannot affect timing or determinism.

## Testing

- b3313 (96 MB), x64 dynarec, repeated castle entries — no longer faults.
- Super Mario 64, x64 dynarec — no regression.
- Parity suite: 667/667, still bit-identical.

## Merge order

Independent of #889 (`feat(Core): support ROMs up to 128MB`) — disjoint files, no conflict, either
order merges cleanly. This fix is not ROM-size specific; the null entry can occur with any ROM.

The only coupling is on the repro: reaching the castle in a 96 MB ROM needs #889, so **merge #889
first if you want to reproduce the scenario above**. The test build carried both.

## Known limitation

The fallback relies on `actual` corresponding to `PC`'s page. That is the standing assumption of the
x86 recompiler, but it is not formally guaranteed here — if `actual` were `NULL`, the emitted thunk
would fault. Flagging it rather than adding a guard, since the only alternative behaviour (leaving
`*return_address` unpatched) would continue into wrong code, which is worse than a clean fault.
Happy to add one if preferred.

## Checklist

- [x] Tests pass — parity suite 667/667, SM64 no regression
- [ ] Documentation updated — no user-facing docs affected by this change
- [x] No breaking changes

changelog: skip
