### PR TITLE
refactor: clean up the plugin API

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run tools/format.py
-        run: python3 ./tools/format.py --clang-format clang-format-18
+        run: python3 ./tools/format.py
 
       - uses: peter-evans/create-pull-request@v7
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,8 @@ find_package(PkgConfig REQUIRED)
 # Core cross-platform dependencies
 find_package(Catch2 CONFIG REQUIRED)
 find_package(libdeflate CONFIG REQUIRED)
-if (NOT WIN32)
+
+if(NOT WIN32)
   pkg_check_modules(libsafec IMPORTED_TARGET GLOBAL "libsafec")
 endif()
 
@@ -105,17 +106,18 @@ endif()
 Copies all vcpkg dependencies into the target's folder.
 ]=======================]
 function(mupen64rr_copy_vcpkg_deps target)
-  if (MUPEN64RR_LINK_STATIC)
+  if(MUPEN64RR_LINK_STATIC)
     return()
   endif()
-  if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Windows" AND DEFINED VCPKG_INSTALLED_DIR))
+
+  if(NOT(${CMAKE_SYSTEM_NAME} STREQUAL "Windows" AND DEFINED VCPKG_INSTALLED_DIR))
     return()
   endif()
 
   add_custom_command(
     TARGET "${target}" POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E copy_directory
-      "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin" "$<TARGET_FILE_DIR:${target}>"
+    "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin" "$<TARGET_FILE_DIR:${target}>"
     VERBATIM
   )
 endfunction()
@@ -138,10 +140,10 @@ function(mupen64rr_copy_mingw_runtime target)
   add_custom_command(
     TARGET "${target}" POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different
-      "${_mingw_bindir}/libgcc_s_seh-1.dll"
-      "${_mingw_bindir}/libstdc++-6.dll"
-      "${_mingw_bindir}/libwinpthread-1.dll"
-      "$<TARGET_FILE_DIR:${target}>"
+    "${_mingw_bindir}/libgcc_s_seh-1.dll"
+    "${_mingw_bindir}/libstdc++-6.dll"
+    "${_mingw_bindir}/libwinpthread-1.dll"
+    "$<TARGET_FILE_DIR:${target}>"
     VERBATIM
   )
 endfunction()

--- a/src/Common/include/FNV1A.hpp
+++ b/src/Common/include/FNV1A.hpp
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <span>
+
 /**
  * \brief A module providing a FNV-1a hash function implementation.
  */

--- a/src/Common/include/IOUtils.hpp
+++ b/src/Common/include/IOUtils.hpp
@@ -5,7 +5,12 @@
  */
 #pragma once
 
+#include <cassert>
 #include <filesystem>
+#include <fstream>
+
+#include "StrUtils.hpp"
+
 #if defined(_WIN32)
 #ifndef NOMINMAX
 #define NOMINMAX

--- a/src/Common/include/MiscHelpers.hpp
+++ b/src/Common/include/MiscHelpers.hpp
@@ -6,6 +6,12 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include <libdeflate.h>
 
 /**

--- a/src/Common/include/StrUtils.hpp
+++ b/src/Common/include/StrUtils.hpp
@@ -6,8 +6,11 @@
 
 #pragma once
 
+#include <ranges>
+#include <sstream>
 #include <string_view>
 #include <string>
+#include <unordered_map>
 
 namespace StrUtils
 {

--- a/src/Common/include/StrUtils.hpp
+++ b/src/Common/include/StrUtils.hpp
@@ -146,7 +146,7 @@ inline std::string_view ctrim_string(std::string_view str)
     auto str2 = str.substr(start_iter - str.begin());
 
     auto end_iter = std::ranges::find_if(std::views::reverse(str2), not_isspace);
-    if (end_iter == str.rend()) return ""sv;
+    if (end_iter == str2.rend()) return ""sv;
     return str2.substr(0, end_iter.base() - str2.begin());
 }
 // Trims whitespace from the start and end of a wstring_view (as determined by iswspace()).
@@ -162,7 +162,7 @@ inline std::wstring_view ctrim_wstring(std::wstring_view str)
     auto str2 = str.substr(start_iter - str.begin());
 
     auto end_iter = std::ranges::find_if(std::views::reverse(str2), not_iswspace);
-    if (end_iter == str.rend()) return L""sv;
+    if (end_iter == str2.rend()) return L""sv;
     return str2.substr(0, end_iter.base() - str2.begin());
 }
 

--- a/src/Core.Tests/CMakeLists.txt
+++ b/src/Core.Tests/CMakeLists.txt
@@ -29,7 +29,9 @@ target_link_libraries(Mupen64RR.Core.Tests PRIVATE
     Catch2::Catch2WithMain
     Mupen64RR.Core._TestIncludes
 )
-if(NOT CMAKE_CROSSCOMPILING)
+
+# Skip running tests when cross-compiling between OSes.
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "${CMAKE_HOST_SYSTEM_NAME}")
     catch_discover_tests(Mupen64RR.Core.Tests)
 else()
     message(STATUS "Cross-compiling: skipping test discovery for Mupen64RR.Core.Tests (run manually on target)")

--- a/src/Core.Tests/CMakeLists.txt
+++ b/src/Core.Tests/CMakeLists.txt
@@ -11,6 +11,8 @@ endif()
 
 add_executable(Mupen64RR.Core.Tests
     "Common.hpp"
+
+    "PluginAPITests.cpp"
     "IOUtilsTests.cpp"
     "VCRTests.cpp"
     "VRTests.cpp"

--- a/src/Core.Tests/Common.hpp
+++ b/src/Core.Tests/Common.hpp
@@ -6,3 +6,4 @@
 
 #include <CommonPCH.hpp>
 #include <catch2/catch_all.hpp>
+

--- a/src/Core.Tests/Common.hpp
+++ b/src/Core.Tests/Common.hpp
@@ -6,4 +6,3 @@
 
 #include <CommonPCH.hpp>
 #include <catch2/catch_all.hpp>
-

--- a/src/Core.Tests/PluginAPITests.cpp
+++ b/src/Core.Tests/PluginAPITests.cpp
@@ -1,0 +1,20 @@
+#include "Common.hpp"
+
+#define PLUGIN_WITH_CALLBACKS
+#include <m64rr/Plugin.hpp>
+
+#define MATCH_PLUGIN_FN(name)                                                                                          \
+    static_assert(std::is_same_v<decltype(&M64RR##name), M64RRSpec::Ptr##name>,                                        \
+                  "signature of M64RR" #name " does not match Ptr" #name);
+
+MATCH_PLUGIN_FN(GetMetadata)
+MATCH_PLUGIN_FN(ProcessEvent)
+MATCH_PLUGIN_FN(ShowConfig)
+MATCH_PLUGIN_FN(ProcessDList)
+MATCH_PLUGIN_FN(ProcessRDPList)
+MATCH_PLUGIN_FN(ReadVideo)
+MATCH_PLUGIN_FN(AIDacrateChanged)
+MATCH_PLUGIN_FN(AILenChanged)
+MATCH_PLUGIN_FN(GetKeys)
+MATCH_PLUGIN_FN(SetKeys)
+MATCH_PLUGIN_FN(ReadController)

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -101,9 +101,7 @@ endif()
 # options: disable dynarec
 if (${MUPEN64RR_ENABLE_DYNAREC})
     target_compile_definitions(Mupen64RR.Core PRIVATE "MUPEN64RR_ENABLE_DYNAREC")
-
-    # Select the dynarec backend by target architecture. The dynarec is
-    # x86-only, so error out on anything else:
+    # Select the dynarec backend by target architecture.
     #   x86-64 -> R4300/x86_64 (x86-64 recompiler)
     #   x86    -> R4300/x86 (original x86-32 recompiler)
     if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "^(AMD64|x86_64)$")

--- a/src/Core/Memory/Pif.cpp
+++ b/src/Core/Memory/Pif.cpp
@@ -136,7 +136,7 @@ void internal_ReadController(int32_t Control, uint8_t *Command)
     switch (Command[2])
     {
     case 1:
-        if (g_core->controls[Control].Present)
+        if (g_core->controls[Control].present)
         {
             cht_execute();
 
@@ -149,9 +149,9 @@ void internal_ReadController(int32_t Control, uint8_t *Command)
         break;
     case 2: // read controller pack
     case 3: // write controller pack
-        if (g_core->controls[Control].Present)
+        if (g_core->controls[Control].present)
         {
-            if (g_core->controls[Control].Plugin == CoreControllerExtension::Raw && g_core->input_controller_command)
+            if (g_core->controls[Control].plugin == CoreControllerExtension::Raw && g_core->input_controller_command)
                 g_core->input_read_controller(Control, Command);
         }
         break;
@@ -165,11 +165,11 @@ void internal_ControllerCommand(int32_t Control, uint8_t *Command)
     case 0x00: // check
     case 0xFF:
         if ((Command[1] & 0x80)) break;
-        if (g_core->controls[Control].Present)
+        if (g_core->controls[Control].present)
         {
             Command[3] = 0x05;
             Command[4] = 0x00;
-            switch (g_core->controls[Control].Plugin)
+            switch (g_core->controls[Control].plugin)
             {
             case CoreControllerExtension::Mempak:
                 Command[5] = 1;
@@ -186,12 +186,12 @@ void internal_ControllerCommand(int32_t Control, uint8_t *Command)
             Command[1] |= 0x80;
         break;
     case 0x01:
-        if (!g_core->controls[Control].Present) Command[1] |= 0x80;
+        if (!g_core->controls[Control].present) Command[1] |= 0x80;
         break;
     case 0x02: // read controller pack
-        if (g_core->controls[Control].Present)
+        if (g_core->controls[Control].present)
         {
-            switch (g_core->controls[Control].Plugin)
+            switch (g_core->controls[Control].plugin)
             {
             case CoreControllerExtension::Mempak: {
                 int32_t address = (Command[3] << 8) | Command[4];
@@ -233,9 +233,9 @@ void internal_ControllerCommand(int32_t Control, uint8_t *Command)
             Command[1] |= 0x80;
         break;
     case 0x03: // write controller pack
-        if (g_core->controls[Control].Present)
+        if (g_core->controls[Control].present)
         {
-            switch (g_core->controls[Control].Plugin)
+            switch (g_core->controls[Control].plugin)
             {
             case CoreControllerExtension::Mempak: {
                 int32_t address = (Command[3] << 8) | Command[4];
@@ -353,7 +353,7 @@ void update_pif_write()
                         break;
                     }
 
-                    if (g_core->controls[channel].Present && g_core->controls[channel].RawData)
+                    if (g_core->controls[channel].present && g_core->controls[channel].raw)
                         g_core->input_controller_command(channel, &PIF_RAMb[i]);
                     else
                         internal_ControllerCommand(channel, &PIF_RAMb[i]);
@@ -507,7 +507,7 @@ void update_pif_read()
 
                     // we handle raw data-mode controllers here:
                     // this is incompatible with VCR!
-                    if (g_core->controls[channel].Present && g_core->controls[channel].RawData &&
+                    if (g_core->controls[channel].present && g_core->controls[channel].raw &&
                         g_ctx.vcr_get_task() == task_idle)
                     {
                         g_core->input_read_controller(channel, &PIF_RAMb[i]);

--- a/src/Core/R4300/Recomp.hpp
+++ b/src/Core/R4300/Recomp.hpp
@@ -17,7 +17,7 @@
 // Interpreter-only build on a non-x86 host: nothing reads these fields, but
 // precomp_instr must still have a member of this type. Recomp.cpp does write
 // need_map unconditionally, so the field has to exist.
-typedef struct _reg_cache_struct
+typedef struct
 {
     int32_t need_map;
 } reg_cache_struct;

--- a/src/Core/R4300/VCR.cpp
+++ b/src/Core/R4300/VCR.cpp
@@ -204,17 +204,17 @@ static void set_rom_info(core_vcr_movie_header *header)
 
     for (int32_t i = 0; i < 4; ++i)
     {
-        if (g_core->controls[i].Plugin == CoreControllerExtension::Mempak)
+        if (g_core->controls[i].plugin == CoreControllerExtension::Mempak)
         {
             header->controller_flags |= CONTROLLER_X_MEMPAK(i);
         }
 
-        if (g_core->controls[i].Plugin == CoreControllerExtension::Rumblepak)
+        if (g_core->controls[i].plugin == CoreControllerExtension::Rumblepak)
         {
             header->controller_flags |= CONTROLLER_X_RUMBLE(i);
         }
 
-        if (!g_core->controls[i].Present) continue;
+        if (!g_core->controls[i].present) continue;
 
         header->controller_flags |= CONTROLLER_X_PRESENT(i);
         header->num_controllers++;
@@ -1244,28 +1244,28 @@ bool show_controller_warning(const core_vcr_movie_header &header)
 {
     for (int32_t i = 0; i < 4; ++i)
     {
-        if (!g_core->controls[i].Present && header.controller_flags & CONTROLLER_X_PRESENT(i))
+        if (!g_core->controls[i].present && header.controller_flags & CONTROLLER_X_PRESENT(i))
         {
             g_core->show_dialog(std::format(CONTROLLER_OFF_ON_MISMATCH, i + 1).c_str(), "VCR", fsvc_error);
             return false;
         }
-        if (g_core->controls[i].Present && !(header.controller_flags & CONTROLLER_X_PRESENT(i)))
+        if (g_core->controls[i].present && !(header.controller_flags & CONTROLLER_X_PRESENT(i)))
         {
             g_core->show_dialog(std::format(CONTROLLER_ON_OFF_MISMATCH, i + 1).c_str(), "VCR", fsvc_warning);
         }
         else
         {
-            if (g_core->controls[i].Present && (g_core->controls[i].Plugin != CoreControllerExtension::Mempak) &&
+            if (g_core->controls[i].present && (g_core->controls[i].plugin != CoreControllerExtension::Mempak) &&
                 header.controller_flags & CONTROLLER_X_MEMPAK(i))
             {
                 g_core->show_dialog(std::format(CONTROLLER_MEMPAK_MISMATCH, i + 1).c_str(), "VCR", fsvc_warning);
             }
-            if (g_core->controls[i].Present && (g_core->controls[i].Plugin != CoreControllerExtension::Rumblepak) &&
+            if (g_core->controls[i].present && (g_core->controls[i].plugin != CoreControllerExtension::Rumblepak) &&
                 header.controller_flags & CONTROLLER_X_RUMBLE(i))
             {
                 g_core->show_dialog(std::format(CONTROLLER_RUMBLEPAK_MISMATCH, i + 1).c_str(), "VCR", fsvc_warning);
             }
-            if (g_core->controls[i].Present && (g_core->controls[i].Plugin != CoreControllerExtension::None) &&
+            if (g_core->controls[i].present && (g_core->controls[i].plugin != CoreControllerExtension::None) &&
                 !(header.controller_flags & (CONTROLLER_X_MEMPAK(i) | CONTROLLER_X_RUMBLE(i))))
             {
                 g_core->show_dialog(std::format(CONTROLLER_MEMPAK_RUMBLEPAK_MISMATCH, i + 1).c_str(), "VCR",

--- a/src/Core/R4300/x86/Assemble.hpp
+++ b/src/Core/R4300/x86/Assemble.hpp
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+#include <cstdint>
 
 #define EAX 0
 #define ECX 1

--- a/src/Core/R4300/x86/Assemble.hpp
+++ b/src/Core/R4300/x86/Assemble.hpp
@@ -33,7 +33,7 @@
 #define DH 6
 #define BH 7
 
-typedef struct _reg_cache_struct
+typedef struct
 {
     int32_t need_map;
     void *needed_registers[8];

--- a/src/Core/R4300/x86_64/Assemble.hpp
+++ b/src/Core/R4300/x86_64/Assemble.hpp
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+#include <cstdint>
 
 #define EAX 0
 #define ECX 1

--- a/src/Core/R4300/x86_64/Assemble.hpp
+++ b/src/Core/R4300/x86_64/Assemble.hpp
@@ -33,7 +33,7 @@
 #define DH 6
 #define BH 7
 
-typedef struct _reg_cache_struct
+typedef struct
 {
     int32_t need_map;
     void *needed_registers[8];

--- a/src/Core/include/m64rr/API.hpp
+++ b/src/Core/include/m64rr/API.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "m64rr/Types.hpp"
+#include <stack>
 
 #ifdef __cplusplus
 extern "C"

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -80,53 +80,17 @@ extern "C"
     /**
      * \brief Represents an extension for a controller.
      */
