### PR TITLE
refactor: cleanup plugin API

### DIFF
--- a/src/Common/include/FNV1A.hpp
+++ b/src/Common/include/FNV1A.hpp
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <span>
+
 /**
  * \brief A module providing a FNV-1a hash function implementation.
  */

--- a/src/Common/include/IOUtils.hpp
+++ b/src/Common/include/IOUtils.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <filesystem>
+#include <fstream>
 #if defined(_WIN32)
 #ifndef NOMINMAX
 #define NOMINMAX

--- a/src/Common/include/IOUtils.hpp
+++ b/src/Common/include/IOUtils.hpp
@@ -5,8 +5,13 @@
  */
 #pragma once
 
+#include <cassert>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
+#include <span>
+#include "StrUtils.hpp"
+
 #if defined(_WIN32)
 #ifndef NOMINMAX
 #define NOMINMAX

--- a/src/Common/include/MiscHelpers.hpp
+++ b/src/Common/include/MiscHelpers.hpp
@@ -6,6 +6,11 @@
 
 #pragma once
 
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include <libdeflate.h>
 
 /**

--- a/src/Common/include/StrUtils.hpp
+++ b/src/Common/include/StrUtils.hpp
@@ -149,7 +149,7 @@ inline std::string_view ctrim_string(std::string_view str)
     auto str2 = str.substr(start_iter - str.begin());
 
     auto end_iter = std::ranges::find_if(std::views::reverse(str2), not_isspace);
-    if (end_iter == str.rend()) return ""sv;
+    if (end_iter.base() == str2.begin()) return ""sv;
     return str2.substr(0, end_iter.base() - str2.begin());
 }
 // Trims whitespace from the start and end of a wstring_view (as determined by iswspace()).
@@ -165,7 +165,7 @@ inline std::wstring_view ctrim_wstring(std::wstring_view str)
     auto str2 = str.substr(start_iter - str.begin());
 
     auto end_iter = std::ranges::find_if(std::views::reverse(str2), not_iswspace);
-    if (end_iter == str.rend()) return L""sv;
+    if (end_iter.base() == str2.begin()) return L""sv;
     return str2.substr(0, end_iter.base() - str2.begin());
 }
 

--- a/src/Common/include/StrUtils.hpp
+++ b/src/Common/include/StrUtils.hpp
@@ -6,8 +6,11 @@
 
 #pragma once
 
-#include <string_view>
+#include <ranges>
+#include <sstream>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 
 namespace StrUtils
 {

--- a/src/Core/Core.cpp
+++ b/src/Core/Core.cpp
@@ -68,7 +68,7 @@ core_result core_create(core_params *params, core_ctx **ctx)
     g_ctx.rdram = rdram;
     g_ctx.rdram_register = &rdram_register;
     g_ctx.pi_register = &pi_register;
-    g_ctx.MI_register = &MI_register;
+    g_ctx.mi_register = &MI_register;
     g_ctx.sp_register = &sp_register;
     g_ctx.si_register = &si_register;
     g_ctx.vi_register = &vi_register;
@@ -77,9 +77,9 @@ core_result core_create(core_params *params, core_ctx **ctx)
     g_ctx.ai_register = &ai_register;
     g_ctx.dpc_register = &dpc_register;
     g_ctx.dps_register = &dps_register;
-    g_ctx.SP_DMEM = SP_DMEM;
-    g_ctx.SP_IMEM = SP_IMEM;
-    g_ctx.PIF_RAM = PIF_RAM;
+    g_ctx.sp_dmem = SP_DMEM;
+    g_ctx.sp_imem = SP_IMEM;
+    g_ctx.pif_ram = PIF_RAM;
     g_ctx.rcp_counter = &g_r4300.rcp_counter;
     CORE_RDRAM = rdram;
 

--- a/src/Core/Memory/Pif.cpp
+++ b/src/Core/Memory/Pif.cpp
@@ -136,7 +136,7 @@ void internal_ReadController(int32_t Control, uint8_t *Command)
     switch (Command[2])
     {
     case 1:
-        if (g_core->controls[Control].Present)
+        if (g_core->controls[Control].present)
         {
             cht_execute();
 
@@ -149,9 +149,9 @@ void internal_ReadController(int32_t Control, uint8_t *Command)
         break;
     case 2: // read controller pack
     case 3: // write controller pack
-        if (g_core->controls[Control].Present)
+        if (g_core->controls[Control].present)
         {
-            if (g_core->controls[Control].Plugin == CoreControllerExtension::Raw && g_core->input_controller_command)
+            if (g_core->controls[Control].plugin == CoreControllerExtension::Raw && g_core->input_controller_command)
                 g_core->input_read_controller(Control, Command);
         }
         break;
@@ -165,11 +165,11 @@ void internal_ControllerCommand(int32_t Control, uint8_t *Command)
     case 0x00: // check
     case 0xFF:
         if ((Command[1] & 0x80)) break;
-        if (g_core->controls[Control].Present)
+        if (g_core->controls[Control].present)
         {
             Command[3] = 0x05;
             Command[4] = 0x00;
-            switch (g_core->controls[Control].Plugin)
+            switch (g_core->controls[Control].plugin)
             {
             case CoreControllerExtension::Mempak:
                 Command[5] = 1;
@@ -186,12 +186,12 @@ void internal_ControllerCommand(int32_t Control, uint8_t *Command)
             Command[1] |= 0x80;
         break;
     case 0x01:
-        if (!g_core->controls[Control].Present) Command[1] |= 0x80;
+        if (!g_core->controls[Control].present) Command[1] |= 0x80;
         break;
     case 0x02: // read controller pack
-        if (g_core->controls[Control].Present)
+        if (g_core->controls[Control].present)
         {
-            switch (g_core->controls[Control].Plugin)
+            switch (g_core->controls[Control].plugin)
             {
             case CoreControllerExtension::Mempak: {
                 int32_t address = (Command[3] << 8) | Command[4];
@@ -233,9 +233,9 @@ void internal_ControllerCommand(int32_t Control, uint8_t *Command)
             Command[1] |= 0x80;
         break;
     case 0x03: // write controller pack
-        if (g_core->controls[Control].Present)
+        if (g_core->controls[Control].present)
         {
-            switch (g_core->controls[Control].Plugin)
+            switch (g_core->controls[Control].plugin)
             {
             case CoreControllerExtension::Mempak: {
                 int32_t address = (Command[3] << 8) | Command[4];
@@ -353,7 +353,7 @@ void update_pif_write()
                         break;
                     }
 
-                    if (g_core->controls[channel].Present && g_core->controls[channel].RawData)
+                    if (g_core->controls[channel].present && g_core->controls[channel].raw)
                         g_core->input_controller_command(channel, &PIF_RAMb[i]);
                     else
                         internal_ControllerCommand(channel, &PIF_RAMb[i]);
@@ -507,7 +507,7 @@ void update_pif_read()
 
                     // we handle raw data-mode controllers here:
                     // this is incompatible with VCR!
-                    if (g_core->controls[channel].Present && g_core->controls[channel].RawData &&
+                    if (g_core->controls[channel].present && g_core->controls[channel].raw &&
                         g_ctx.vcr_get_task() == task_idle)
                     {
                         g_core->input_read_controller(channel, &PIF_RAMb[i]);

--- a/src/Core/R4300/VCR.cpp
+++ b/src/Core/R4300/VCR.cpp
@@ -204,17 +204,17 @@ static void set_rom_info(core_vcr_movie_header *header)
 
     for (int32_t i = 0; i < 4; ++i)
     {
-        if (g_core->controls[i].Plugin == CoreControllerExtension::Mempak)
+        if (g_core->controls[i].plugin == CoreControllerExtension::Mempak)
         {
             header->controller_flags |= CONTROLLER_X_MEMPAK(i);
         }
 
-        if (g_core->controls[i].Plugin == CoreControllerExtension::Rumblepak)
+        if (g_core->controls[i].plugin == CoreControllerExtension::Rumblepak)
         {
             header->controller_flags |= CONTROLLER_X_RUMBLE(i);
         }
 
-        if (!g_core->controls[i].Present) continue;
+        if (!g_core->controls[i].present) continue;
 
         header->controller_flags |= CONTROLLER_X_PRESENT(i);
         header->num_controllers++;
@@ -1244,28 +1244,28 @@ bool show_controller_warning(const core_vcr_movie_header &header)
 {
     for (int32_t i = 0; i < 4; ++i)
     {
-        if (!g_core->controls[i].Present && header.controller_flags & CONTROLLER_X_PRESENT(i))
+        if (!g_core->controls[i].present && header.controller_flags & CONTROLLER_X_PRESENT(i))
         {
             g_core->show_dialog(std::format(CONTROLLER_OFF_ON_MISMATCH, i + 1).c_str(), "VCR", fsvc_error);
             return false;
         }
-        if (g_core->controls[i].Present && !(header.controller_flags & CONTROLLER_X_PRESENT(i)))
+        if (g_core->controls[i].present && !(header.controller_flags & CONTROLLER_X_PRESENT(i)))
         {
             g_core->show_dialog(std::format(CONTROLLER_ON_OFF_MISMATCH, i + 1).c_str(), "VCR", fsvc_warning);
         }
         else
         {
-            if (g_core->controls[i].Present && (g_core->controls[i].Plugin != CoreControllerExtension::Mempak) &&
+            if (g_core->controls[i].present && (g_core->controls[i].plugin != CoreControllerExtension::Mempak) &&
                 header.controller_flags & CONTROLLER_X_MEMPAK(i))
             {
                 g_core->show_dialog(std::format(CONTROLLER_MEMPAK_MISMATCH, i + 1).c_str(), "VCR", fsvc_warning);
             }
-            if (g_core->controls[i].Present && (g_core->controls[i].Plugin != CoreControllerExtension::Rumblepak) &&
+            if (g_core->controls[i].present && (g_core->controls[i].plugin != CoreControllerExtension::Rumblepak) &&
                 header.controller_flags & CONTROLLER_X_RUMBLE(i))
             {
                 g_core->show_dialog(std::format(CONTROLLER_RUMBLEPAK_MISMATCH, i + 1).c_str(), "VCR", fsvc_warning);
             }
-            if (g_core->controls[i].Present && (g_core->controls[i].Plugin != CoreControllerExtension::None) &&
+            if (g_core->controls[i].present && (g_core->controls[i].plugin != CoreControllerExtension::None) &&
                 !(header.controller_flags & (CONTROLLER_X_MEMPAK(i) | CONTROLLER_X_RUMBLE(i))))
             {
                 g_core->show_dialog(std::format(CONTROLLER_MEMPAK_RUMBLEPAK_MISMATCH, i + 1).c_str(), "VCR",

--- a/src/Core/include/m64rr/API.hpp
+++ b/src/Core/include/m64rr/API.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "m64rr/Types.hpp"
+#include <stack>
 
 #ifdef __cplusplus
 extern "C"
@@ -241,27 +242,27 @@ extern "C"
         std::function<void(const core_st_callback_info &info, const std::vector<uint8_t> &buffer)> st_pre_callback =
             [](const core_st_callback_info &, const std::vector<uint8_t> &) {};
 
-        std::function<void()> video_process_dlist;
-        std::function<void()> video_process_rdp_list;
-        std::function<void()> video_show_cfb;
-        std::function<void()> video_vi_status_changed;
-        std::function<void()> video_vi_width_changed;
-        std::function<void(int32_t *width, int32_t *height)> video_get_video_size;
-        std::function<void(uint32_t)> video_fb_read;
-        std::function<void(uint32_t addr, uint32_t size)> video_fb_write;
-        std::function<void(CoreFBInfo[6])> video_fb_get_frame_buffer_info;
+        void (*video_process_dlist)();
+        void (*video_process_rdp_list)();
+        void (*video_show_cfb)();
+        void (*video_vi_status_changed)();
+        void (*video_vi_width_changed)();
+        void (*video_get_video_size)(int32_t *width, int32_t *height);
+        void (*video_fb_read)(uint32_t);
+        void (*video_fb_write)(uint32_t addr, uint32_t size);
+        void (*video_fb_get_frame_buffer_info)(CoreFBInfo[6]);
 
-        std::function<void(CoreSystemType system_type)> audio_ai_dacrate_changed;
-        std::function<void()> audio_ai_len_changed;
-        std::function<uint32_t()> audio_ai_read_length;
-        std::function<void()> audio_process_alist;
+        void (*audio_ai_dacrate_changed)(CoreSystemType system_type);
+        void (*audio_ai_len_changed)();
+        uint32_t (*audio_ai_read_length)();
+        void (*audio_process_alist)();
 
-        std::function<void(int32_t controller, unsigned char *command)> input_controller_command;
-        std::function<void(int32_t controller, CoreButtons *keys)> input_get_keys;
-        std::function<void(int32_t controller, CoreButtons keys)> input_set_keys;
-        std::function<void(int32_t controller, unsigned char *command)> input_read_controller;
+        void (*input_controller_command)(int32_t controller, unsigned char *command);
+        void (*input_get_keys)(int32_t controller, CoreButtons *keys);
+        void (*input_set_keys)(int32_t controller, CoreButtons keys);
+        void (*input_read_controller)(int32_t controller, unsigned char *command);
 
-        std::function<uint32_t(uint32_t)> rsp_do_rsp_cycles;
+        uint32_t (*rsp_do_rsp_cycles)(uint32_t);
     };
 
     /**

--- a/src/Core/include/m64rr/API.hpp
+++ b/src/Core/include/m64rr/API.hpp
@@ -274,7 +274,7 @@ extern "C"
         uint32_t *rdram;
         core_rdram_reg *rdram_register;
         core_pi_reg *pi_register;
-        core_mips_reg *MI_register;
+        core_mips_reg *mi_register;
         core_sp_reg *sp_register;
         core_si_reg *si_register;
         core_vi_reg *vi_register;
@@ -283,9 +283,9 @@ extern "C"
         core_ai_reg *ai_register;
         core_dpc_reg *dpc_register;
         core_dps_reg *dps_register;
-        uint32_t *SP_DMEM;
-        uint32_t *SP_IMEM;
-        uint32_t *PIF_RAM;
+        uint32_t *sp_dmem;
+        uint32_t *sp_imem;
+        uint32_t *pif_ram;
         size_t *rcp_counter;
 
 #pragma region Emulator

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -78,53 +78,17 @@ extern "C"
     /**
      * \brief Represents an extension for a controller.
      */
