### PR TITLE
fix(TASVideo): sync the GPU before reading back the color buffer

### DIFF
--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -26,6 +26,8 @@ void OGL_ReadPixels()
 {
     if (!gCapturedPixels) return;
 
+    glFinish();
+
     glReadPixels(0, 0, OGL.width, OGL.height, GL_RGBA, GL_UNSIGNED_BYTE, gCapturedPixels);
 
     auto pixels = (uint8_t *)gCapturedPixels;


### PR DESCRIPTION
Fixes #892.

## Summary

`OGL_ReadPixels` sampled the color buffer without any guarantee that the display list had finished
rendering, which showed up as roughly two frames of input delay (frame advance, punch in SM64, the
action lands late).

`VI_UpdateScreen()` used to bracket the frame with `glFinish()`, but the M64RR plugin spec routes
presentation through `read_video` and never calls `video_update_screen`, so that function is now
dead code and its sync went with it. The fixed-function renderer on a desktop GL context did not
show the delay; the shader renderer on an OpenGL ES context does.

The cause given in the issue — framebuffer emulation being enabled — is not it. That path is gated
on the plugin exposing `fb_read` / `fb_write` / `fb_get_frame_buffer_info`, and both the ZE and
M64RR specs substitute non-null stubs for those, so the gate was already satisfied before the
OpenGL change and `frameBufferInfos[0].addr` stays zero either way.

## Changes

- `OGL_ReadPixels` calls `glFinish()` before `glReadPixels`.

## Testing

Manual, on SM64 with an ES 2.0 context:

- Frame advance + punch: action now lands on the expected frame instead of ~2 frames later.
- Built the pre-#851 renderer (`de6d81f7^`) against the same emulator and plugin spec to confirm the
  regression came from the renderer change and not from the M64RR migration — no delay there.
- Instrumented `M64RRProcessDList` / `M64RRReadVideo` over ~1000 frames beforehand: the call order is
  always render-then-read, and the read always sees the newest display list, so the delay was not an
  ordering problem in the plugin.

No automated test covers this path; the verification above is manual.

## Notes

Per the GL spec `glReadPixels` should already synchronize, so the exact driver behaviour behind the
delay is not fully explained — the fix is empirically verified rather than derived from the spec. If
a reviewer would rather not pay for a full pipeline stall every frame, the alternative is to restore
an explicit sync at the presentation boundary instead of inside the readback.

changelog: skip