-    enum class ControllerExtension : uint8_t
-    {
-        None,
-        Mempak,
-        Rumblepak,
-        Transferpak,
-        Raw,
-    };
+    using ControllerExtension = CoreControllerExtension;
 
     /**
      * \brief Describes a controller.
      */
-    struct Controller
-    {
-        bool present;
-        bool raw;
-        ControllerExtension plugin;
-    };
+    using Controller = CoreController;
 
     /**
      * \brief Represents a controller state.
      */
-    union Buttons {
-        uint32_t value;
-
-        struct
-        {
-            unsigned dr : 1;
-            unsigned dl : 1;
-            unsigned dd : 1;
-            unsigned du : 1;
-            unsigned start : 1;
-            unsigned z : 1;
-            unsigned b : 1;
-            unsigned a : 1;
-            unsigned cr : 1;
-            unsigned cl : 1;
-            unsigned cd : 1;
-            unsigned cu : 1;
-            unsigned r : 1;
-            unsigned l : 1;
-            unsigned reserved_1 : 1;
-            unsigned reserved_2 : 1;
-            signed x : 8;
-            signed y : 8;
-        };
-    };
+    using Buttons = CoreButtons;
 
     struct PluginMetadata
     {

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -16,10 +16,14 @@
 #endif
 
 #include "m64rr/Types.hpp"
+#include <cstdint>
 
 #if defined(_WIN32)
 #define EXPORT __declspec(dllexport)
 #define CALL __cdecl
+
+#include <Windows.h>
+
 #elif defined(__linux__)
 #define EXPORT
 #define CALL

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -22,7 +22,7 @@
 #define EXPORT __declspec(dllexport)
 #define CALL __cdecl
 
-#include <Windows.h>
+#include <windows.h>
 
 #elif defined(__linux__)
 #define EXPORT

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -134,22 +134,22 @@ extern "C"
         /**
          * \brief Logs the specified message at the trace level.
          */
-        void (*log_trace)(const wchar_t *);
+        void (*log_trace)(const char *);
 
         /**
          * \brief Logs the specified message at the info level.
          */
-        void (*log_info)(const wchar_t *);
+        void (*log_info)(const char *);
 
         /**
          * \brief Logs the specified message at the warning level.
          */
-        void (*log_warn)(const wchar_t *);
+        void (*log_warn)(const char *);
 
         /**
          * \brief Logs the specified message at the error level.
          */
-        void (*log_error)(const wchar_t *);
+        void (*log_error)(const char *);
 
         /**
          * \brief Gets the effective speed mode.

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -236,11 +236,11 @@ extern "C"
     typedef void(CALL *PtrAIDacrateChanged)(CoreSystemType system_type);
     typedef void(CALL *PtrAILenChanged)();
 
-    typedef void(CALL *PtrGetKeys)(uint8_t index, Buttons *buttons);
-    typedef void(CALL *PtrSetKeys)(uint8_t index, const Buttons *buttons);
+    typedef void(CALL *PtrGetKeys)(int32_t index, Buttons *buttons);
+    typedef void(CALL *PtrSetKeys)(int32_t index, Buttons buttons);
     typedef void(CALL *PtrReadController)(int32_t controller, unsigned char *command);
 
-    typedef void(CALL *PtrDoRSPCycles)(uint8_t);
+    typedef uint32_t(CALL *PtrDoRSPCycles)(uint32_t);
 };
 
 } // namespace M64RRSpec
@@ -269,7 +269,7 @@ extern "C"
      * \brief Shows the configuration window.
      * \param parent_window The parent window handle.
      */
-    EXPORT void CALL M64RRRShowConfig(WindowHandle parent_window);
+    EXPORT void CALL M64RRShowConfig(WindowHandle parent_window);
 
     // ---
 
@@ -307,18 +307,18 @@ extern "C"
     // ---
 
     /**
-     * \brief Gets the keys for the specified controller.
+     * \brief Reads inputs for the specified controller.
      * \param controller The controller index.
      * \param keys The buttons to be filled in.
      */
-    EXPORT void CALL M64RRGetKeys(uint8_t index, Buttons *buttons);
+    EXPORT void CALL M64RRGetKeys(int32_t index, Buttons *buttons);
 
     /**
      * \brief Notifies the plugin that the keys for the specified controller have changed.
      * \param controller The controller index.
      * \param keys The buttons to be set.
      */
-    EXPORT void CALL M64RRSetKeys(uint8_t index, const Buttons *buttons);
+    EXPORT void CALL M64RRSetKeys(int32_t index, Buttons buttons);
 
     /**
      * \brief Notifies the plugin of a controller command.
@@ -330,10 +330,10 @@ extern "C"
     // ---
 
     /**
-     * \brief Does RSP cycles.
+     * \brief Advances the RSP.
      * \param cycles The number of RSP cycles to do.
      */
-    EXPORT void CALL M64RRDoRSPCycles(uint8_t cycles);
+    EXPORT uint32_t CALL M64RRDoRSPCycles(uint32_t cycles);
 
     // ReSharper restore CppInconsistentNaming
 }

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -77,21 +77,6 @@ extern "C"
         RSP,
     };
 