-    enum class ControllerExtension : uint8_t
-    {
-        None,
-        Mempak,
-        Rumblepak,
-        Transferpak,
-        Raw,
-    };
+    using ControllerExtension = CoreControllerExtension;
 
     /**
      * \brief Describes a controller.
      */
-    struct Controller
-    {
-        bool present;
-        bool raw;
-        ControllerExtension plugin;
-    };
+    using Controller = CoreController;
 
     /**
      * \brief Represents a controller state.
      */
-    union Buttons {
-        uint32_t value;
-
-        struct
-        {
-            unsigned dr : 1;
-            unsigned dl : 1;
-            unsigned dd : 1;
-            unsigned du : 1;
-            unsigned start : 1;
-            unsigned z : 1;
-            unsigned b : 1;
-            unsigned a : 1;
-            unsigned cr : 1;
-            unsigned cl : 1;
-            unsigned cd : 1;
-            unsigned cu : 1;
-            unsigned r : 1;
-            unsigned l : 1;
-            unsigned reserved_1 : 1;
-            unsigned reserved_2 : 1;
-            signed x : 8;
-            signed y : 8;
-        };
-    };
+    using Buttons = CoreButtons;
 
     struct PluginMetadata
     {

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -267,11 +267,12 @@ extern "C"
     typedef void(CALL *PtrProcessRDPList)();
     typedef void(CALL *PtrReadVideo)(void *buffer, int32_t *width, int32_t *height);
 
+
     typedef void(CALL *PtrAIDacrateChanged)(CoreSystemType system_type);
     typedef void(CALL *PtrAILenChanged)();
 
-    typedef void(CALL *PtrGetKeys)(uint8_t index, Buttons *buttons);
-    typedef void(CALL *PtrSetKeys)(uint8_t index, const Buttons *buttons);
+    typedef void(CALL *PtrGetKeys)(int32_t index, Buttons *buttons);
+    typedef void(CALL *PtrSetKeys)(int32_t index, Buttons buttons);
     typedef void(CALL *PtrReadController)(int32_t controller, unsigned char *command);
 
     typedef void(CALL *PtrDoRSPCycles)(uint32_t);
@@ -352,7 +353,7 @@ extern "C"
      * \param controller The controller index.
      * \param keys The buttons to be set.
      */
-    EXPORT void CALL M64RRSetKeys(uint8_t index, const Buttons *buttons);
+    EXPORT void CALL M64RRSetKeys(uint8_t index, Buttons buttons);
 
     /**
      * \brief Notifies the plugin of a controller command.

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -16,10 +16,12 @@
 #endif
 
 #include "m64rr/Types.hpp"
+#include <cstdint>
 
 #if defined(_WIN32)
 #define EXPORT __declspec(dllexport)
 #define CALL __cdecl
+#include <Windows.h>
 #elif defined(__linux__)
 #define EXPORT
 #define CALL
@@ -272,7 +274,7 @@ extern "C"
     typedef void(CALL *PtrSetKeys)(uint8_t index, const Buttons *buttons);
     typedef void(CALL *PtrReadController)(int32_t controller, unsigned char *command);
 
-    typedef void(CALL *PtrDoRSPCycles)(uint8_t);
+    typedef void(CALL *PtrDoRSPCycles)(uint32_t);
 };
 
 } // namespace M64RRSpec
@@ -362,10 +364,10 @@ extern "C"
     // ---
 
     /**
-     * \brief Does RSP cycles.
+     * \brief Advances the RSP by a number of cycles.
      * \param cycles The number of RSP cycles to do.
      */
-    EXPORT void CALL M64RRDoRSPCycles(uint8_t cycles);
+    EXPORT void CALL M64RRDoRSPCycles(uint32_t cycles);
 
     // ReSharper restore CppInconsistentNaming
 }

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -166,22 +166,22 @@ extern "C"
         /**
          * \brief Logs the specified message at the trace level.
          */
