### PR TITLE
fix(TASVideo): resolution changes not applying as expected

### DIFF
--- a/src/Plugins.Win32.TASVideo/Config.cpp
+++ b/src/Plugins.Win32.TASVideo/Config.cpp
@@ -178,17 +178,20 @@ void Config_ApplyDlgConfig(HWND hWndDlg)
     }
 }
 
-static void select_current_resolution_in_combobox(HWND cb_hwnd)
+static void select_resolution_in_combobox(HWND cb_hwnd, uint32_t width, uint32_t height)
 {
     for (size_t i = 0; i < RESOLUTION_PRESETS.size(); i++)
     {
         const auto &preset = RESOLUTION_PRESETS[i];
-        if (OGL.windowedWidth == preset.width && OGL.windowedHeight == preset.height)
+        if (width == preset.width && height == preset.height)
         {
             ComboBox_SetCurSel(cb_hwnd, i);
             return;
         }
     }
+
+    // A size that matches no preset is a custom one, so leaving a stale entry highlighted would lie.
+    ComboBox_SetCurSel(cb_hwnd, -1);
 }
 
 BOOL CALLBACK ConfigDlgProc(HWND hWndDlg, UINT message, WPARAM wParam, LPARAM lParam)
@@ -211,7 +214,7 @@ BOOL CALLBACK ConfigDlgProc(HWND hWndDlg, UINT message, WPARAM wParam, LPARAM lP
         }
         ComboBox_SetCurSel(GetDlgItem(hWndDlg, IDC_SMOOTHING), (int)OGL.smoothing);
 
-        select_current_resolution_in_combobox(cb_hwnd);
+        select_resolution_in_combobox(cb_hwnd, OGL.windowedWidth, OGL.windowedHeight);
 
         SendDlgItemMessage(hWndDlg, IDC_WINDOWED_X, WM_SETTEXT, 0, (LPARAM)std::to_wstring(OGL.windowedWidth).c_str());
         SendDlgItemMessage(hWndDlg, IDC_WINDOWED_Y, WM_SETTEXT, 0, (LPARAM)std::to_wstring(OGL.windowedHeight).c_str());
@@ -271,23 +274,16 @@ BOOL CALLBACK ConfigDlgProc(HWND hWndDlg, UINT message, WPARAM wParam, LPARAM lP
         case IDC_WINDOWED_Y:
             if (HIWORD(wParam) == EN_CHANGE)
             {
-                std::wstring w_str(32, 0);
-                std::wstring h_str(32, 0);
-                Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_X), w_str.data(), w_str.size());
-                Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_Y), h_str.data(), h_str.size());
+                // Only mirror the typed size into the preset combo. Writing it into OGL here would mean
+                // Config_ApplyDlgConfig's prev_OGL snapshot already holds the new resolution, so its
+                // needs_restart check would never see the change and the context would never be
+                // recreated at the new size.
+                wchar_t w_str[32]{};
+                wchar_t h_str[32]{};
+                Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_X), w_str, std::size(w_str));
+                Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_Y), h_str, std::size(h_str));
 
-                try
-                {
-                    OGL.windowedWidth = std::stoul(std::wstring(w_str));
-                    OGL.windowedHeight = std::stoul(std::wstring(h_str));
-                }
-                catch (...)
-                {
-                    break;
-                }
-
-                const auto cb_hwnd = GetDlgItem(hWndDlg, IDC_WINDOWEDRES);
-                select_current_resolution_in_combobox(cb_hwnd);
+                select_resolution_in_combobox(GetDlgItem(hWndDlg, IDC_WINDOWEDRES), _wtoi(w_str), _wtoi(h_str));
             }
             break;
         case IDC_TEXTUREFILTER:

--- a/src/Plugins.Win32.TASVideo/Config.cpp
+++ b/src/Plugins.Win32.TASVideo/Config.cpp
@@ -190,7 +190,6 @@ static void select_resolution_in_combobox(HWND cb_hwnd, uint32_t width, uint32_t
         }
     }
 
-    // A size that matches no preset is a custom one, so leaving a stale entry highlighted would lie.
     ComboBox_SetCurSel(cb_hwnd, -1);
 }
 
@@ -274,10 +273,6 @@ BOOL CALLBACK ConfigDlgProc(HWND hWndDlg, UINT message, WPARAM wParam, LPARAM lP
         case IDC_WINDOWED_Y:
             if (HIWORD(wParam) == EN_CHANGE)
             {
-                // Only mirror the typed size into the preset combo. Writing it into OGL here would mean
-                // Config_ApplyDlgConfig's prev_OGL snapshot already holds the new resolution, so its
-                // needs_restart check would never see the change and the context would never be
-                // recreated at the new size.
                 wchar_t w_str[32]{};
                 wchar_t h_str[32]{};
                 Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_X), w_str, std::size(w_str));

--- a/src/Plugins.Win32.TASVideo/Config.cpp
+++ b/src/Plugins.Win32.TASVideo/Config.cpp
@@ -278,7 +278,19 @@ BOOL CALLBACK ConfigDlgProc(HWND hWndDlg, UINT message, WPARAM wParam, LPARAM lP
                 Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_X), w_str, std::size(w_str));
                 Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_Y), h_str, std::size(h_str));
 
-                select_resolution_in_combobox(GetDlgItem(hWndDlg, IDC_WINDOWEDRES), _wtoi(w_str), _wtoi(h_str));
+                uint32_t width{};
+                uint32_t height{};
+                try
+                {
+                    width = std::stoul(w_str);
+                    height = std::stoul(h_str);
+                }
+                catch (...)
+                {
+                    break;
+                }
+
+                select_resolution_in_combobox(GetDlgItem(hWndDlg, IDC_WINDOWEDRES), width, height);
             }
             break;
         case IDC_TEXTUREFILTER:


### PR DESCRIPTION
This pull request refactors how the resolution preset combo box is updated in the configuration dialog, improving correctness when custom resolutions are entered. The main change is to decouple updating the OpenGL resolution state from UI feedback, ensuring that the dialog's logic properly detects when a restart is needed.

**Resolution preset combo box handling:**

* Refactored `select_current_resolution_in_combobox` to `select_resolution_in_combobox`, which now takes explicit width and height parameters rather than relying on global state. Also, it clears the selection if the current size does not match a preset.
* Updated all usages of the old function to use the new signature, passing the current width and height explicitly.
* Changed the handling of manual resolution edits so that the OpenGL state (`OGL.windowedWidth`/`Height`) is not updated until the configuration is applied. This prevents the restart detection logic from missing changes. The combo box is now only updated to reflect the typed values, not to update the application state.