-    /**
-     * \brief Represents an extension for a controller.
-     */
-    using ControllerExtension = CoreControllerExtension;
-
-    /**
-     * \brief Describes a controller.
-     */
-    using Controller = CoreController;
-
-    /**
-     * \brief Represents a controller state.
-     */
-    using Buttons = CoreButtons;
-
     struct PluginMetadata
     {
         PluginType type;
@@ -129,7 +114,7 @@ extern "C"
 
         void(CALL *process_dlist)(void);
 
-        Controller *controllers;
+        CoreController* controllers;
 
         /**
          * \brief Logs the specified message at the trace level.
@@ -236,8 +221,8 @@ extern "C"
     typedef void(CALL *PtrAIDacrateChanged)(CoreSystemType system_type);
     typedef void(CALL *PtrAILenChanged)();
 
-    typedef void(CALL *PtrGetKeys)(int32_t index, Buttons *buttons);
-    typedef void(CALL *PtrSetKeys)(int32_t index, Buttons buttons);
+    typedef void(CALL *PtrGetKeys)(int32_t index, CoreButtons *buttons);
+    typedef void(CALL *PtrSetKeys)(int32_t index, CoreButtons buttons);
     typedef void(CALL *PtrReadController)(int32_t controller, unsigned char *command);
 
     typedef uint32_t(CALL *PtrDoRSPCycles)(uint32_t);
@@ -311,14 +296,14 @@ extern "C"
      * \param controller The controller index.
      * \param keys The buttons to be filled in.
      */
-    EXPORT void CALL M64RRGetKeys(int32_t index, Buttons *buttons);
+    EXPORT void CALL M64RRGetKeys(int32_t index, CoreButtons *buttons);
 
     /**
      * \brief Notifies the plugin that the keys for the specified controller have changed.
      * \param controller The controller index.
      * \param keys The buttons to be set.
      */
-    EXPORT void CALL M64RRSetKeys(int32_t index, Buttons buttons);
+    EXPORT void CALL M64RRSetKeys(int32_t index, CoreButtons buttons);
 
     /**
      * \brief Notifies the plugin of a controller command.

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -114,7 +114,7 @@ extern "C"
 
         void(CALL *process_dlist)(void);
 
-        CoreController* controllers;
+        CoreController *controllers;
 
         /**
          * \brief Logs the specified message at the trace level.

--- a/src/Core/include/m64rr/Types.hpp
+++ b/src/Core/include/m64rr/Types.hpp
@@ -135,9 +135,9 @@ enum class CoreControllerExtension : int32_t
  */
 struct CoreController
 {
-    int32_t Present;
-    int32_t RawData;
-    CoreControllerExtension Plugin;
+    int32_t present;
+    int32_t raw;
+    CoreControllerExtension plugin;
 };
 
 /**

--- a/src/Core/include/m64rr/Types.hpp
+++ b/src/Core/include/m64rr/Types.hpp
@@ -6,6 +6,10 @@
 
 // ReSharper disable CppInconsistentNaming
 #pragma once
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <string>
 
 /**
  * An enum containing results that can be returned by the core.

--- a/src/Plugins.Win32.DummyInput/Main.cpp
+++ b/src/Plugins.Win32.DummyInput/Main.cpp
@@ -22,7 +22,7 @@ EXPORT void CALL M64RRProcessEvent(Event event)
         {
             controllers[i].present = 0;
             controllers[i].raw = 0;
-            controllers[i].plugin = M64RRSpec::ControllerExtension::None;
+            controllers[i].plugin = CoreControllerExtension::None;
         }
 
         controllers[0].present = 1;

--- a/src/Plugins.Win32.TASAudio/Config.cpp
+++ b/src/Plugins.Win32.TASAudio/Config.cpp
@@ -26,7 +26,11 @@ void Config::read_from(std::istream &in)
 
 void Config::write_to(std::ostream &out) const
 {
-    nlohmann::json j{{"swap_channels", swap_channels}, {"sync_audio", sync_audio}, {"volume_db", (uint32_t)volume_pct}};
+    nlohmann::json j{
+        {"swap_channels", swap_channels},
+        {"sync_audio", sync_audio},
+        {"volume_db", (uint32_t)volume_pct},
+    };
 
     auto old_flags = out.flags();
     out << std::setw(2) << j << '\n';

--- a/src/Plugins.Win32.TASAudio/Config_Win32.hpp
+++ b/src/Plugins.Win32.TASAudio/Config_Win32.hpp
@@ -8,6 +8,8 @@
 
 #include "Config.hpp"
 
+#include <Windows.h>
+
 namespace SDLAudio
 {
 // Displays a Win32 dialog box for the provided config object.

--- a/src/Plugins.Win32.TASAudio/Config_Win32.hpp
+++ b/src/Plugins.Win32.TASAudio/Config_Win32.hpp
@@ -8,7 +8,7 @@
 
 #include "Config.hpp"
 
-#include <Windows.h>
+#include <windows.h>
 
 namespace SDLAudio
 {

--- a/src/Plugins.Win32.TASAudio/Main.cpp
+++ b/src/Plugins.Win32.TASAudio/Main.cpp
@@ -120,7 +120,7 @@ EXPORT void CALL M64RRProcessEvent(Event event)
         catch (std::exception &e)
         {
             g_plugin->log_error(
-                IOUtils::to_wide_string(std::format("Exception at InitiateAudio(): {}", e.what())).c_str());
+                std::format("Exception at InitiateAudio(): {}", e.what()).c_str());
         }
         break;
     }
@@ -145,7 +145,7 @@ EXPORT void CALL M64RRAIDacrateChanged(CoreSystemType system_type)
     catch (std::exception &e)
     {
         g_plugin->log_error(
-            IOUtils::to_wide_string(std::format("Exception at AiDacrateChanged(): {}", e.what())).c_str());
+            std::format("Exception at AiDacrateChanged(): {}", e.what()).c_str());
     }
 }
 
@@ -166,6 +166,6 @@ EXPORT void CALL M64RRAILenChanged()
     }
     catch (std::exception &e)
     {
-        g_plugin->log_error(IOUtils::to_wide_string(std::format("Exception at AiLenChanged(): {}", e.what())).c_str());
+        g_plugin->log_error(std::format("Exception at AiLenChanged(): {}", e.what()).c_str());
     }
 }

--- a/src/Plugins.Win32.TASAudio/Main.cpp
+++ b/src/Plugins.Win32.TASAudio/Main.cpp
@@ -119,8 +119,7 @@ EXPORT void CALL M64RRProcessEvent(Event event)
         }
         catch (std::exception &e)
         {
-            g_plugin->log_error(
-                std::format("Exception at InitiateAudio(): {}", e.what()).c_str());
+            g_plugin->log_error(std::format("Exception at InitiateAudio(): {}", e.what()).c_str());
         }
         break;
     }
@@ -144,8 +143,7 @@ EXPORT void CALL M64RRAIDacrateChanged(CoreSystemType system_type)
     }
     catch (std::exception &e)
     {
-        g_plugin->log_error(
-            std::format("Exception at AiDacrateChanged(): {}", e.what()).c_str());
+        g_plugin->log_error(std::format("Exception at AiDacrateChanged(): {}", e.what()).c_str());
     }
 }
 

--- a/src/Plugins.Win32.TASAudio/Main_Win32.cpp
+++ b/src/Plugins.Win32.TASAudio/Main_Win32.cpp
@@ -50,7 +50,7 @@ EXPORT void CALL M64RRRShowConfig(WindowHandle parent_window)
     SDLAudio::Config cfg = read_config();
     if (SDLAudio::win32_show_config(parent_window.hwnd(), cfg))
     {
-        if (g_plugin) g_plugin->log_info(L"Saving config...");
+        if (g_plugin) g_plugin->log_info("Saving config...");
         write_config(cfg);
         if (g_backend.has_value()) g_backend->merge_cfg_live(cfg);
     }

--- a/src/Plugins.Win32.TASAudio/Main_Win32.cpp
+++ b/src/Plugins.Win32.TASAudio/Main_Win32.cpp
@@ -45,7 +45,7 @@ BOOL __stdcall DllMain(HINSTANCE hmod, DWORD reason, LPVOID)
     return TRUE;
 }
 
-EXPORT void CALL M64RRRShowConfig(WindowHandle parent_window)
+EXPORT void CALL M64RRShowConfig(WindowHandle parent_window)
 {
     SDLAudio::Config cfg = read_config();
     if (SDLAudio::win32_show_config(parent_window.hwnd(), cfg))

--- a/src/Plugins.Win32.TASAudio/SDLBackend.cpp
+++ b/src/Plugins.Win32.TASAudio/SDLBackend.cpp
@@ -40,7 +40,7 @@ SDLBackend::SDLBackend(Config &&config) : m_config(config)
     if (!m_stream) throw std::runtime_error(SDL_GetError());
     if (!SDL_BindAudioStream(m_device_id, m_stream)) throw std::runtime_error(SDL_GetError());
 
-    g_plugin->log_info(std::format(L"Opened default audio device, buffer size = {}, target = {}", m_buffer_size,
+    g_plugin->log_info(std::format("Opened default audio device, buffer size = {}, target = {}", m_buffer_size,
                                    config.src_buffer_target)
                            .c_str());
 

--- a/src/Plugins.Win32.TASInput/Combo.cpp
+++ b/src/Plugins.Win32.TASInput/Combo.cpp
@@ -10,7 +10,7 @@
 bool t_combo::uses_joystick() const
 {
     return std::any_of(samples.begin(), samples.end(),
-                       [](const M64RRSpec::Buttons sample) { return sample.x != 0 || sample.y != 0; });
+                       [](const CoreButtons sample) { return sample.x != 0 || sample.y != 0; });
 }
 
 std::vector<uint8_t> t_combo::serialize() const
@@ -68,7 +68,7 @@ std::variant<t_combo, std::wstring> t_combo::deserialize(const std::span<uint8_t
     offset += sizeof(uint32_t);
 
     // 3. Read the samples data
-    size_t samples_byte_size = samples_size * sizeof(M64RRSpec::Buttons);
+    size_t samples_byte_size = samples_size * sizeof(CoreButtons);
     if (offset + samples_byte_size > data.size())
     {
         return L"Malformed samples.";

--- a/src/Plugins.Win32.TASInput/Combo.hpp
+++ b/src/Plugins.Win32.TASInput/Combo.hpp
@@ -26,7 +26,7 @@ struct t_combo
     /**
      * \brief The combo's samples.
      */
-    std::vector<M64RRSpec::Buttons> samples{};
+    std::vector<CoreButtons> samples{};
 
     /**
      * \return Whether any sample utilizes the joystick (magnitude > 0).

--- a/src/Plugins.Win32.TASInput/Combo.hpp
+++ b/src/Plugins.Win32.TASInput/Combo.hpp
@@ -12,7 +12,6 @@
 #include <variant>
 #include <vector>
 
-
 /**
  * \brief Represents a combo.
  */

--- a/src/Plugins.Win32.TASInput/Combo.hpp
+++ b/src/Plugins.Win32.TASInput/Combo.hpp
@@ -8,6 +8,11 @@
 
 #include "Main.hpp"
 
+#include <span>
+#include <variant>
+#include <vector>
+
+
 /**
  * \brief Represents a combo.
  */

--- a/src/Plugins.Win32.TASInput/GamepadManager.cpp
+++ b/src/Plugins.Win32.TASInput/GamepadManager.cpp
@@ -153,9 +153,9 @@ static int32_t get_axis(const t_axis_mapping &mapping)
     return remap_axis(SDL_GetGamepadAxis(g_ctx.gamepad, (SDL_GamepadAxis)mapping.axis));
 }
 