-        void (*log_trace)(const wchar_t *);
+        void (*log_trace)(const char *);
 
         /**
          * \brief Logs the specified message at the info level.
          */
-        void (*log_info)(const wchar_t *);
+        void (*log_info)(const char *);
 
         /**
          * \brief Logs the specified message at the warning level.
          */
-        void (*log_warn)(const wchar_t *);
+        void (*log_warn)(const char *);
 
         /**
          * \brief Logs the specified message at the error level.
          */
-        void (*log_error)(const wchar_t *);
+        void (*log_error)(const char *);
 
         /**
          * \brief Gets the effective speed mode.

--- a/src/Core/include/m64rr/Types.hpp
+++ b/src/Core/include/m64rr/Types.hpp
@@ -137,9 +137,9 @@ enum class CoreControllerExtension : int32_t
  */
 struct CoreController
 {
-    int32_t Present;
-    int32_t RawData;
-    CoreControllerExtension Plugin;
+    int32_t present;
+    int32_t raw;
+    CoreControllerExtension plugin;
 };
 
 /**

--- a/src/Core/include/m64rr/Types.hpp
+++ b/src/Core/include/m64rr/Types.hpp
@@ -7,6 +7,12 @@
 // ReSharper disable CppInconsistentNaming
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <type_traits>
+
 /**
  * An enum containing results that can be returned by the core.
  */

--- a/src/Plugins.Win32.TASAudio/Main.cpp
+++ b/src/Plugins.Win32.TASAudio/Main.cpp
@@ -119,8 +119,7 @@ EXPORT void CALL M64RRProcessEvent(Event event)
         }
         catch (std::exception &e)
         {
-            g_plugin->log_error(
-                IOUtils::to_wide_string(std::format("Exception at InitiateAudio(): {}", e.what())).c_str());
+            g_plugin->log_error(std::format("Exception at InitiateAudio(): {}", e.what()).c_str());
         }
         break;
     }
@@ -144,8 +143,7 @@ EXPORT void CALL M64RRAIDacrateChanged(CoreSystemType system_type)
     }
     catch (std::exception &e)
     {
-        g_plugin->log_error(
-            IOUtils::to_wide_string(std::format("Exception at AiDacrateChanged(): {}", e.what())).c_str());
+        g_plugin->log_error(std::format("Exception at AiDacrateChanged(): {}", e.what()).c_str());
     }
 }
 
@@ -166,6 +164,6 @@ EXPORT void CALL M64RRAILenChanged()
     }
     catch (std::exception &e)
     {
-        g_plugin->log_error(IOUtils::to_wide_string(std::format("Exception at AiLenChanged(): {}", e.what())).c_str());
+        g_plugin->log_error(std::format("Exception at AiLenChanged(): {}", e.what()).c_str());
     }
 }

--- a/src/Plugins.Win32.TASAudio/Main_Win32.cpp
+++ b/src/Plugins.Win32.TASAudio/Main_Win32.cpp
@@ -50,7 +50,7 @@ EXPORT void CALL M64RRRShowConfig(WindowHandle parent_window)
     SDLAudio::Config cfg = read_config();
     if (SDLAudio::win32_show_config(parent_window.hwnd(), cfg))
     {
-        if (g_plugin) g_plugin->log_info(L"Saving config...");
+        if (g_plugin) g_plugin->log_info("Saving config...");
         write_config(cfg);
         if (g_backend.has_value()) g_backend->merge_cfg_live(cfg);
     }

--- a/src/Plugins.Win32.TASAudio/SDLBackend.cpp
+++ b/src/Plugins.Win32.TASAudio/SDLBackend.cpp
@@ -40,7 +40,7 @@ SDLBackend::SDLBackend(Config &&config) : m_config(config)
     if (!m_stream) throw std::runtime_error(SDL_GetError());
     if (!SDL_BindAudioStream(m_device_id, m_stream)) throw std::runtime_error(SDL_GetError());
 