-M64RRSpec::Buttons GamepadManager::get_input(const size_t i)
+CoreButtons GamepadManager::get_input(const size_t i)
 {
-    M64RRSpec::Buttons buttons{};
+    CoreButtons buttons{};
 
     const auto controller_config = new_config.controller_config[i];
 

--- a/src/Plugins.Win32.TASInput/GamepadManager.cpp
+++ b/src/Plugins.Win32.TASInput/GamepadManager.cpp
@@ -190,7 +190,7 @@ void GamepadManager::update_current_gamepad()
     if (g_ctx.gamepad)
     {
         if (SDL_GetGamepadGUID(g_ctx.gamepad) == new_config.preferred_device_guid) return;
-        g_plugin->log_info(std::format(L"Closing gamepad {}", SDL_GetGamepadGUID(g_ctx.gamepad).data).c_str());
+        g_plugin->log_info(std::format("Closing gamepad {}", SDL_GetGamepadGUID(g_ctx.gamepad).data).c_str());
         SDL_CloseGamepad(g_ctx.gamepad);
         g_ctx.gamepad = nullptr;
     }
@@ -200,10 +200,10 @@ void GamepadManager::update_current_gamepad()
     g_ctx.gamepad = SDL_OpenGamepadByGUID(*new_config.preferred_device_guid);
     if (!g_ctx.gamepad)
     {
-        g_plugin->log_info(std::format(L"Failed to open gamepad {}", *new_config.preferred_device_guid->data).c_str());
+        g_plugin->log_info(std::format("Failed to open gamepad {}", *new_config.preferred_device_guid->data).c_str());
         return;
     }
-    g_plugin->log_info(std::format(L"Opened gamepad {}", *new_config.preferred_device_guid->data).c_str());
+    g_plugin->log_info(std::format("Opened gamepad {}", *new_config.preferred_device_guid->data).c_str());
 }
 
 GamepadManager::DeviceRegistry &GamepadManager::device_registry()

--- a/src/Plugins.Win32.TASInput/GamepadManager.hpp
+++ b/src/Plugins.Win32.TASInput/GamepadManager.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include "Main.hpp"
+#include <SDL3/SDL_events.h>
+#include <SDL3/SDL_gamepad.h>
 
 /**
  * \brief Provides gamepad-related functionality.
@@ -42,7 +44,7 @@ void on_sdl_event(const SDL_Event &e);
  * \brief Gets the current gamepad input state.
  * \param i The controller index.
  */
-M64RRSpec::Buttons get_input(size_t i);
+CoreButtons get_input(size_t i);
 
 /**
  * \brief Updates the currently selected gamepad. Should be called after `new_config.preferred_device_id` is changed.

--- a/src/Plugins.Win32.TASInput/NewConfig.cpp
+++ b/src/Plugins.Win32.TASInput/NewConfig.cpp
@@ -23,7 +23,7 @@ static std::filesystem::path get_config_path()
 
 void save_config()
 {
-    g_plugin->log_trace(L"Saving config...");
+    g_plugin->log_trace("Saving config...");
 
     nlohmann::json j = new_config;
     std::ofstream ofs(get_config_path());
@@ -34,7 +34,7 @@ void save_config()
 
 void load_config()
 {
-    g_plugin->log_trace(L"Loading config...");
+    g_plugin->log_trace("Loading config...");
 
     auto json_path = get_config_path();
 
@@ -56,7 +56,7 @@ void load_config()
     }
     catch (const std::exception &e)
     {
-        g_plugin->log_warn(L"Config load failed, using defaults...");
+        g_plugin->log_warn("Config load failed, using defaults...");
         new_config = default_config;
     }
 

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -1324,7 +1324,7 @@ EXPORT void CALL M64RRShowConfig(WindowHandle parent_window)
     // TODO: Do we have to restart the dialogs here like in old version?
 }
 
-EXPORT void CALL M64RRGetKeys(int32_t index, Buttons *buttons)
+EXPORT void CALL M64RRGetKeys(int32_t index, CoreButtons *buttons)
 {
     if (new_frame)
     {
@@ -1335,7 +1335,7 @@ EXPORT void CALL M64RRGetKeys(int32_t index, Buttons *buttons)
     status[index].get_input(buttons);
 }
 
-EXPORT void CALL M64RRSetKeys(int32_t index, Buttons buttons)
+EXPORT void CALL M64RRSetKeys(int32_t index, CoreButtons buttons)
 {
     status[index].set_visuals_lazy(buttons, false);
 }

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -1317,7 +1317,7 @@ EXPORT void CALL M64RRReadController(int32_t controller, unsigned char *command)
     }
 }
 
-EXPORT void CALL M64RRRShowConfig(WindowHandle parent_window)
+EXPORT void CALL M64RRShowConfig(WindowHandle parent_window)
 {
     attach_event_watch();
     ConfigDialog::show(parent_window.hwnd());
@@ -1325,7 +1325,7 @@ EXPORT void CALL M64RRRShowConfig(WindowHandle parent_window)
     // TODO: Do we have to restart the dialogs here like in old version?
 }
 
-EXPORT void CALL M64RRGetKeys(uint8_t index, Buttons *buttons)
+EXPORT void CALL M64RRGetKeys(int32_t index, Buttons *buttons)
 {
     if (new_frame)
     {
@@ -1336,7 +1336,7 @@ EXPORT void CALL M64RRGetKeys(uint8_t index, Buttons *buttons)
     status[index].get_input(buttons);
 }
 
-EXPORT void CALL M64RRSetKeys(uint8_t index, const Buttons *buttons)
+EXPORT void CALL M64RRSetKeys(int32_t index, Buttons buttons)
 {
-    status[index].set_visuals_lazy(*buttons, false);
+    status[index].set_visuals_lazy(buttons, false);
 }

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -1256,8 +1256,7 @@ EXPORT void CALL M64RRProcessEvent(Event event)
             g_plugin->controllers[i].present = new_config.controller_active[i];
             g_plugin->controllers[i].raw = false;
             g_plugin->controllers[i].plugin = CoreControllerExtension::None;
-            if (new_config.controller_mempak[i])
-                g_plugin->controllers[i].plugin = CoreControllerExtension::Mempak;
+            if (new_config.controller_mempak[i]) g_plugin->controllers[i].plugin = CoreControllerExtension::Mempak;
             if (new_config.controller_rumblepak[i])
                 g_plugin->controllers[i].plugin = CoreControllerExtension::Rumblepak;
         }

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -1071,12 +1071,12 @@ void Status::end_edit(int id, wchar_t *name)
 
 void Status::save_combos()
 {
-    const auto path = _T("combos.cmb");
+    const auto path = std::filesystem::path("combos.cmb");
 
-    g_plugin->log_trace(std::format(L"Saving combos to {}...", path).c_str());
+    g_plugin->log_trace(std::format("Saving combos to {}...", path.string()).c_str());
 
     FILE *f{};
-    if (_tfopen_s(&f, path, _T("wb")))
+    if (IOUtils::path_fopen_s(f, path, "wb"))
     {
         return;
     }
@@ -1090,12 +1090,12 @@ void Status::save_combos()
 
 void Status::load_combos(const std::filesystem::path &path)
 {
-    g_plugin->log_trace(std::format(L"Loading combos from {}...", path.c_str()).c_str());
+    g_plugin->log_trace(std::format("Loading combos from {}...", path.string()).c_str());
 
     auto buf = IOUtils::read_entire_file(path);
     if (buf.empty())
     {
-        g_plugin->log_error(L"read_file_buffer failed");
+        g_plugin->log_error("read_file_buffer failed");
         return;
     }
 

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -51,12 +51,12 @@ struct Status
     /**
      * \brief The current internal input state before any processing
      */