-    g_plugin->log_info(std::format(L"Opened default audio device, buffer size = {}, target = {}", m_buffer_size,
+    g_plugin->log_info(std::format("Opened default audio device, buffer size = {}, target = {}", m_buffer_size,
                                    config.src_buffer_target)
                            .c_str());
 

--- a/src/Plugins.Win32.TASInput/GamepadManager.cpp
+++ b/src/Plugins.Win32.TASInput/GamepadManager.cpp
@@ -190,7 +190,7 @@ void GamepadManager::update_current_gamepad()
     if (g_ctx.gamepad)
     {
         if (SDL_GetGamepadGUID(g_ctx.gamepad) == new_config.preferred_device_guid) return;
-        g_plugin->log_info(std::format(L"Closing gamepad {}", SDL_GetGamepadGUID(g_ctx.gamepad).data).c_str());
+        g_plugin->log_info(std::format("Closing gamepad {}", SDL_GetGamepadGUID(g_ctx.gamepad).data).c_str());
         SDL_CloseGamepad(g_ctx.gamepad);
         g_ctx.gamepad = nullptr;
     }
@@ -200,10 +200,10 @@ void GamepadManager::update_current_gamepad()
     g_ctx.gamepad = SDL_OpenGamepadByGUID(*new_config.preferred_device_guid);
     if (!g_ctx.gamepad)
     {
-        g_plugin->log_info(std::format(L"Failed to open gamepad {}", *new_config.preferred_device_guid->data).c_str());
+        g_plugin->log_info(std::format("Failed to open gamepad {}", *new_config.preferred_device_guid->data).c_str());
         return;
     }
-    g_plugin->log_info(std::format(L"Opened gamepad {}", *new_config.preferred_device_guid->data).c_str());
+    g_plugin->log_info(std::format("Opened gamepad {}", *new_config.preferred_device_guid->data).c_str());
 }
 
 GamepadManager::DeviceRegistry &GamepadManager::device_registry()

--- a/src/Plugins.Win32.TASInput/NewConfig.cpp
+++ b/src/Plugins.Win32.TASInput/NewConfig.cpp
@@ -23,7 +23,7 @@ static std::filesystem::path get_config_path()
 
 void save_config()
 {
-    g_plugin->log_trace(L"Saving config...");
+    g_plugin->log_trace("Saving config...");
 
     nlohmann::json j = new_config;
     std::ofstream ofs(get_config_path());
@@ -34,7 +34,7 @@ void save_config()
 
 void load_config()
 {
-    g_plugin->log_trace(L"Loading config...");
+    g_plugin->log_trace("Loading config...");
 
     auto json_path = get_config_path();
 
@@ -56,7 +56,7 @@ void load_config()
     }
     catch (const std::exception &e)
     {
-        g_plugin->log_warn(L"Config load failed, using defaults...");
+        g_plugin->log_warn("Config load failed, using defaults...");
         new_config = default_config;
     }
 

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -1071,12 +1071,12 @@ void Status::end_edit(int id, wchar_t *name)
 
 void Status::save_combos()
 {
-    const auto path = _T("combos.cmb");
+    const auto path = std::filesystem::path("combos.cmb");
 
-    g_plugin->log_trace(std::format(L"Saving combos to {}...", path).c_str());
+    g_plugin->log_trace(std::format("Saving combos to {}...", path.string()).c_str());
 
     FILE *f{};
-    if (_tfopen_s(&f, path, _T("wb")))
+    if (_tfopen_s(&f, path.c_str(), _T("wb")))
     {
         return;
     }
@@ -1090,12 +1090,12 @@ void Status::save_combos()
 
 void Status::load_combos(const std::filesystem::path &path)
 {
-    g_plugin->log_trace(std::format(L"Loading combos from {}...", path.c_str()).c_str());
+    g_plugin->log_trace(std::format("Loading combos from {}...", path.string()).c_str());
 
     auto buf = IOUtils::read_entire_file(path);
     if (buf.empty())
     {
-        g_plugin->log_error(L"read_file_buffer failed");
+        g_plugin->log_error("read_file_buffer failed");
         return;
     }
 

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -1336,7 +1336,7 @@ EXPORT void CALL M64RRGetKeys(uint8_t index, Buttons *buttons)
     status[index].get_input(buttons);
 }
 
-EXPORT void CALL M64RRSetKeys(uint8_t index, const Buttons *buttons)
+EXPORT void CALL M64RRSetKeys(uint8_t index, Buttons buttons)
 {
-    status[index].set_visuals_lazy(*buttons, false);
+    status[index].set_visuals_lazy(buttons, false);
 }

--- a/src/Plugins.Win32.TASRSP/Config.cpp
+++ b/src/Plugins.Win32.TASRSP/Config.cpp
@@ -23,7 +23,7 @@ static std::filesystem::path get_config_path()
 
 void config_save()
 {
-    g_plugin->log_trace(L"Saving config...");
+    g_plugin->log_trace("Saving config...");
 
     nlohmann::json j = config;
     std::ofstream ofs(get_config_path());
@@ -32,7 +32,7 @@ void config_save()
 
 void config_load()
 {
-    g_plugin->log_trace(L"Loading config...");
+    g_plugin->log_trace("Loading config...");
 
     auto json_path = get_config_path();
 
@@ -53,7 +53,7 @@ void config_load()
     }
     catch (const std::exception &e)
     {
-        g_plugin->log_warn(L"Config load failed, using defaults...");
+        g_plugin->log_warn("Config load failed, using defaults...");
         config = default_config;
     }
 }

--- a/src/Plugins.Win32.TASRSP/JPEG.cpp
+++ b/src/Plugins.Win32.TASRSP/JPEG.cpp
@@ -48,7 +48,7 @@ void jpg_uncompress(OSTask_t *task)
     }
     else
     {
-        g_plugin->log_warn(L"jpg_uncompress: !flags");
+        g_plugin->log_warn("jpg_uncompress: !flags");
     }
     pic = (int16_t *)(g_plugin->rdram + jpg_data.pic);
 
@@ -271,7 +271,7 @@ void jpg_uncompress(OSTask_t *task)
 
         if (jpg_data.h == 0)
         {
-            g_plugin->log_warn(L"h==0");
+            g_plugin->log_warn("h==0");
         }
         else
         {

--- a/src/Plugins.Win32.TASVideo/Config.cpp
+++ b/src/Plugins.Win32.TASVideo/Config.cpp
@@ -106,7 +106,7 @@ void Config_LoadConfig()
     }
     catch (const std::exception &e)
     {
-        g_plugin->log_warn(L"Config load failed, using defaults...");
+        g_plugin->log_warn("Config load failed, using defaults...");
         Config_SetDefaults();
     }
 }

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -46,7 +46,7 @@ void OGL_InitExtensions()
     GLenum glew = glewInit();
     if (glew != GLEW_OK)
     {
-        g_plugin->log_error(L"Error initialising glew");
+        g_plugin->log_error("Error initialising glew");
         return;
     }
 
@@ -176,7 +176,7 @@ bool OGL_InitContext()
 
     if (!s_sdl_context)
     {
-        g_plugin->log_info(L"OpenGL ES 2.0 context unavailable; falling back to desktop OpenGL.");
+        g_plugin->log_info("OpenGL ES 2.0 context unavailable; falling back to desktop OpenGL.");
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
@@ -201,8 +201,8 @@ bool OGL_InitContext()
     OGL_InitExtensions();
     OGL_InitStates();
 
-    g_plugin->log_info(OGL.isGLES ? L"TASVideo: running on an OpenGL ES 2.0 context."
-                              : L"TASVideo: running on a desktop OpenGL compatibility context.");
+    g_plugin->log_info(OGL.isGLES ? "TASVideo: running on an OpenGL ES 2.0 context."
+                              : "TASVideo: running on a desktop OpenGL compatibility context.");
 
     OGL.context_initialized = TRUE;
 

--- a/src/Plugins.Win32.TASVideo/glsl_combiner.cpp
+++ b/src/Plugins.Win32.TASVideo/glsl_combiner.cpp
@@ -63,7 +63,7 @@ static const char *s_vertexShaderBody = "attribute vec4 aPosition;\n"
                                           "    vFog = aFog;\n"
                                           "}\n";
 
-static void LogInfoLog(const wchar_t *what, GLuint object, bool isProgram)
+static void LogInfoLog(const char *what, GLuint object, bool isProgram)
 {
     GLint length = 0;
     if (isProgram)
@@ -81,13 +81,7 @@ static void LogInfoLog(const wchar_t *what, GLuint object, bool isProgram)
             glGetShaderInfoLog(object, length, nullptr, infoLog.data());
     }
 
-    std::wstring message(what);
-    message += L": ";
-    for (const char c : infoLog)
-    {
-        if (c != '\0') message += (wchar_t)(unsigned char)c;
-    }
-    g_plugin->log_error(message.c_str());
+    g_plugin->log_error(std::format("{}: {}", what, infoLog).c_str());
 }
 
 static GLuint CompileShader(GLenum type, const char *source)
@@ -95,7 +89,7 @@ static GLuint CompileShader(GLenum type, const char *source)
     const GLuint shader = glCreateShader(type);
     if (shader == 0)
     {
-        g_plugin->log_error(L"GLSL combiner: glCreateShader failed");
+        g_plugin->log_error("GLSL combiner: glCreateShader failed");
         return 0;
     }
 
@@ -106,8 +100,8 @@ static GLuint CompileShader(GLenum type, const char *source)
     glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
     if (status != GL_TRUE)
     {
-        LogInfoLog(type == GL_VERTEX_SHADER ? L"GLSL combiner: vertex shader compile failed"
-                                            : L"GLSL combiner: fragment shader compile failed",
+        LogInfoLog(type == GL_VERTEX_SHADER ? "GLSL combiner: vertex shader compile failed"
+                                            : "GLSL combiner: fragment shader compile failed",
                    shader, false);
         glDeleteShader(shader);
         return 0;
@@ -433,7 +427,7 @@ void GLSLCombiner_Init()
 
     if (!GLEW_VERSION_2_0)
     {
-        g_plugin->log_error(L"GLSL combiner: OpenGL 2.0 not available, shaders will fail to compile");
+        g_plugin->log_error("GLSL combiner: OpenGL 2.0 not available, shaders will fail to compile");
         return;
     }
 
@@ -505,7 +499,7 @@ GLSLProgram *GLSLCombiner_Compile(Combiner *color, Combiner *alpha)
     glGetProgramiv(glProgram, GL_LINK_STATUS, &status);
     if (status != GL_TRUE)
     {
-        LogInfoLog(L"GLSL combiner: program link failed", glProgram, true);
+        LogInfoLog("GLSL combiner: program link failed", glProgram, true);
         glDeleteProgram(glProgram);
         CacheUniformLocations(program);
         return program;

--- a/src/Views.Win32/include/Views.Win32/ZESpec.h
+++ b/src/Views.Win32/include/Views.Win32/ZESpec.h
@@ -87,9 +87,9 @@ extern "C"
             }
 
             return CoreController{
-                .Present = present ? 1 : 0,
-                .RawData = raw ? 1 : 0,
-                .Plugin = extension,
+                .present = present ? 1 : 0,
+                .raw = raw ? 1 : 0,
+                .plugin = extension,
             };
         }
     };

--- a/src/Views.Win32/lua/modules/Emu.hpp
+++ b/src/Views.Win32/lua/modules/Emu.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <Main.hpp>
 #include <Messenger.hpp>
 #include <plugin/Plugin.hpp>
 #include <components/Statusbar.hpp>

--- a/src/Views.Win32/lua/modules/Emu.hpp
+++ b/src/Views.Win32/lua/modules/Emu.hpp
@@ -224,7 +224,7 @@ static int GetAddress(lua_State *L)
     }
     const NameAndVariable list[] = {A("rdram", g_main_ctx.core_ctx->rdram),
                                     A("rdram_register", g_main_ctx.core_ctx->rdram_register),
-                                    A("MI_register", g_main_ctx.core_ctx->MI_register),
+                                    A("MI_register", g_main_ctx.core_ctx->mi_register),
                                     A("pi_register", g_main_ctx.core_ctx->pi_register),
                                     A("sp_register", g_main_ctx.core_ctx->sp_register),
                                     A("rsp_register", g_main_ctx.core_ctx->rsp_register),
@@ -234,8 +234,8 @@ static int GetAddress(lua_State *L)
                                     A("ai_register", g_main_ctx.core_ctx->ai_register),
                                     A("dpc_register", g_main_ctx.core_ctx->dpc_register),
                                     A("dps_register", g_main_ctx.core_ctx->dps_register),
-                                    B("SP_DMEM", g_main_ctx.core_ctx->SP_DMEM),
-                                    B("PIF_RAM", g_main_ctx.core_ctx->PIF_RAM),
+                                    B("SP_DMEM", g_main_ctx.core_ctx->sp_dmem),
+                                    B("PIF_RAM", g_main_ctx.core_ctx->pif_ram),
                                     {NULL, NULL}};
 #undef A
 #undef B