-    M64RRSpec::Buttons current_input{};
+    CoreButtons current_input{};
 
     /**
      * \brief The internal input state at the previous GetKeys call before any processing
      */
-    M64RRSpec::Buttons last_controller_input{};
+    CoreButtons last_controller_input{};
 
     /**
      * \brief Ignores the next joystick increment, used for relative mode tracking
@@ -95,7 +95,7 @@ struct Status
 
     struct t_set_visuals_request
     {
-        M64RRSpec::Buttons input;
+        CoreButtons input;
         bool needs_processing;
     };
 
@@ -106,8 +106,8 @@ struct Status
 
     bool last_lmb_down{};
     bool last_rmb_down{};
-    M64RRSpec::Buttons autofire_input_a{};
-    M64RRSpec::Buttons autofire_input_b{};
+    CoreButtons autofire_input_a{};
+    CoreButtons autofire_input_b{};
     bool ready;
     HWND hwnd{};
     HWND combos_hwnd{};
@@ -143,7 +143,7 @@ struct Status
      * \param input The values to be shown in the UI
      * \param needs_processing Whether the UI values need per-frame processing.
      */
-    void set_visuals(M64RRSpec::Buttons input, bool needs_processing = true);
+    void set_visuals(CoreButtons input, bool needs_processing = true);
 
     /**
      * \brief Queues the UI to be updated at the next possible opportunity. Doesn't block the caller until the UI has
@@ -151,7 +151,7 @@ struct Status
      * \param input The values to be shown in the UI
      * \param needs_processing Whether the UI values need per-frame processing.
      */
-    void set_visuals_lazy(M64RRSpec::Buttons input, bool needs_processing = true);
+    void set_visuals_lazy(CoreButtons input, bool needs_processing = true);
 
     void set_visuals_if_needed();
 
@@ -160,7 +160,7 @@ struct Status
      * \param input The input to process
      * \return The processed input
      */