--- a/src/Views.Win32/plugin/M64RRPlugin.cpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.cpp
@@ -31,38 +31,6 @@ static M64RRSpec::PtrDoRSPCycles s_mupenrr_do_rsp_cycles_fn = nullptr;
 #define LOOKUP_MUPENRR_FN(mupenrr_ptr, mupenrr_type, export_name)                                                      \
     mupenrr_ptr = (mupenrr_type)GetProcAddress(m_module, export_name);
 
-static CoreController controller_to_core_controller(const M64RRSpec::Controller &controller)
-{
-    CoreControllerExtension extension;
-    switch (controller.plugin)
-    {
-    case M64RRSpec::ControllerExtension::None:
-        extension = CoreControllerExtension::None;
-        break;
-    case M64RRSpec::ControllerExtension::Mempak:
-        extension = CoreControllerExtension::Mempak;
-        break;
-    case M64RRSpec::ControllerExtension::Rumblepak:
-        extension = CoreControllerExtension::Rumblepak;
-        break;
-    case M64RRSpec::ControllerExtension::Transferpak:
-        extension = CoreControllerExtension::Transferpak;
-        break;
-    case M64RRSpec::ControllerExtension::Raw:
-        extension = CoreControllerExtension::Raw;
-        break;
-    default:
-        RT_ASSERT(false, L"Unknown controller extension");
-        break;
-    }
-
-    return CoreController{
-        .Present = controller.present ? 1 : 0,
-        .RawData = controller.raw ? 1 : 0,
-        .Plugin = extension,
-    };
-}
-
 static size_t get_config_path(char *data, size_t size)
 {
     static const std::u8string config_path = std::filesystem::absolute(IOUtils::config_path()).u8string();
@@ -368,7 +336,7 @@ void M64RRPlugin::initiate(ZESpecFuncs &funcs)
 
         for (size_t i = 0; i < std::size(tmp_controllers); ++i)
         {
-            g_main_ctx.core.controls[i] = controller_to_core_controller(tmp_controllers[i]);
+            g_main_ctx.core.controls[i] = tmp_controllers[i];
         }
         break;
     }