-    M64RRSpec::Buttons get_processed_input(M64RRSpec::Buttons input);
+    CoreButtons get_processed_input(CoreButtons input);
 
     /**
      * \brief Activates the mupen window, releasing focus capture from the current window
@@ -169,7 +169,7 @@ struct Status
 
     void on_config_changed();
 
-    void get_input(M64RRSpec::Buttons *keys);
+    void get_input(CoreButtons *keys);
 };
 
 static ULONG_PTR gdi_plus_token{};
@@ -241,7 +241,7 @@ apply:
     return DefSubclassProc(hwnd, msg, wParam, lParam);
 }
 
-void Status::get_input(M64RRSpec::Buttons *keys)
+void Status::get_input(CoreButtons *keys)
 {
     keys->value = get_processed_input(current_input).value;
 
@@ -281,7 +281,7 @@ end:
     PostMessage(hwnd, WM_UPDATE_VISUALS, 0, keys->value);
 }
 
-M64RRSpec::Buttons Status::get_processed_input(M64RRSpec::Buttons input)
+CoreButtons Status::get_processed_input(CoreButtons input)
 {
     input.value |= frame_counter % 2 == 0 ? autofire_input_a.value : autofire_input_b.value;
 
@@ -310,7 +310,7 @@ void Status::activate_emulator_window()
     SetForegroundWindow(g_plugin->main_window.hwnd());
 }
 
-void Status::set_visuals(M64RRSpec::Buttons input, bool needs_processing)
+void Status::set_visuals(CoreButtons input, bool needs_processing)
 {
     if (needs_processing)
     {
@@ -346,7 +346,7 @@ void Status::set_visuals(M64RRSpec::Buttons input, bool needs_processing)
     JoystickControl::set_position(joy_hwnd, input.x, input.y);
 }
 
-void Status::set_visuals_lazy(M64RRSpec::Buttons input, bool needs_processing)
+void Status::set_visuals_lazy(CoreButtons input, bool needs_processing)
 {
     std::lock_guard lock(pending_visuals_mutex);
     pending_set_visuals_request = t_set_visuals_request{input, needs_processing};
@@ -661,7 +661,7 @@ INT_PTR CALLBACK wndproc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
     case WM_TIMER: {
         ctx->set_visuals_if_needed();
 
-        M64RRSpec::Buttons controller_input = GamepadManager::get_input(ctx->controller_index);
+        CoreButtons controller_input = GamepadManager::get_input(ctx->controller_index);
 
         if (controller_input.value != ctx->last_controller_input.value)
         {
@@ -788,7 +788,7 @@ INT_PTR CALLBACK wndproc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
     }
     break;
     case WM_UPDATE_VISUALS:
-        ctx->set_visuals(static_cast<M64RRSpec::Buttons>(lparam), false);
+        ctx->set_visuals(static_cast<CoreButtons>(lparam), false);
         break;
     case WM_SIZE:
     case WM_MOVE: {
@@ -808,7 +808,7 @@ INT_PTR CALLBACK wndproc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
             {
                 break;
             }
-            M64RRSpec::Buttons last_input = ctx->current_input;
+            CoreButtons last_input = ctx->current_input;
             wchar_t str[8]{};
             GetDlgItemText(ctx->hwnd, LOWORD(wparam), str, std::size(str));
             try
@@ -832,7 +832,7 @@ INT_PTR CALLBACK wndproc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
             {
                 break;
             }
-            M64RRSpec::Buttons last_input = ctx->current_input;
+            CoreButtons last_input = ctx->current_input;
             wchar_t str[8]{};
             GetDlgItemText(ctx->hwnd, LOWORD(wparam), str, std::size(str));
             try
@@ -1255,11 +1255,11 @@ EXPORT void CALL M64RRProcessEvent(Event event)
         {
             g_plugin->controllers[i].present = new_config.controller_active[i];
             g_plugin->controllers[i].raw = false;
-            g_plugin->controllers[i].plugin = M64RRSpec::ControllerExtension::None;
+            g_plugin->controllers[i].plugin = CoreControllerExtension::None;
             if (new_config.controller_mempak[i])
-                g_plugin->controllers[i].plugin = M64RRSpec::ControllerExtension::Mempak;
+                g_plugin->controllers[i].plugin = CoreControllerExtension::Mempak;
             if (new_config.controller_rumblepak[i])
-                g_plugin->controllers[i].plugin = M64RRSpec::ControllerExtension::Rumblepak;
+                g_plugin->controllers[i].plugin = CoreControllerExtension::Rumblepak;
         }
         break;
     }

--- a/src/Plugins.Win32.TASRSP/Config.cpp
+++ b/src/Plugins.Win32.TASRSP/Config.cpp
@@ -23,7 +23,7 @@ static std::filesystem::path get_config_path()
 
 void config_save()
 {
-    g_plugin->log_trace(L"Saving config...");
+    g_plugin->log_trace("Saving config...");
 
     nlohmann::json j = config;
     std::ofstream ofs(get_config_path());
@@ -32,7 +32,7 @@ void config_save()
 
 void config_load()
 {
-    g_plugin->log_trace(L"Loading config...");
+    g_plugin->log_trace("Loading config...");
 
     auto json_path = get_config_path();
 
@@ -53,7 +53,7 @@ void config_load()
     }
     catch (const std::exception &e)
     {
-        g_plugin->log_warn(L"Config load failed, using defaults...");
+        g_plugin->log_warn("Config load failed, using defaults...");
         config = default_config;
     }
 }

--- a/src/Plugins.Win32.TASRSP/JPEG.cpp
+++ b/src/Plugins.Win32.TASRSP/JPEG.cpp
@@ -48,7 +48,7 @@ void jpg_uncompress(OSTask_t *task)
     }
     else
     {
-        g_plugin->log_warn(L"jpg_uncompress: !flags");
+        g_plugin->log_warn("jpg_uncompress: !flags");
     }
     pic = (int16_t *)(g_plugin->rdram + jpg_data.pic);
 
@@ -271,7 +271,7 @@ void jpg_uncompress(OSTask_t *task)
 
         if (jpg_data.h == 0)
         {
-            g_plugin->log_warn(L"h==0");
+            g_plugin->log_warn("h==0");
         }
         else
         {

--- a/src/Plugins.Win32.TASRSP/Main.cpp
+++ b/src/Plugins.Win32.TASRSP/Main.cpp
@@ -206,7 +206,7 @@ EXPORT void CALL M64RRProcessEvent(Event event)
     }
 }
 
-EXPORT void CALL M64RRDoRSPCycles(uint8_t cycles)
+EXPORT uint32_t CALL M64RRDoRSPCycles(uint32_t cycles)
 {
-    do_rsp_cycles(cycles);
+    return do_rsp_cycles(cycles);
 }

--- a/src/Plugins.Win32.TASVideo/Config.cpp
+++ b/src/Plugins.Win32.TASVideo/Config.cpp
@@ -106,7 +106,7 @@ void Config_LoadConfig()
     }
     catch (const std::exception &e)
     {
-        g_plugin->log_warn(L"Config load failed, using defaults...");
+        g_plugin->log_warn("Config load failed, using defaults...");
         Config_SetDefaults();
     }
 }

--- a/src/Plugins.Win32.TASVideo/Config.cpp
+++ b/src/Plugins.Win32.TASVideo/Config.cpp
@@ -178,17 +178,19 @@ void Config_ApplyDlgConfig(HWND hWndDlg)
     }
 }
 
-static void select_current_resolution_in_combobox(HWND cb_hwnd)
+static void select_resolution_in_combobox(HWND cb_hwnd, uint32_t width, uint32_t height)
 {
     for (size_t i = 0; i < RESOLUTION_PRESETS.size(); i++)
     {
         const auto &preset = RESOLUTION_PRESETS[i];
-        if (OGL.windowedWidth == preset.width && OGL.windowedHeight == preset.height)
+        if (width == preset.width && height == preset.height)
         {
             ComboBox_SetCurSel(cb_hwnd, i);
             return;
         }
     }
+
+    ComboBox_SetCurSel(cb_hwnd, -1);
 }
 
 BOOL CALLBACK ConfigDlgProc(HWND hWndDlg, UINT message, WPARAM wParam, LPARAM lParam)
@@ -211,7 +213,7 @@ BOOL CALLBACK ConfigDlgProc(HWND hWndDlg, UINT message, WPARAM wParam, LPARAM lP
         }
         ComboBox_SetCurSel(GetDlgItem(hWndDlg, IDC_SMOOTHING), (int)OGL.smoothing);
 
-        select_current_resolution_in_combobox(cb_hwnd);
+        select_resolution_in_combobox(cb_hwnd, OGL.windowedWidth, OGL.windowedHeight);
 
         SendDlgItemMessage(hWndDlg, IDC_WINDOWED_X, WM_SETTEXT, 0, (LPARAM)std::to_wstring(OGL.windowedWidth).c_str());
         SendDlgItemMessage(hWndDlg, IDC_WINDOWED_Y, WM_SETTEXT, 0, (LPARAM)std::to_wstring(OGL.windowedHeight).c_str());
@@ -271,23 +273,24 @@ BOOL CALLBACK ConfigDlgProc(HWND hWndDlg, UINT message, WPARAM wParam, LPARAM lP
         case IDC_WINDOWED_Y:
             if (HIWORD(wParam) == EN_CHANGE)
             {
-                std::wstring w_str(32, 0);
-                std::wstring h_str(32, 0);
-                Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_X), w_str.data(), w_str.size());
-                Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_Y), h_str.data(), h_str.size());
+                wchar_t w_str[32]{};
+                wchar_t h_str[32]{};
+                Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_X), w_str, std::size(w_str));
+                Edit_GetText(GetDlgItem(hWndDlg, IDC_WINDOWED_Y), h_str, std::size(h_str));
 
+                uint32_t width{};
+                uint32_t height{};
                 try
                 {
-                    OGL.windowedWidth = std::stoul(std::wstring(w_str));
-                    OGL.windowedHeight = std::stoul(std::wstring(h_str));
+                    width = std::stoul(w_str);
+                    height = std::stoul(h_str);
                 }
                 catch (...)
                 {
                     break;
                 }
 
-                const auto cb_hwnd = GetDlgItem(hWndDlg, IDC_WINDOWEDRES);
-                select_current_resolution_in_combobox(cb_hwnd);
+                select_resolution_in_combobox(GetDlgItem(hWndDlg, IDC_WINDOWEDRES), width, height);
             }
             break;
         case IDC_TEXTUREFILTER:

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -61,7 +61,7 @@ void OGL_InitExtensions()
 void OGL_SetIdentityProjection()
 {
     static const float identity[16] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
-                                        0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+                                       0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
     Combiner_SetProjection(identity);
 }
 
@@ -202,7 +202,7 @@ bool OGL_InitContext()
     OGL_InitStates();
 
     g_plugin->log_info(OGL.isGLES ? "TASVideo: running on an OpenGL ES 2.0 context."
-                              : "TASVideo: running on a desktop OpenGL compatibility context.");
+                                  : "TASVideo: running on a desktop OpenGL compatibility context.");
 
     OGL.context_initialized = TRUE;
 
@@ -322,8 +322,7 @@ void OGL_UpdateStates()
     {
         if ((gDP.otherMode.alphaCompare == G_AC_THRESHOLD) && !(gDP.otherMode.alphaCvgSel))
             Combiner_SetAlphaTest((gDP.blendColor.a > 0.0f) ? 1 : 2, gDP.blendColor.a);
-        else if (OGL.usePolygonStipple && (gDP.otherMode.alphaCompare == G_AC_DITHER) &&
-                 !(gDP.otherMode.alphaCvgSel))
+        else if (OGL.usePolygonStipple && (gDP.otherMode.alphaCompare == G_AC_DITHER) && !(gDP.otherMode.alphaCvgSel))
             Combiner_SetAlphaTest(3, 0.0f);
         // Used in TEX_EDGE and similar render modes
         else if (gDP.otherMode.cvgXAlpha)

--- a/src/Plugins.Win32.TASVideo/OpenGL.cpp
+++ b/src/Plugins.Win32.TASVideo/OpenGL.cpp
@@ -46,7 +46,7 @@ void OGL_InitExtensions()
     GLenum glew = glewInit();
     if (glew != GLEW_OK)
     {
-        g_plugin->log_error(L"Error initialising glew");
+        g_plugin->log_error("Error initialising glew");
         return;
     }
 
@@ -176,7 +176,7 @@ bool OGL_InitContext()
 
     if (!s_sdl_context)
     {
-        g_plugin->log_info(L"OpenGL ES 2.0 context unavailable; falling back to desktop OpenGL.");
+        g_plugin->log_info("OpenGL ES 2.0 context unavailable; falling back to desktop OpenGL.");
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
@@ -201,8 +201,8 @@ bool OGL_InitContext()
     OGL_InitExtensions();
     OGL_InitStates();
 
-    g_plugin->log_info(OGL.isGLES ? L"TASVideo: running on an OpenGL ES 2.0 context."
-                              : L"TASVideo: running on a desktop OpenGL compatibility context.");
+    g_plugin->log_info(OGL.isGLES ? "TASVideo: running on an OpenGL ES 2.0 context."
+                              : "TASVideo: running on a desktop OpenGL compatibility context.");
 
     OGL.context_initialized = TRUE;
 

--- a/src/Plugins.Win32.TASVideo/glN64.cpp
+++ b/src/Plugins.Win32.TASVideo/glN64.cpp
@@ -140,7 +140,7 @@ EXPORT void CALL M64RRProcessEvent(Event event)
     }
 }
 
-EXPORT void CALL M64RRRShowConfig(WindowHandle parent_window)
+EXPORT void CALL M64RRShowConfig(WindowHandle parent_window)
 {
     Config_Show(parent_window.hwnd());
 }

--- a/src/Plugins.Win32.TASVideo/glsl_combiner.cpp
+++ b/src/Plugins.Win32.TASVideo/glsl_combiner.cpp
@@ -63,7 +63,7 @@ static const char *s_vertexShaderBody = "attribute vec4 aPosition;\n"
                                           "    vFog = aFog;\n"
                                           "}\n";
 
-static void LogInfoLog(const wchar_t *what, GLuint object, bool isProgram)
+static void LogInfoLog(const char *what, GLuint object, bool isProgram)
 {
     GLint length = 0;
     if (isProgram)
@@ -80,14 +80,8 @@ static void LogInfoLog(const wchar_t *what, GLuint object, bool isProgram)
         else
             glGetShaderInfoLog(object, length, nullptr, infoLog.data());
     }
-
-    std::wstring message(what);
-    message += L": ";
-    for (const char c : infoLog)
-    {
-        if (c != '\0') message += (wchar_t)(unsigned char)c;
-    }
-    g_plugin->log_error(message.c_str());
+    
+    g_plugin->log_error(std::format("{}: {}", what, infoLog).c_str());
 }
 
 static GLuint CompileShader(GLenum type, const char *source)
@@ -95,7 +89,7 @@ static GLuint CompileShader(GLenum type, const char *source)
     const GLuint shader = glCreateShader(type);
     if (shader == 0)
     {
-        g_plugin->log_error(L"GLSL combiner: glCreateShader failed");
+        g_plugin->log_error("GLSL combiner: glCreateShader failed");
         return 0;
     }
 
@@ -106,8 +100,8 @@ static GLuint CompileShader(GLenum type, const char *source)
     glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
     if (status != GL_TRUE)
     {
-        LogInfoLog(type == GL_VERTEX_SHADER ? L"GLSL combiner: vertex shader compile failed"
-                                            : L"GLSL combiner: fragment shader compile failed",
+        LogInfoLog(type == GL_VERTEX_SHADER ? "GLSL combiner: vertex shader compile failed"
+                                            : "GLSL combiner: fragment shader compile failed",
                    shader, false);
         glDeleteShader(shader);
         return 0;
@@ -433,7 +427,7 @@ void GLSLCombiner_Init()
 
     if (!GLEW_VERSION_2_0)
     {
-        g_plugin->log_error(L"GLSL combiner: OpenGL 2.0 not available, shaders will fail to compile");
+        g_plugin->log_error("GLSL combiner: OpenGL 2.0 not available, shaders will fail to compile");
         return;
     }
 
@@ -505,7 +499,7 @@ GLSLProgram *GLSLCombiner_Compile(Combiner *color, Combiner *alpha)
     glGetProgramiv(glProgram, GL_LINK_STATUS, &status);
     if (status != GL_TRUE)
     {
-        LogInfoLog(L"GLSL combiner: program link failed", glProgram, true);
+        LogInfoLog("GLSL combiner: program link failed", glProgram, true);
         glDeleteProgram(glProgram);
         CacheUniformLocations(program);
         return program;

--- a/src/Plugins.Win32.TASVideo/glsl_combiner.cpp
+++ b/src/Plugins.Win32.TASVideo/glsl_combiner.cpp
@@ -43,25 +43,25 @@ static int s_fogEnabled = 0;
 static float s_projection[16];
 
 static const char *s_vertexShaderBody = "attribute vec4 aPosition;\n"
-                                          "attribute vec4 aColor;\n"
-                                          "attribute vec4 aSecondaryColor;\n"
-                                          "attribute vec2 aTexCoord0;\n"
-                                          "attribute vec2 aTexCoord1;\n"
-                                          "attribute float aFog;\n"
-                                          "uniform mat4 uProjection;\n"
-                                          "varying lowp vec4 vColor;\n"
-                                          "varying lowp vec4 vSecondaryColor;\n"
-                                          "varying highp vec2 vTexCoord0;\n"
-                                          "varying highp vec2 vTexCoord1;\n"
-                                          "varying mediump float vFog;\n"
-                                          "void main() {\n"
-                                          "    gl_Position = uProjection * aPosition;\n"
-                                          "    vColor = clamp(aColor, 0.0, 1.0);\n"
-                                          "    vSecondaryColor = clamp(aSecondaryColor, 0.0, 1.0);\n"
-                                          "    vTexCoord0 = aTexCoord0;\n"
-                                          "    vTexCoord1 = aTexCoord1;\n"
-                                          "    vFog = aFog;\n"
-                                          "}\n";
+                                        "attribute vec4 aColor;\n"
+                                        "attribute vec4 aSecondaryColor;\n"
+                                        "attribute vec2 aTexCoord0;\n"
+                                        "attribute vec2 aTexCoord1;\n"
+                                        "attribute float aFog;\n"
+                                        "uniform mat4 uProjection;\n"
+                                        "varying lowp vec4 vColor;\n"
+                                        "varying lowp vec4 vSecondaryColor;\n"
+                                        "varying highp vec2 vTexCoord0;\n"
+                                        "varying highp vec2 vTexCoord1;\n"
+                                        "varying mediump float vFog;\n"
+                                        "void main() {\n"
+                                        "    gl_Position = uProjection * aPosition;\n"
+                                        "    vColor = clamp(aColor, 0.0, 1.0);\n"
+                                        "    vSecondaryColor = clamp(aSecondaryColor, 0.0, 1.0);\n"
+                                        "    vTexCoord0 = aTexCoord0;\n"
+                                        "    vTexCoord1 = aTexCoord1;\n"
+                                        "    vFog = aFog;\n"
+                                        "}\n";
 
 static void LogInfoLog(const char *what, GLuint object, bool isProgram)
 {
@@ -80,7 +80,7 @@ static void LogInfoLog(const char *what, GLuint object, bool isProgram)
         else
             glGetShaderInfoLog(object, length, nullptr, infoLog.data());
     }
-    
+
     g_plugin->log_error(std::format("{}: {}", what, infoLog).c_str());
 }
 

--- a/src/Views.Win32/Hotkey.hpp
+++ b/src/Views.Win32/Hotkey.hpp
@@ -6,6 +6,11 @@
 
 #pragma once
 
+#include <cstdint>
+#include <string>
+
+#include <Windows.h>
+
 /**
  * \brief A module responsible for providing the hotkey structure and related functionality.
  */

--- a/src/Views.Win32/Hotkey.hpp
+++ b/src/Views.Win32/Hotkey.hpp
@@ -8,8 +8,7 @@
 
 #include <cstdint>
 #include <string>
-
-#include <Windows.h>
+#include <windows.h>
 
 /**
  * \brief A module responsible for providing the hotkey structure and related functionality.

--- a/src/Views.Win32/Loggers.hpp
+++ b/src/Views.Win32/Loggers.hpp
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include <memory>
+
+#include <spdlog/spdlog.h>
+
 extern std::shared_ptr<spdlog::logger> g_view_logger;
 extern std::shared_ptr<spdlog::logger> g_core_logger;
 extern std::shared_ptr<spdlog::logger> g_video_logger;

--- a/src/Views.Win32/ResizeAnchor.hpp
+++ b/src/Views.Win32/ResizeAnchor.hpp
@@ -6,6 +6,12 @@
 
 #pragma once
 
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <Windows.h>
+
 namespace ResizeAnchor
 {
 /**

--- a/src/Views.Win32/ResizeAnchor.hpp
+++ b/src/Views.Win32/ResizeAnchor.hpp
@@ -9,8 +9,7 @@
 #include <cstdint>
 #include <utility>
 #include <vector>
-
-#include <Windows.h>
+#include <windows.h>
 
 namespace ResizeAnchor
 {

--- a/src/Views.Win32/ThreadPool.hpp
+++ b/src/Views.Win32/ThreadPool.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <functional>
+
 namespace ThreadPool
 {
 /**

--- a/src/Views.Win32/include/Views.Win32/ZESpec.h
+++ b/src/Views.Win32/include/Views.Win32/ZESpec.h
@@ -87,9 +87,9 @@ extern "C"
             }
 
             return CoreController{
-                .Present = present ? 1 : 0,
-                .RawData = raw ? 1 : 0,
-                .Plugin = extension,
+                .present = present ? 1 : 0,
+                .raw = raw ? 1 : 0,
+                .plugin = extension,
             };
         }
     };

--- a/src/Views.Win32/include/Views.Win32/ZESpec.h
+++ b/src/Views.Win32/include/Views.Win32/ZESpec.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "m64rr/Types.hpp"
+#include <cassert>
 
 #ifdef _WIN32
 

--- a/src/Views.Win32/plugin/M64RRPlugin.cpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.cpp
@@ -332,7 +332,7 @@ void M64RRPlugin::initiate(ZESpecFuncs &funcs)
         };
         funcs.input_key_down = [](uint32_t, int32_t) {};
         funcs.input_key_up = [](uint32_t, int32_t) {};
-        
+
         break;
     }
     case Plugin::Type::RSP: {

--- a/src/Views.Win32/plugin/M64RRPlugin.cpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.cpp
@@ -57,9 +57,9 @@ static CoreController controller_to_core_controller(const M64RRSpec::Controller 
     }
 
     return CoreController{
-        .Present = controller.present ? 1 : 0,
-        .RawData = controller.raw ? 1 : 0,
-        .Plugin = extension,
+        .present = controller.present ? 1 : 0,
+        .raw = controller.raw ? 1 : 0,
+        .plugin = extension,
     };
 }
 

--- a/src/Views.Win32/plugin/M64RRPlugin.cpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.cpp
@@ -31,38 +31,6 @@ static M64RRSpec::PtrDoRSPCycles s_mupenrr_do_rsp_cycles_fn = nullptr;
 #define LOOKUP_MUPENRR_FN(mupenrr_ptr, mupenrr_type, export_name)                                                      \
     mupenrr_ptr = (mupenrr_type)GetProcAddress(m_module, export_name);
 
-// static CoreController controller_to_core_controller(const M64RRSpec::Controller &controller)
-// {
-//     CoreControllerExtension extension;
-//     switch (controller.plugin)
-//     {
-//     case M64RRSpec::ControllerExtension::None:
-//         extension = CoreControllerExtension::None;
-//         break;
-//     case M64RRSpec::ControllerExtension::Mempak:
-//         extension = CoreControllerExtension::Mempak;
-//         break;
-//     case M64RRSpec::ControllerExtension::Rumblepak:
-//         extension = CoreControllerExtension::Rumblepak;
-//         break;
-//     case M64RRSpec::ControllerExtension::Transferpak:
-//         extension = CoreControllerExtension::Transferpak;
-//         break;
-//     case M64RRSpec::ControllerExtension::Raw:
-//         extension = CoreControllerExtension::Raw;
-//         break;
-//     default:
-//         RT_ASSERT(false, L"Unknown controller extension");
-//         break;
-//     }
-
-//     return CoreController{
-//         .present = controller.present ? 1 : 0,
-//         .raw = controller.raw ? 1 : 0,
-//         .plugin = controller.plugin,
-//     };
-// }
-
 static size_t get_config_path(char *data, size_t size)
 {
     static const std::u8string config_path = std::filesystem::absolute(IOUtils::config_path()).u8string();
@@ -351,12 +319,12 @@ void M64RRPlugin::initiate(ZESpecFuncs &funcs)
         };
         funcs.input_controller_command = [](int32_t, uint8_t *) {};
         funcs.input_get_keys = [](int32_t controller, ZESpec::Buttons *keys) {
-            M64RRSpec::Buttons buttons{keys->value};
+            CoreButtons buttons{keys->value};
             if (s_mupenrr_get_keys_fn) s_mupenrr_get_keys_fn(controller, &buttons);
             keys->value = buttons.value;
         };
         funcs.input_set_keys = [](int32_t controller, ZESpec::Buttons keys) {
-            M64RRSpec::Buttons buttons{keys.value};
+            CoreButtons buttons{keys.value};
             if (s_mupenrr_set_keys_fn) s_mupenrr_set_keys_fn(controller, buttons);
         };
         funcs.input_read_controller = [](int32_t controller, unsigned char *command) {

--- a/src/Views.Win32/plugin/M64RRPlugin.cpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.cpp
@@ -220,28 +220,28 @@ void M64RRPlugin::initiate(ZESpecFuncs &funcs)
     switch (m_type)
     {
     case Plugin::Type::Video:
-        init->log_trace = [](const wchar_t *str) { g_video_logger->trace(str); };
-        init->log_info = [](const wchar_t *str) { g_video_logger->info(str); };
-        init->log_warn = [](const wchar_t *str) { g_video_logger->warn(str); };
-        init->log_error = [](const wchar_t *str) { g_video_logger->error(str); };
+        init->log_trace = [](const char *str) { g_video_logger->trace(str); };
+        init->log_info = [](const char *str) { g_video_logger->info(str); };
+        init->log_warn = [](const char *str) { g_video_logger->warn(str); };
+        init->log_error = [](const char *str) { g_video_logger->error(str); };
         break;
     case Plugin::Type::Audio:
-        init->log_trace = [](const wchar_t *str) { g_audio_logger->trace(str); };
-        init->log_info = [](const wchar_t *str) { g_audio_logger->info(str); };
-        init->log_warn = [](const wchar_t *str) { g_audio_logger->warn(str); };
-        init->log_error = [](const wchar_t *str) { g_audio_logger->error(str); };
+        init->log_trace = [](const char *str) { g_audio_logger->trace(str); };
+        init->log_info = [](const char *str) { g_audio_logger->info(str); };
+        init->log_warn = [](const char *str) { g_audio_logger->warn(str); };
+        init->log_error = [](const char *str) { g_audio_logger->error(str); };
         break;
     case Plugin::Type::Input:
-        init->log_trace = [](const wchar_t *str) { g_input_logger->trace(str); };
-        init->log_info = [](const wchar_t *str) { g_input_logger->info(str); };
-        init->log_warn = [](const wchar_t *str) { g_input_logger->warn(str); };
-        init->log_error = [](const wchar_t *str) { g_input_logger->error(str); };
+        init->log_trace = [](const char *str) { g_input_logger->trace(str); };
+        init->log_info = [](const char *str) { g_input_logger->info(str); };
+        init->log_warn = [](const char *str) { g_input_logger->warn(str); };
+        init->log_error = [](const char *str) { g_input_logger->error(str); };
         break;
     case Plugin::Type::RSP:
-        init->log_trace = [](const wchar_t *str) { g_rsp_logger->trace(str); };
-        init->log_info = [](const wchar_t *str) { g_rsp_logger->info(str); };
-        init->log_warn = [](const wchar_t *str) { g_rsp_logger->warn(str); };
-        init->log_error = [](const wchar_t *str) { g_rsp_logger->error(str); };
+        init->log_trace = [](const char *str) { g_rsp_logger->trace(str); };
+        init->log_info = [](const char *str) { g_rsp_logger->info(str); };
+        init->log_warn = [](const char *str) { g_rsp_logger->warn(str); };
+        init->log_error = [](const char *str) { g_rsp_logger->error(str); };
         break;
     }
 

--- a/src/Views.Win32/plugin/M64RRPlugin.cpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.cpp
@@ -31,37 +31,37 @@ static M64RRSpec::PtrDoRSPCycles s_mupenrr_do_rsp_cycles_fn = nullptr;
 #define LOOKUP_MUPENRR_FN(mupenrr_ptr, mupenrr_type, export_name)                                                      \
     mupenrr_ptr = (mupenrr_type)GetProcAddress(m_module, export_name);
 
-static CoreController controller_to_core_controller(const M64RRSpec::Controller &controller)
-{
-    CoreControllerExtension extension;
-    switch (controller.plugin)
-    {
-    case M64RRSpec::ControllerExtension::None:
-        extension = CoreControllerExtension::None;
-        break;
-    case M64RRSpec::ControllerExtension::Mempak:
-        extension = CoreControllerExtension::Mempak;
-        break;
-    case M64RRSpec::ControllerExtension::Rumblepak:
-        extension = CoreControllerExtension::Rumblepak;
-        break;
-    case M64RRSpec::ControllerExtension::Transferpak:
-        extension = CoreControllerExtension::Transferpak;
-        break;
-    case M64RRSpec::ControllerExtension::Raw:
-        extension = CoreControllerExtension::Raw;
-        break;
-    default:
-        RT_ASSERT(false, L"Unknown controller extension");
-        break;
-    }
+// static CoreController controller_to_core_controller(const M64RRSpec::Controller &controller)
+// {
+//     CoreControllerExtension extension;
+//     switch (controller.plugin)
+//     {
+//     case M64RRSpec::ControllerExtension::None:
+//         extension = CoreControllerExtension::None;
+//         break;
+//     case M64RRSpec::ControllerExtension::Mempak:
+//         extension = CoreControllerExtension::Mempak;
+//         break;
+//     case M64RRSpec::ControllerExtension::Rumblepak:
+//         extension = CoreControllerExtension::Rumblepak;
+//         break;
+//     case M64RRSpec::ControllerExtension::Transferpak:
+//         extension = CoreControllerExtension::Transferpak;
+//         break;
+//     case M64RRSpec::ControllerExtension::Raw:
+//         extension = CoreControllerExtension::Raw;
+//         break;
+//     default:
+//         RT_ASSERT(false, L"Unknown controller extension");
+//         break;
+//     }
 
-    return CoreController{
-        .present = controller.present ? 1 : 0,
-        .raw = controller.raw ? 1 : 0,
-        .plugin = extension,
-    };
-}
+//     return CoreController{
+//         .present = controller.present ? 1 : 0,
+//         .raw = controller.raw ? 1 : 0,
+//         .plugin = controller.plugin,
+//     };
+// }
 
 static size_t get_config_path(char *data, size_t size)
 {
@@ -136,7 +136,7 @@ void M64RRPlugin::config(HWND hwnd)
     initiate(g_plugin_funcs);
     const bool newly_initiated = m_initialized && !prev_initiated;
 
-    const auto show_config = (M64RRSpec::PtrShowConfig)GetProcAddress(m_module, "M64RRRShowConfig");
+    const auto show_config = (M64RRSpec::PtrShowConfig)GetProcAddress(m_module, "M64RRShowConfig");
 
     if (show_config)
         show_config(hwnd);
@@ -208,8 +208,7 @@ void M64RRPlugin::initiate(ZESpecFuncs &funcs)
 
     init->process_dlist = funcs.video_process_dlist;
 
-    std::array<M64RRSpec::Controller, 4> tmp_controllers{};
-    init->controllers = tmp_controllers.data();
+    init->controllers = g_main_ctx.core.controls;
 
     init->get_effective_speed_mode = [](void) { return g_main_ctx.core_ctx->vr_get_effective_speed_mode(); };
     init->frame_skipped = [](void) { return g_main_ctx.core_ctx->vr_get_frame_skipped(); };
@@ -358,18 +357,14 @@ void M64RRPlugin::initiate(ZESpecFuncs &funcs)
         };
         funcs.input_set_keys = [](int32_t controller, ZESpec::Buttons keys) {
             M64RRSpec::Buttons buttons{keys.value};
-            if (s_mupenrr_set_keys_fn) s_mupenrr_set_keys_fn(controller, &buttons);
+            if (s_mupenrr_set_keys_fn) s_mupenrr_set_keys_fn(controller, buttons);
         };
         funcs.input_read_controller = [](int32_t controller, unsigned char *command) {
             if (s_mupenrr_read_controller_fn) s_mupenrr_read_controller_fn(controller, command);
         };
         funcs.input_key_down = [](uint32_t, int32_t) {};
         funcs.input_key_up = [](uint32_t, int32_t) {};
-
-        for (size_t i = 0; i < std::size(tmp_controllers); ++i)
-        {
-            g_main_ctx.core.controls[i] = controller_to_core_controller(tmp_controllers[i]);
-        }
+        
         break;
     }
     case Plugin::Type::RSP: {
@@ -390,8 +385,7 @@ void M64RRPlugin::initiate(ZESpecFuncs &funcs)
         funcs.rsp_do_rsp_cycles = [](uint32_t cycles) {
             if (s_mupenrr_do_rsp_cycles_fn)
             {
-                s_mupenrr_do_rsp_cycles_fn((uint8_t)cycles);
-                return 0u;
+                return s_mupenrr_do_rsp_cycles_fn(cycles);
             }
             return cycles;
         };

--- a/toolchains/vcpkg-win64.cmake
+++ b/toolchains/vcpkg-win64.cmake
@@ -71,7 +71,7 @@ endif()
 list(GET _sys_proc_values "${_index}" _sys_proc)
 list(GET _comp_arch_values "${_index}" _comp_arch)
 
-# set(CMAKE_SYSTEM_NAME "Windows" PARENT_SCOPE)
+set(CMAKE_SYSTEM_NAME "Windows" PARENT_SCOPE)
 set(CMAKE_SYSTEM_PROCESSOR "${_sys_proc}" PARENT_SCOPE)
 set(CMAKE_C_COMPILER_TARGET "${_comp_arch}" PARENT_SCOPE)
 set(CMAKE_CXX_COMPILER_TARGET "${_comp_arch}" PARENT_SCOPE)

--- a/toolchains/vcpkg-win64.cmake
+++ b/toolchains/vcpkg-win64.cmake
@@ -71,7 +71,7 @@ endif()
 list(GET _sys_proc_values "${_index}" _sys_proc)
 list(GET _comp_arch_values "${_index}" _comp_arch)
 
-set(CMAKE_SYSTEM_NAME "Windows" PARENT_SCOPE)
+# set(CMAKE_SYSTEM_NAME "Windows" PARENT_SCOPE)
 set(CMAKE_SYSTEM_PROCESSOR "${_sys_proc}" PARENT_SCOPE)
 set(CMAKE_C_COMPILER_TARGET "${_comp_arch}" PARENT_SCOPE)
 set(CMAKE_CXX_COMPILER_TARGET "${_comp_arch}" PARENT_SCOPE)


### PR DESCRIPTION
This PR does the following:

- **critical:** fixes a bug with `StrUtils::ctrim_string` that I missed in the last PR
- Unifies various core functions and types with their plugin counterparts
- Changes the plugin logging to use UTF-8
- Adds compile-time tests to ensure plugin API types and their callbacks are kept in sync
- Fixes a typo with `M64RRShowConfig`
- Adds a bunch of missing headers in various places