--- a/src/Views.Win32/plugin/M64RRPlugin.cpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.cpp
@@ -358,7 +358,7 @@ void M64RRPlugin::initiate(ZESpecFuncs &funcs)
         };
         funcs.input_set_keys = [](int32_t controller, ZESpec::Buttons keys) {
             M64RRSpec::Buttons buttons{keys.value};
-            if (s_mupenrr_set_keys_fn) s_mupenrr_set_keys_fn(controller, &buttons);
+            if (s_mupenrr_set_keys_fn) s_mupenrr_set_keys_fn(controller, buttons);
         };
         funcs.input_read_controller = [](int32_t controller, unsigned char *command) {
             if (s_mupenrr_read_controller_fn) s_mupenrr_read_controller_fn(controller, command);

--- a/src/Views.Win32/plugin/M64RRPlugin.cpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.cpp
@@ -191,11 +191,11 @@ void M64RRPlugin::initiate(ZESpecFuncs &funcs)
     init->main_window = M64RRSpec::WindowHandle(g_main_ctx.hwnd);
     init->rom = g_main_ctx.core_ctx->rom;
     init->rdram = (uint8_t *)g_main_ctx.core_ctx->rdram;
-    init->dmem = (uint8_t *)g_main_ctx.core_ctx->SP_DMEM;
-    init->imem = (uint8_t *)g_main_ctx.core_ctx->SP_IMEM;
+    init->dmem = (uint8_t *)g_main_ctx.core_ctx->sp_dmem;
+    init->imem = (uint8_t *)g_main_ctx.core_ctx->sp_imem;
 
     init->rdram_register = g_main_ctx.core_ctx->rdram_register;
-    init->mi_register = g_main_ctx.core_ctx->MI_register;
+    init->mi_register = g_main_ctx.core_ctx->mi_register;
     init->pi_register = g_main_ctx.core_ctx->pi_register;
     init->sp_register = g_main_ctx.core_ctx->sp_register;
     init->rsp_register = g_main_ctx.core_ctx->rsp_register;
@@ -220,28 +220,28 @@ void M64RRPlugin::initiate(ZESpecFuncs &funcs)
     switch (m_type)
     {
     case Plugin::Type::Video:
-        init->log_trace = [](const wchar_t *str) { g_video_logger->trace(str); };
-        init->log_info = [](const wchar_t *str) { g_video_logger->info(str); };
-        init->log_warn = [](const wchar_t *str) { g_video_logger->warn(str); };
-        init->log_error = [](const wchar_t *str) { g_video_logger->error(str); };
+        init->log_trace = [](const char *str) { g_video_logger->trace(str); };
+        init->log_info = [](const char *str) { g_video_logger->info(str); };
+        init->log_warn = [](const char *str) { g_video_logger->warn(str); };
+        init->log_error = [](const char *str) { g_video_logger->error(str); };
         break;
     case Plugin::Type::Audio:
-        init->log_trace = [](const wchar_t *str) { g_audio_logger->trace(str); };
-        init->log_info = [](const wchar_t *str) { g_audio_logger->info(str); };
-        init->log_warn = [](const wchar_t *str) { g_audio_logger->warn(str); };
-        init->log_error = [](const wchar_t *str) { g_audio_logger->error(str); };
+        init->log_trace = [](const char *str) { g_audio_logger->trace(str); };
+        init->log_info = [](const char *str) { g_audio_logger->info(str); };
+        init->log_warn = [](const char *str) { g_audio_logger->warn(str); };
+        init->log_error = [](const char *str) { g_audio_logger->error(str); };
         break;
     case Plugin::Type::Input:
-        init->log_trace = [](const wchar_t *str) { g_input_logger->trace(str); };
-        init->log_info = [](const wchar_t *str) { g_input_logger->info(str); };
-        init->log_warn = [](const wchar_t *str) { g_input_logger->warn(str); };
-        init->log_error = [](const wchar_t *str) { g_input_logger->error(str); };
+        init->log_trace = [](const char *str) { g_input_logger->trace(str); };
+        init->log_info = [](const char *str) { g_input_logger->info(str); };
+        init->log_warn = [](const char *str) { g_input_logger->warn(str); };
+        init->log_error = [](const char *str) { g_input_logger->error(str); };
         break;
     case Plugin::Type::RSP:
-        init->log_trace = [](const wchar_t *str) { g_rsp_logger->trace(str); };
-        init->log_info = [](const wchar_t *str) { g_rsp_logger->info(str); };
-        init->log_warn = [](const wchar_t *str) { g_rsp_logger->warn(str); };
-        init->log_error = [](const wchar_t *str) { g_rsp_logger->error(str); };
+        init->log_trace = [](const char *str) { g_rsp_logger->trace(str); };
+        init->log_info = [](const char *str) { g_rsp_logger->info(str); };
+        init->log_warn = [](const char *str) { g_rsp_logger->warn(str); };
+        init->log_error = [](const char *str) { g_rsp_logger->error(str); };
         break;
     }
 

--- a/src/Views.Win32/plugin/Plugin.hpp
+++ b/src/Views.Win32/plugin/Plugin.hpp
@@ -36,7 +36,7 @@ struct ZESpecFuncs
     ZESpec::ROMOPEN audio_rom_open;
     ZESpec::ROMCLOSED audio_rom_closed;
     ZESpec::CLOSEDLL audio_close_dll_audio;
-    std::function<void(CoreSystemType system_type)> audio_ai_dacrate_changed;
+    M64RRSpec::PtrAIDacrateChanged audio_ai_dacrate_changed;
     ZESpec::AILENCHANGED audio_ai_len_changed;
     ZESpec::AIREADLENGTH audio_ai_read_length;
     ZESpec::PROCESSALIST audio_process_alist;

--- a/src/Views.Win32/plugin/ZEPlugin.cpp
+++ b/src/Views.Win32/plugin/ZEPlugin.cpp
@@ -282,9 +282,9 @@ void ZEPlugin::initiate(ZESpecFuncs &funcs)
         gfx_info.byteswapped = 1;
         gfx_info.rom = g_main_ctx.core_ctx->rom;
         gfx_info.rdram = (uint8_t *)g_main_ctx.core_ctx->rdram;
-        gfx_info.dmem = (uint8_t *)g_main_ctx.core_ctx->SP_DMEM;
-        gfx_info.imem = (uint8_t *)g_main_ctx.core_ctx->SP_IMEM;
-        gfx_info.mi_intr_reg = &g_main_ctx.core_ctx->MI_register->mi_intr_reg;
+        gfx_info.dmem = (uint8_t *)g_main_ctx.core_ctx->sp_dmem;
+        gfx_info.imem = (uint8_t *)g_main_ctx.core_ctx->sp_imem;
+        gfx_info.mi_intr_reg = &g_main_ctx.core_ctx->mi_register->mi_intr_reg;
         gfx_info.dpc_start_reg = &g_main_ctx.core_ctx->dpc_register->dpc_start;
         gfx_info.dpc_end_reg = &g_main_ctx.core_ctx->dpc_register->dpc_end;
         gfx_info.dpc_current_reg = &g_main_ctx.core_ctx->dpc_register->dpc_current;
@@ -361,8 +361,8 @@ void ZEPlugin::initiate(ZESpecFuncs &funcs)
         audio_info.byteswapped = 1;
         audio_info.rom = g_main_ctx.core_ctx->rom;
         audio_info.rdram = (uint8_t *)g_main_ctx.core_ctx->rdram;
-        audio_info.dmem = (uint8_t *)g_main_ctx.core_ctx->SP_DMEM;
-        audio_info.imem = (uint8_t *)g_main_ctx.core_ctx->SP_IMEM;
+        audio_info.dmem = (uint8_t *)g_main_ctx.core_ctx->sp_dmem;
+        audio_info.imem = (uint8_t *)g_main_ctx.core_ctx->sp_dmem;
         audio_info.mi_intr_reg = &dummy_dw;
         audio_info.ai_dram_addr_reg = &g_main_ctx.core_ctx->ai_register->ai_dram_addr;
         audio_info.ai_len_reg = &g_main_ctx.core_ctx->ai_register->ai_len;
@@ -430,9 +430,9 @@ void ZEPlugin::initiate(ZESpecFuncs &funcs)
 
         rsp_info.byteswapped = 1;
         rsp_info.rdram = (uint8_t *)g_main_ctx.core_ctx->rdram;
-        rsp_info.dmem = (uint8_t *)g_main_ctx.core_ctx->SP_DMEM;
-        rsp_info.imem = (uint8_t *)g_main_ctx.core_ctx->SP_IMEM;
-        rsp_info.mi_intr_reg = &g_main_ctx.core_ctx->MI_register->mi_intr_reg;
+        rsp_info.dmem = (uint8_t *)g_main_ctx.core_ctx->sp_dmem;
+        rsp_info.imem = (uint8_t *)g_main_ctx.core_ctx->sp_dmem;
+        rsp_info.mi_intr_reg = &g_main_ctx.core_ctx->mi_register->mi_intr_reg;
         rsp_info.sp_mem_addr_reg = &g_main_ctx.core_ctx->sp_register->sp_mem_addr_reg;
         rsp_info.sp_dram_addr_reg = &g_main_ctx.core_ctx->sp_register->sp_dram_addr_reg;
         rsp_info.sp_rd_len_reg = &g_main_ctx.core_ctx->sp_register->sp_rd_len_reg;

--- a/src/Views.Win32/plugin/ZEPlugin.cpp
+++ b/src/Views.Win32/plugin/ZEPlugin.cpp
@@ -22,6 +22,8 @@ ZESpec::Controller dummy_controllers[4]{};
 uint8_t dummy_header[0x40]{};
 uint32_t dummy_dw{};
 
+static ZESpec::AIDACRATECHANGED s_zespec_ai_dacrate_changed_fn = nullptr;
+
 #pragma region Dummy Functions
 
 static uint32_t CALL dummy_do_rsp_cycles(uint32_t Cycles)
@@ -333,8 +335,11 @@ void ZEPlugin::initiate(ZESpecFuncs &funcs)
 
         ZESpec::AIDACRATECHANGED audio_ai_dacrate_changed{};
         FUNC(audio_ai_dacrate_changed, ZESpec::AIDACRATECHANGED, dummy_ai_dacrate_changed, "AiDacrateChanged");
+        s_zespec_ai_dacrate_changed_fn = audio_ai_dacrate_changed;
 
-        funcs.audio_ai_dacrate_changed = [=](CoreSystemType system_type) {
+        funcs.audio_ai_dacrate_changed = [](CoreSystemType system_type) {
+            if (!s_zespec_ai_dacrate_changed_fn) return;
+
             int32_t ze_system_type{};
             switch (system_type)
             {
@@ -345,7 +350,8 @@ void ZEPlugin::initiate(ZESpecFuncs &funcs)
                 ze_system_type = 1;
                 break;
             }
-            if (audio_ai_dacrate_changed) audio_ai_dacrate_changed(ze_system_type);
+            
+            s_zespec_ai_dacrate_changed_fn(ze_system_type);
         };
 
         FUNC(funcs.audio_ai_len_changed, ZESpec::AILENCHANGED, dummy_void, "AiLenChanged");


### PR DESCRIPTION
This makes some changes to the manner in which plugins are implemented:

- Fixes some weird case inconsistencies in the core API.
- Switches logging to UTF-8.
- Changes the plugin functions in the core parameters to be passed via raw function pointers.
    - This should slightly reduce the overhead of calling into plugins.
- (WIP) Adjust core callbacks to match the M64RR spec.