### PR TITLE
perf(dynarec/x64): allocate FPU registers with an XMM value cache

### DIFF
--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -134,6 +134,13 @@ if (${MUPEN64RR_ENABLE_DYNAREC})
         "${DYNAREC_DIR}/RegCache.cpp"
         "${DYNAREC_DIR}/RJump.cpp"
     )
+
+    if (DYNAREC_DIR STREQUAL "R4300/x86_64")
+        target_sources(Mupen64RR.Core PRIVATE
+            "${DYNAREC_DIR}/FprCache.hpp"
+            "${DYNAREC_DIR}/FprCache.cpp"
+        )
+    endif()
 endif()
 
 # FOR TESTING ONLY. DO NOT USE OTHERWISE.

--- a/src/Core/R4300/Recomp.cpp
+++ b/src/Core/R4300/Recomp.cpp
@@ -16,8 +16,18 @@
 #include <R4300/Tracelog.hpp>
 #if defined(_M_X64) || defined(__x86_64__)
 #include <R4300/x86_64/RegCache.hpp>
+#include <R4300/x86_64/FprCache.hpp>
 #elif defined(_M_IX86) || defined(__i386__)
 #include <R4300/x86/RegCache.hpp>
+static inline void fpr_cache_reset()
+{
+}
+static inline void fpr_cache_flush()
+{
+}
+static inline void fpr_cache_gate(uint32_t)
+{
+}
 #elif defined(MUPEN64RR_ENABLE_DYNAREC)
 #error "No dynarec backend exists for this architecture; build with MUPEN64RR_ENABLE_DYNAREC=OFF."
 #endif
@@ -2959,6 +2969,7 @@ void recompile_block(int32_t *source, precomp_block *block, uint32_t func)
         inst_pointer = &block->code;
         init_assembler(block->jumps_table, block->jumps_number);
         init_cache(block->block + (func & 0xFFF) / 4);
+        fpr_cache_reset();
     }
 #endif
 
@@ -2980,6 +2991,9 @@ void recompile_block(int32_t *source, precomp_block *block, uint32_t func)
         dst = block->block + i;
         dst->addr = block->start + i * 4;
         dst->reg_cache_infos.need_map = 0;
+#ifdef MUPEN64RR_ENABLE_DYNAREC
+        if (dynacore) fpr_cache_gate(src);
+#endif
         dst->local_addr = code_length;
         recomp_ops[((src >> 26) & 0x3F)]();
         if (g_ctx.tl_active())
@@ -3019,6 +3033,9 @@ if (dynacore) genlink_subblock();
         dst = block->block + i;
         dst->addr = block->start + i * 4;
         dst->reg_cache_infos.need_map = 0;
+#ifdef MUPEN64RR_ENABLE_DYNAREC
+        if (dynacore) fpr_cache_gate(0);
+#endif
         dst->local_addr = code_length;
         RFIN_BLOCK();
         i++;
@@ -3027,6 +3044,9 @@ if (dynacore) genlink_subblock();
             dst = block->block + i;
             dst->addr = block->start + i * 4;
             dst->reg_cache_infos.need_map = 0;
+#ifdef MUPEN64RR_ENABLE_DYNAREC
+            if (dynacore) fpr_cache_gate(0);
+#endif
             dst->local_addr = code_length;
             RFIN_BLOCK();
             i++;
@@ -3037,6 +3057,7 @@ if (dynacore) genlink_subblock();
         genlink_subblock();
     if (dynacore)
     {
+        fpr_cache_flush();
         free_all_registers();
         passe2(block->block, (func & 0xFFF) / 4, i, block);
         block->code_length = code_length;
@@ -3086,6 +3107,9 @@ void recompile_opcode()
     dst++;
     dst->addr = (dst - 1)->addr + 4;
     dst->reg_cache_infos.need_map = 0;
+#ifdef MUPEN64RR_ENABLE_DYNAREC
+    if (dynacore) fpr_cache_gate(src);
+#endif
     if (!is_jump())
         recomp_ops[((src >> 26) & 0x3F)]();
     else

--- a/src/Core/R4300/x86_64/Assemble.cpp
+++ b/src/Core/R4300/x86_64/Assemble.cpp
@@ -532,6 +532,23 @@ void je_near_rj(uint32_t saut)
     put8(0x84);
     put32(saut);
 }
+void ja_near_rj(uint32_t saut)
+{
+    put8(0x0F);
+    put8(0x87);
+    put32(saut);
+}
+void jp_near_rj(uint32_t saut)
+{
+    put8(0x0F);
+    put8(0x8A);
+    put32(saut);
+}
+void jmp_near_rj(uint32_t saut)
+{
+    put8(0xE9);
+    put32(saut);
+}
 
 void jl_near(uint32_t mi_addr)
 {
@@ -1846,6 +1863,100 @@ void cvtsd2ss_xmm_xmm(int32_t dst, int32_t src) // cvtsd2ss dst, src (double->fl
     put8(0x0F);
     put8(0x5A);
     put8(sse_modrm_reg(dst, src));
+}
+
+void movaps_xmm_xmm(int32_t dst, int32_t src)
+{
+    put8(0x0F);
+    put8(0x28);
+    put8(sse_modrm_reg(dst, src));
+}
+static void sse_arith_reg(unsigned char prefix, unsigned char opcode, int32_t dst, int32_t src)
+{
+    put8(prefix);
+    put8(0x0F);
+    put8(opcode);
+    put8(sse_modrm_reg(dst, src));
+}
+void addss_xmm_xmm(int32_t dst, int32_t src)
+{
+    sse_arith_reg(0xF3, 0x58, dst, src);
+}
+void subss_xmm_xmm(int32_t dst, int32_t src)
+{
+    sse_arith_reg(0xF3, 0x5C, dst, src);
+}
+void mulss_xmm_xmm(int32_t dst, int32_t src)
+{
+    sse_arith_reg(0xF3, 0x59, dst, src);
+}
+void divss_xmm_xmm(int32_t dst, int32_t src)
+{
+    sse_arith_reg(0xF3, 0x5E, dst, src);
+}
+void cvtss2sd_xmm_xmm(int32_t dst, int32_t src)
+{
+    sse_arith_reg(0xF3, 0x5A, dst, src);
+}
+void addsd_xmm_xmm(int32_t dst, int32_t src)
+{
+    sse_arith_reg(0xF2, 0x58, dst, src);
+}
+void subsd_xmm_xmm(int32_t dst, int32_t src)
+{
+    sse_arith_reg(0xF2, 0x5C, dst, src);
+}
+void mulsd_xmm_xmm(int32_t dst, int32_t src)
+{
+    sse_arith_reg(0xF2, 0x59, dst, src);
+}
+void divsd_xmm_xmm(int32_t dst, int32_t src)
+{
+    sse_arith_reg(0xF2, 0x5E, dst, src);
+}
+
+void mov_r11_pm64(void *m64)
+{
+    mov_r11_imm64((uintptr_t)m64);
+    put8(0x4D);
+    put8(0x8B);
+    put8(0x1B);
+}
+static inline unsigned char sse_modrm_r11(int32_t xmm)
+{
+    return (unsigned char)((xmm << 3) | 3);
+}
+void movss_xmm_pr11(int32_t xmm)
+{
+    put8(0xF3);
+    put8(0x41);
+    put8(0x0F);
+    put8(0x10);
+    put8(sse_modrm_r11(xmm));
+}
+void movss_pr11_xmm(int32_t xmm)
+{
+    put8(0xF3);
+    put8(0x41);
+    put8(0x0F);
+    put8(0x11);
+    put8(sse_modrm_r11(xmm));
+}
+void movsd_xmm_pr11(int32_t xmm)
+{
+    put8(0xF2);
+    put8(0x41);
+    put8(0x0F);
+    put8(0x10);
+    put8(sse_modrm_r11(xmm));
+}
+void movsd_pr11_xmm(int32_t xmm)
+{
+    put8(0xF2);
+    put8(0x41);
+    put8(0x0F);
+    put8(0x11);
+    put8(sse_modrm_r11(xmm));
 }
 // MXCSR save/load (the SSE analogue of x87 fnstcw/fldcw), used to swap the SSE rounding
 // mode for ROUND/CEIL/FLOOR the way the interpreter does with fesetround.

--- a/src/Core/R4300/x86_64/Assemble.hpp
+++ b/src/Core/R4300/x86_64/Assemble.hpp
@@ -33,10 +33,15 @@
 #define DH 6
 #define BH 7
 
+#define FPR_CACHE_XMM_BASE 3
+#define FPR_CACHE_SLOTS 3
+
 typedef struct _reg_cache_struct
 {
     int32_t need_map;
     void *needed_registers[8];
+    void *needed_xmm[FPR_CACHE_SLOTS];
+    unsigned char needed_xmm_double[FPR_CACHE_SLOTS];
     unsigned char jump_wrapper[256];
     int32_t need_cop1_check;
     // dyna_jump thunk cache (see RJump.cpp): generated once per instruction and reused.
@@ -154,6 +159,9 @@ void cmp_rax_imm64(uintptr_t imm64);                                     // x64:
 void jg_near(uint32_t mi_addr);
 void add_m32_reg32(void *_m32, int32_t reg32);
 void je_near_rj(uint32_t saut);
+void ja_near_rj(uint32_t saut);
+void jp_near_rj(uint32_t saut);
+void jmp_near_rj(uint32_t saut);
 void jge_near_rj(uint32_t saut);
 void jl_near_rj(uint32_t saut);
 void jle_near_rj(uint32_t saut);
@@ -238,6 +246,21 @@ void cvtsi2sd_xmm_preg64(int32_t xmm, int32_t base);
 void cvtsi2sdq_xmm_preg64(int32_t xmm, int32_t base);
 void sqrtsd_xmm_xmm(int32_t dst, int32_t src);
 void cvtsd2ss_xmm_xmm(int32_t dst, int32_t src);
+void movaps_xmm_xmm(int32_t dst, int32_t src);
+void addss_xmm_xmm(int32_t dst, int32_t src);
+void subss_xmm_xmm(int32_t dst, int32_t src);
+void mulss_xmm_xmm(int32_t dst, int32_t src);
+void divss_xmm_xmm(int32_t dst, int32_t src);
+void cvtss2sd_xmm_xmm(int32_t dst, int32_t src);
+void addsd_xmm_xmm(int32_t dst, int32_t src);
+void subsd_xmm_xmm(int32_t dst, int32_t src);
+void mulsd_xmm_xmm(int32_t dst, int32_t src);
+void divsd_xmm_xmm(int32_t dst, int32_t src);
+void mov_r11_pm64(void *m64);
+void movss_xmm_pr11(int32_t xmm);
+void movss_pr11_xmm(int32_t xmm);
+void movsd_xmm_pr11(int32_t xmm);
+void movsd_pr11_xmm(int32_t xmm);
 void stmxcsr_m32(void *m32);
 void ldmxcsr_m32(void *m32);
 void fstp_fpreg(int32_t fpreg);

--- a/src/Core/R4300/x86_64/FprCache.cpp
+++ b/src/Core/R4300/x86_64/FprCache.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <CommonPCH.hpp>
+#include <Core.hpp>
+#include <R4300/R4300.hpp>
+#include <R4300/Recomp.hpp>
+#include <R4300/Recomph.hpp>
+#include <R4300/x86_64/Assemble.hpp>
+#include <R4300/x86_64/FprCache.hpp>
+
+namespace
+{
+struct Slot
+{
+    int32_t fgr;
+    bool dirty;
+    bool locked;
+    uint32_t stamp;
+};
+
+Slot g_slots[FPR_CACHE_SLOTS] = {
+    {-1, false, false, 0},
+    {-1, false, false, 0},
+    {-1, false, false, 0},
+};
+static_assert(FPR_CACHE_SLOTS == 3, "keep g_slots' initialiser in sync with FPR_CACHE_SLOTS");
+
+uint32_t g_clock;
+
+bool g_double;
+
+int32_t slot_xmm(int32_t slot)
+{
+    return FPR_CACHE_XMM_BASE + slot;
+}
+
+void *fpr_ptr_addr(int32_t fgr)
+{
+    return g_double ? (void *)&reg_cop1_double[fgr] : (void *)&reg_cop1_simple[fgr];
+}
+
+void emit_fill(int32_t slot)
+{
+    mov_r11_pm64(fpr_ptr_addr(g_slots[slot].fgr));
+    if (g_double)
+        movsd_xmm_pr11(slot_xmm(slot));
+    else
+        movss_xmm_pr11(slot_xmm(slot));
+}
+
+void emit_spill(int32_t slot)
+{
+    mov_r11_pm64(fpr_ptr_addr(g_slots[slot].fgr));
+    if (g_double)
+        movsd_pr11_xmm(slot_xmm(slot));
+    else
+        movss_pr11_xmm(slot_xmm(slot));
+}
+
+void drop(int32_t slot)
+{
+    if (g_slots[slot].fgr >= 0 && g_slots[slot].dirty) emit_spill(slot);
+    g_slots[slot].fgr = -1;
+    g_slots[slot].dirty = false;
+    g_slots[slot].locked = false;
+}
+
+int32_t find(int32_t fgr)
+{
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++)
+        if (g_slots[i].fgr == fgr) return i;
+    return -1;
+}
+
+bool is_cache_aware(uint32_t src)
+{
+    if (((src >> 26) & 0x3F) != 17) return false;
+
+    const uint32_t fmt = (src >> 21) & 0x1F;
+    if (fmt != 16 && fmt != 17) return false;
+
+    const uint32_t funct = src & 0x3F;
+    if (funct <= 7) return true;
+    if (funct >= 0x30) return true;
+    return false;
+}
+
+int32_t acquire()
+{
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++)
+        if (g_slots[i].fgr < 0) return i;
+
+    int32_t victim = -1;
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++)
+    {
+        if (g_slots[i].locked) continue;
+        if (victim < 0 || g_slots[i].stamp < g_slots[victim].stamp) victim = i;
+    }
+
+    if (victim < 0)
+    {
+        g_core->log_error("[Dynarec] FATAL: FPR cache has no unlocked slot to evict");
+        abort();
+    }
+
+    drop(victim);
+    return victim;
+}
+}
+
+void fpr_cache_reset()
+{
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++)
+    {
+        g_slots[i].fgr = -1;
+        g_slots[i].dirty = false;
+        g_slots[i].locked = false;
+        g_slots[i].stamp = 0;
+    }
+    g_clock = 0;
+}
+
+void fpr_cache_begin(bool dbl)
+{
+#if FPR_CACHE_PERSIST
+    if (dbl != g_double) fpr_cache_flush();
+#else
+    if (!fpr_cache_empty())
+    {
+        g_core->log_error("[Dynarec] FATAL: FPR cache not empty on entry to a COP1 instruction");
+        abort();
+    }
+    fpr_cache_reset();
+#endif
+    g_double = dbl;
+    fpr_cache_unlock_all();
+}
+
+void fpr_cache_end()
+{
+#if !FPR_CACHE_PERSIST
+    fpr_cache_flush();
+#endif
+}
+
+void fpr_cache_gate(uint32_t src)
+{
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++) dst->reg_cache_infos.needed_xmm[i] = nullptr;
+
+    if (!is_cache_aware(src)) fpr_cache_flush();
+}
+
+void fpr_cache_mark_live()
+{
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++)
+    {
+        dst->reg_cache_infos.needed_xmm[i] = g_slots[i].fgr >= 0 ? fpr_ptr_addr(g_slots[i].fgr) : nullptr;
+        dst->reg_cache_infos.needed_xmm_double[i] = (unsigned char)g_double;
+    }
+}
+
+void fpr_cache_reload_live()
+{
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++)
+        if (g_slots[i].fgr >= 0) emit_fill(i);
+}
+
+bool fpr_cache_empty()
+{
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++)
+        if (g_slots[i].fgr >= 0) return false;
+    return true;
+}
+
+void fpr_cache_flush()
+{
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++) drop(i);
+}
+
+int32_t fpr_cache_read(int32_t fgr)
+{
+    int32_t slot = find(fgr);
+    if (slot < 0)
+    {
+        slot = acquire();
+        g_slots[slot].fgr = fgr;
+        g_slots[slot].dirty = false;
+        emit_fill(slot);
+    }
+
+    g_slots[slot].stamp = ++g_clock;
+    return slot_xmm(slot);
+}
+
+int32_t fpr_cache_write(int32_t fgr)
+{
+    int32_t slot = find(fgr);
+    if (slot < 0)
+    {
+        slot = acquire();
+        g_slots[slot].fgr = fgr;
+    }
+
+    g_slots[slot].dirty = true;
+    g_slots[slot].stamp = ++g_clock;
+    return slot_xmm(slot);
+}
+
+void fpr_cache_lock(int32_t xmm)
+{
+    const int32_t slot = xmm - FPR_CACHE_XMM_BASE;
+    if (slot >= 0 && slot < FPR_CACHE_SLOTS) g_slots[slot].locked = true;
+}
+
+void fpr_cache_unlock_all()
+{
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++) g_slots[i].locked = false;
+}
+
+void fpr_cache_spill_live()
+{
+    for (int32_t i = 0; i < FPR_CACHE_SLOTS; i++)
+        if (g_slots[i].fgr >= 0 && g_slots[i].dirty) emit_spill(i);
+}

--- a/src/Core/R4300/x86_64/FprCache.hpp
+++ b/src/Core/R4300/x86_64/FprCache.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, Mupen64 Organization (https://github.com/mupen64)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <R4300/Recomp.hpp>
+
+#define FPR_CACHE_PERSIST 1
+
+void fpr_cache_begin(bool dbl);
+
+void fpr_cache_end();
+
+void fpr_cache_flush();
+
+void fpr_cache_reset();
+
+void fpr_cache_gate(uint32_t src);
+
+void fpr_cache_mark_live();
+
+void fpr_cache_reload_live();
+
+int32_t fpr_cache_read(int32_t fgr);
+
+int32_t fpr_cache_write(int32_t fgr);
+
+void fpr_cache_lock(int32_t xmm);
+void fpr_cache_unlock_all();
+
+void fpr_cache_spill_live();
+
+bool fpr_cache_empty();

--- a/src/Core/R4300/x86_64/GCop1D.cpp
+++ b/src/Core/R4300/x86_64/GCop1D.cpp
@@ -9,6 +9,7 @@
 #include <R4300/R4300.hpp>
 #include <R4300/Recomph.hpp>
 #include <R4300/x86_64/Assemble.hpp>
+#include <R4300/x86_64/FprCache.hpp>
 #include <R4300/x86_64/Gcop1Helpers.hpp>
 #include <R4300/Cop1Helpers.hpp>
 #include <R4300/Ops.hpp>
@@ -39,11 +40,11 @@ static void gen_fcr31_clear_c()
 }
 static void gen_cmp_load_d()
 {
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fs]));
-    movsd_xmm_preg64(0, EAX); // xmm0 = fs
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.ft]));
-    movsd_xmm_preg64(1, EAX); // xmm1 = ft
-    ucomisd_xmm_xmm(0, 1);
+    const int32_t s = fpr_cache_read(dst->f.cf.fs);
+    fpr_cache_lock(s);
+    const int32_t t = fpr_cache_read(dst->f.cf.ft);
+    fpr_cache_unlock_all();
+    ucomisd_xmm_xmm(s, t);
 }
 static void ccond_setjump_body_d(void (*jset)(unsigned char))
 {
@@ -75,6 +76,7 @@ static void ccond_clearjump_body_d(void (*jclear2)(unsigned char))
 static void ccond_signaling_nan_d()
 {
     gen_cmp_load_d();
+    fpr_cache_flush();
     jp_rj(0);
     int32_t jf = code_length - 1;
     jmp_imm_short(0);
@@ -85,25 +87,99 @@ static void ccond_signaling_nan_d()
 }
 static void gen_ccond_setjump_d(void (*jset)(unsigned char))
 {
+    fpr_cache_begin(true);
     gencheck_cop1_unusable();
     ccond_setjump_body_d(jset);
+    fpr_cache_end();
 }
 static void gen_ccond_clearjump_d(void (*jclear2)(unsigned char))
 {
+    fpr_cache_begin(true);
     gencheck_cop1_unusable();
     ccond_clearjump_body_d(jclear2);
+    fpr_cache_end();
 }
 static void gen_ccond_sig_clearjump_d(void (*jclear2)(unsigned char))
 {
+    fpr_cache_begin(true);
     gencheck_cop1_unusable();
     if (g_core->cfg->float_exception_emulation) ccond_signaling_nan_d();
     ccond_clearjump_body_d(jclear2);
+    fpr_cache_end();
 }
 static void gen_ccond_sig_clear_d()
 {
+    fpr_cache_begin(true);
     gencheck_cop1_unusable();
     if (g_core->cfg->float_exception_emulation) ccond_signaling_nan_d();
     gen_fcr31_clear_c();
+    fpr_cache_end();
+}
+
+#define ARITH_TMP 0
+
+static uint64_t neg_abs_mask_d = 0x7FFFFFFFFFFFFFFFULL;
+static uint64_t neg_sign_mask_d = 0x8000000000000000ULL;
+
+static void apply_mask_d(int32_t d, void *mask, void (*op)(int32_t, int32_t))
+{
+    mov_reg64_imm64(EBX, (uintptr_t)mask);
+    movsd_xmm_preg64(ARITH_TMP, EBX);
+    op(d, ARITH_TMP);
+}
+
+static void emit_binop_d(void (*op)(int32_t, int32_t), int32_t d, int32_t s, int32_t t)
+{
+    if (d == s)
+    {
+        op(d, t);
+    }
+    else if (d == t)
+    {
+        movaps_xmm_xmm(ARITH_TMP, t);
+        movaps_xmm_xmm(d, s);
+        op(d, ARITH_TMP);
+    }
+    else
+    {
+        movaps_xmm_xmm(d, s);
+        op(d, t);
+    }
+}
+
+static void gen_arith_d(void (*op)(int32_t, int32_t))
+{
+    fpr_cache_begin(true);
+    gencheck_cop1_unusable();
+
+    const int32_t s = fpr_cache_read(dst->f.cf.fs);
+    fpr_cache_lock(s);
+    const int32_t t = fpr_cache_read(dst->f.cf.ft);
+    fpr_cache_lock(t);
+    gencheck_input_d_xmm(s);
+    gencheck_input_d_xmm(t);
+
+    const int32_t d = fpr_cache_write(dst->f.cf.fd);
+    fpr_cache_unlock_all();
+    emit_binop_d(op, d, s, t);
+    gencheck_output_d_xmm(d);
+
+    fpr_cache_end();
+}
+
+static void gen_unop_d(int32_t *s_out, int32_t *d_out, bool check_input)
+{
+    fpr_cache_begin(true);
+    gencheck_cop1_unusable();
+
+    const int32_t s = fpr_cache_read(dst->f.cf.fs);
+    fpr_cache_lock(s);
+    if (check_input) gencheck_input_d_xmm(s);
+    const int32_t d = fpr_cache_write(dst->f.cf.fd);
+    fpr_cache_unlock_all();
+
+    *s_out = s;
+    *d_out = d;
 }
 
 void genadd_d()
@@ -111,16 +187,7 @@ void genadd_d()
 #ifdef INTERPRET_ADD_D
     gencallinterp((uintptr_t)ADD_D, 0);
 #else
-    gencheck_cop1_unusable();
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.fs]));
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.ft]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fs]));
-    movsd_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.ft]));
-    addsd_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fd]));
-    movsd_preg64_xmm(EAX, 0);
-    gencheck_output_d((void *)(&reg_cop1_double[dst->f.cf.fd]));
+    gen_arith_d(addsd_xmm_xmm);
 #endif
 }
 
@@ -129,16 +196,7 @@ void gensub_d()
 #ifdef INTERPRET_SUB_D
     gencallinterp((uintptr_t)SUB_D, 0);
 #else
-    gencheck_cop1_unusable();
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.fs]));
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.ft]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fs]));
-    movsd_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.ft]));
-    subsd_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fd]));
-    movsd_preg64_xmm(EAX, 0);
-    gencheck_output_d((void *)(&reg_cop1_double[dst->f.cf.fd]));
+    gen_arith_d(subsd_xmm_xmm);
 #endif
 }
 
@@ -147,16 +205,7 @@ void genmul_d()
 #ifdef INTERPRET_MUL_D
     gencallinterp((uintptr_t)MUL_D, 0);
 #else
-    gencheck_cop1_unusable();
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.fs]));
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.ft]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fs]));
-    movsd_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.ft]));
-    mulsd_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fd]));
-    movsd_preg64_xmm(EAX, 0);
-    gencheck_output_d((void *)(&reg_cop1_double[dst->f.cf.fd]));
+    gen_arith_d(mulsd_xmm_xmm);
 #endif
 }
 
@@ -165,16 +214,7 @@ void gendiv_d()
 #ifdef INTERPRET_DIV_D
     gencallinterp((uintptr_t)DIV_D, 0);
 #else
-    gencheck_cop1_unusable();
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.fs]));
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.ft]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fs]));
-    movsd_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.ft]));
-    divsd_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fd]));
-    movsd_preg64_xmm(EAX, 0);
-    gencheck_output_d((void *)(&reg_cop1_double[dst->f.cf.fd]));
+    gen_arith_d(divsd_xmm_xmm);
 #endif
 }
 
@@ -184,13 +224,11 @@ void gensqrt_d()
     gencallinterp((uintptr_t)SQRT_D, 0);
 #else
     // sqrt(double) is unambiguously double precision -> sqrtsd (bit-exact).
-    gencheck_cop1_unusable();
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.fs]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fs]));
-    sqrtsd_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fd]));
-    movsd_preg64_xmm(EAX, 0);
-    gencheck_output_d((void *)(&reg_cop1_double[dst->f.cf.fd]));
+    int32_t s, d;
+    gen_unop_d(&s, &d, true);
+    sqrtsd_xmm_xmm(d, s);
+    gencheck_output_d_xmm(d);
+    fpr_cache_end();
 #endif
 }
 
@@ -199,16 +237,11 @@ void genabs_d()
 #ifdef INTERPRET_ABS_D
     gencallinterp((uintptr_t)ABS_D, 0);
 #else
-    // fabs = clear the sign bit (bit 63 = bit 31 of the high dword). ABS cannot fail.
-    gencheck_cop1_unusable();
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.fs]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fs]));
-    mov_reg32_preg32(EBX, EAX);
-    mov_reg32_preg32pimm32(ECX, EAX, 4);
-    and_reg32_imm32(ECX, 0x7FFFFFFF);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fd]));
-    mov_preg32_reg32(EAX, EBX);
-    mov_preg32pimm32_reg32(EAX, 4, ECX);
+    int32_t s, d;
+    gen_unop_d(&s, &d, true);
+    if (d != s) movaps_xmm_xmm(d, s);
+    apply_mask_d(d, &neg_abs_mask_d, andpd_xmm_xmm);
+    fpr_cache_end();
 #endif
 }
 
@@ -217,14 +250,10 @@ void genmov_d()
 #ifdef INTERPRET_MOV_D
     gencallinterp((uintptr_t)MOV_D, 0);
 #else
-    // Raw 64-bit copy (two dwords), no check. 64-bit pointer loads.
-    gencheck_cop1_unusable();
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fs]));
-    mov_reg32_preg32(EBX, EAX);
-    mov_reg32_preg32pimm32(ECX, EAX, 4);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fd]));
-    mov_preg32_reg32(EAX, EBX);
-    mov_preg32pimm32_reg32(EAX, 4, ECX);
+    int32_t s, d;
+    gen_unop_d(&s, &d, false);
+    if (d != s) movaps_xmm_xmm(d, s);
+    fpr_cache_end();
 #endif
 }
 
@@ -233,16 +262,11 @@ void genneg_d()
 #ifdef INTERPRET_NEG_D
     gencallinterp((uintptr_t)NEG_D, 0);
 #else
-    // Negate = flip the sign bit (bit 63 = bit 31 of the high dword). NEG cannot fail.
-    gencheck_cop1_unusable();
-    gencheck_input_d((void *)(&reg_cop1_double[dst->f.cf.fs]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fs]));
-    mov_reg32_preg32(EBX, EAX);
-    mov_reg32_preg32pimm32(ECX, EAX, 4);
-    xor_reg32_imm32(ECX, 0x80000000);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_double[dst->f.cf.fd]));
-    mov_preg32_reg32(EAX, EBX);
-    mov_preg32pimm32_reg32(EAX, 4, ECX);
+    int32_t s, d;
+    gen_unop_d(&s, &d, true);
+    if (d != s) movaps_xmm_xmm(d, s);
+    apply_mask_d(d, &neg_sign_mask_d, xorpd_xmm_xmm);
+    fpr_cache_end();
 #endif
 }
 

--- a/src/Core/R4300/x86_64/GCop1Helpers.cpp
+++ b/src/Core/R4300/x86_64/GCop1Helpers.cpp
@@ -10,6 +10,7 @@
 #include <R4300/R4300.hpp>
 #include <R4300/Recomph.hpp>
 #include <R4300/x86_64/Assemble.hpp>
+#include <R4300/x86_64/FprCache.hpp>
 #include <R4300/x86_64/Gcop1Helpers.hpp>
 
 uint32_t g_saved_mxcsr = 0, g_scratch_mxcsr = 0;
@@ -29,10 +30,21 @@ static void patch_jump(uint32_t addr, uint32_t target)
 
 static void gencall_noret(void (*fn)())
 {
+    fpr_cache_spill_live();
     mov_m64_imm64((void *)(&PC), (uintptr_t)(dst));
     mov_reg64_imm64(EAX, (uintptr_t)fn);
     call_reg64(EAX);
     ud2();
+}
+
+static void require_empty_cache_for_rel8()
+{
+    if (!fpr_cache_empty())
+    {
+        g_core->log_error("[Dynarec] FATAL: pointer-form COP1 check reached with a live FPR cache; "
+                          "use the _xmm form (its jumps are near) or drop the op from is_cache_aware()");
+        abort();
+    }
 }
 
 // --- SSE single-precision denormal/NaN checks (FP JIT port) ---
@@ -46,6 +58,8 @@ static uint32_t sse_sign_mask_s = 0x80000000;
 void gencheck_input_s(void *fpr_slot)
 {
     if (!g_core->cfg->float_exception_emulation) return;
+
+    require_empty_cache_for_rel8();
 
     mov_reg64_m64(EAX, fpr_slot); // EAX = float* (the FPR pointer)
     movss_xmm_preg64(1, EAX);     // xmm1 = x
@@ -63,7 +77,6 @@ void gencheck_input_s(void *fpr_slot)
     uint32_t jfail = code_length;
     je_rj(0); // |x| == 0 -> pass (zero)
     uint32_t jpass2 = code_length;
-    // denormal-nonzero falls through here -> fail (NaN jumps here too)
     patch_jump(jfail, code_length);
     gencall_noret(fail_float_input);
     patch_jump(jpass1, code_length);
@@ -75,6 +88,8 @@ void gencheck_input_s(void *fpr_slot)
 void gencheck_output_s(void *fpr_slot)
 {
     if (!g_core->cfg->float_exception_emulation) return;
+
+    require_empty_cache_for_rel8();
 
     mov_reg64_m64(EAX, fpr_slot); // EAX = float* (fd pointer)
     movss_xmm_preg64(1, EAX);     // xmm1 = x
@@ -96,12 +111,65 @@ void gencheck_output_s(void *fpr_slot)
     movss_preg64_xmm(EAX, 2); // store +-0.0 -> *fd
     jmp_imm_short(0);         // -> done
     uint32_t jdone2 = code_length;
-    // fail:
     patch_jump(jfail, code_length);
     gencall_noret(fail_float_output);
-    // done:
     patch_jump(jdone1, code_length);
     patch_jump(jdone2, code_length);
+}
+
+#define CHKX_VAL 0
+#define CHKX_TMP 1
+
+static void loadx_const_s(void *addr)
+{
+    mov_reg64_imm64(EBX, (uintptr_t)addr);
+    movss_xmm_preg64(CHKX_TMP, EBX);
+}
+
+void gencheck_input_s_xmm(int32_t xmm)
+{
+    if (!g_core->cfg->float_exception_emulation) return;
+
+    movaps_xmm_xmm(CHKX_VAL, xmm);
+    loadx_const_s(&sse_abs_mask_s);
+    andps_xmm_xmm(CHKX_VAL, CHKX_TMP);
+    loadx_const_s(&largest_denormal_float);
+    ucomiss_xmm_xmm(CHKX_VAL, CHKX_TMP);
+    ja_near_rj(0);
+    int32_t jpass1 = code_length - 4;
+    xorps_xmm_xmm(CHKX_TMP, CHKX_TMP);
+    ucomiss_xmm_xmm(CHKX_VAL, CHKX_TMP);
+    jp_near_rj(0);
+    int32_t jfail = code_length - 4;
+    je_near_rj(0);
+    int32_t jpass2 = code_length - 4;
+    rj_patch_near(jfail);
+    gencall_noret(fail_float_input);
+    rj_patch_near(jpass1);
+    rj_patch_near(jpass2);
+}
+
+void gencheck_output_s_xmm(int32_t xmm)
+{
+    if (!g_core->cfg->float_exception_emulation) return;
+
+    movaps_xmm_xmm(CHKX_VAL, xmm);
+    loadx_const_s(&sse_abs_mask_s);
+    andps_xmm_xmm(CHKX_VAL, CHKX_TMP);
+    loadx_const_s(&largest_denormal_float);
+    ucomiss_xmm_xmm(CHKX_VAL, CHKX_TMP);
+    ja_near_rj(0);
+    int32_t jdone1 = code_length - 4;
+    jp_near_rj(0);
+    int32_t jfail = code_length - 4;
+    loadx_const_s(&sse_sign_mask_s);
+    andps_xmm_xmm(xmm, CHKX_TMP);
+    jmp_near_rj(0);
+    int32_t jdone2 = code_length - 4;
+    rj_patch_near(jfail);
+    gencall_noret(fail_float_output);
+    rj_patch_near(jdone1);
+    rj_patch_near(jdone2);
 }
 
 // --- SSE double-precision denormal/NaN checks (FP JIT port) ---
@@ -111,6 +179,8 @@ static uint64_t sse_sign_mask_d = 0x8000000000000000ULL;
 void gencheck_input_d(void *fpr_slot)
 {
     if (!g_core->cfg->float_exception_emulation) return;
+
+    require_empty_cache_for_rel8();
 
     mov_reg64_m64(EAX, fpr_slot); // EAX = double* (the FPR pointer)
     movsd_xmm_preg64(1, EAX);     // xmm1 = x
@@ -138,6 +208,8 @@ void gencheck_output_d(void *fpr_slot)
 {
     if (!g_core->cfg->float_exception_emulation) return;
 
+    require_empty_cache_for_rel8();
+
     mov_reg64_m64(EAX, fpr_slot); // EAX = double* (fd pointer)
     movsd_xmm_preg64(1, EAX);     // xmm1 = x
     mov_reg64_imm64(EBX, (uintptr_t)&sse_abs_mask_d);
@@ -158,12 +230,62 @@ void gencheck_output_d(void *fpr_slot)
     movsd_preg64_xmm(EAX, 2); // store +-0.0 -> *fd
     jmp_imm_short(0);         // -> done
     uint32_t jdone2 = code_length;
-    // fail:
     patch_jump(jfail, code_length);
     gencall_noret(fail_float_output);
-    // done:
     patch_jump(jdone1, code_length);
     patch_jump(jdone2, code_length);
+}
+
+static void loadx_const_d(void *addr)
+{
+    mov_reg64_imm64(EBX, (uintptr_t)addr);
+    movsd_xmm_preg64(CHKX_TMP, EBX);
+}
+
+void gencheck_input_d_xmm(int32_t xmm)
+{
+    if (!g_core->cfg->float_exception_emulation) return;
+
+    movaps_xmm_xmm(CHKX_VAL, xmm);
+    loadx_const_d(&sse_abs_mask_d);
+    andpd_xmm_xmm(CHKX_VAL, CHKX_TMP);
+    loadx_const_d(&largest_denormal_double);
+    ucomisd_xmm_xmm(CHKX_VAL, CHKX_TMP);
+    ja_near_rj(0);
+    int32_t jpass1 = code_length - 4;
+    xorps_xmm_xmm(CHKX_TMP, CHKX_TMP);
+    ucomisd_xmm_xmm(CHKX_VAL, CHKX_TMP);
+    jp_near_rj(0);
+    int32_t jfail = code_length - 4;
+    je_near_rj(0);
+    int32_t jpass2 = code_length - 4;
+    rj_patch_near(jfail);
+    gencall_noret(fail_float_input);
+    rj_patch_near(jpass1);
+    rj_patch_near(jpass2);
+}
+
+void gencheck_output_d_xmm(int32_t xmm)
+{
+    if (!g_core->cfg->float_exception_emulation) return;
+
+    movaps_xmm_xmm(CHKX_VAL, xmm);
+    loadx_const_d(&sse_abs_mask_d);
+    andpd_xmm_xmm(CHKX_VAL, CHKX_TMP);
+    loadx_const_d(&largest_denormal_double);
+    ucomisd_xmm_xmm(CHKX_VAL, CHKX_TMP);
+    ja_near_rj(0);
+    int32_t jdone1 = code_length - 4;
+    jp_near_rj(0);
+    int32_t jfail = code_length - 4;
+    loadx_const_d(&sse_sign_mask_d);
+    andpd_xmm_xmm(xmm, CHKX_TMP);
+    jmp_near_rj(0);
+    int32_t jdone2 = code_length - 4;
+    rj_patch_near(jfail);
+    gencall_noret(fail_float_output);
+    rj_patch_near(jdone1);
+    rj_patch_near(jdone2);
 }
 
 // ROUND/CEIL/FLOOR: temporarily force the SSE rounding mode (MXCSR RC bits 13-14), then a

--- a/src/Core/R4300/x86_64/GCop1S.cpp
+++ b/src/Core/R4300/x86_64/GCop1S.cpp
@@ -9,6 +9,7 @@
 #include <R4300/R4300.hpp>
 #include <R4300/Recomph.hpp>
 #include <R4300/x86_64/Assemble.hpp>
+#include <R4300/x86_64/FprCache.hpp>
 #include <R4300/x86_64/Gcop1Helpers.hpp>
 #include <R4300/Cop1Helpers.hpp>
 #include <R4300/Ops.hpp>
@@ -42,11 +43,11 @@ static void gen_fcr31_clear_c()
 }
 static void gen_cmp_load_s()
 {
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    movss_xmm_preg64(0, EAX); // xmm0 = fs
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.ft]));
-    movss_xmm_preg64(1, EAX); // xmm1 = ft
-    ucomiss_xmm_xmm(0, 1);
+    const int32_t s = fpr_cache_read(dst->f.cf.fs);
+    fpr_cache_lock(s);
+    const int32_t t = fpr_cache_read(dst->f.cf.ft);
+    fpr_cache_unlock_all();
+    ucomiss_xmm_xmm(s, t);
 }
 // C = 1 when `jset` is taken (UN=jp, UEQ=je, ULT=jb, ULE=jbe). Assumes cop1 check already emitted.
 static void ccond_setjump_body_s(void (*jset)(unsigned char))
@@ -82,6 +83,7 @@ static void ccond_clearjump_body_s(void (*jclear2)(unsigned char))
 static void ccond_signaling_nan_s()
 {
     gen_cmp_load_s();
+    fpr_cache_flush();
     jp_rj(0);
     int32_t jf = code_length - 1;
     jmp_imm_short(0);
@@ -92,27 +94,101 @@ static void ccond_signaling_nan_s()
 }
 static void gen_ccond_setjump_s(void (*jset)(unsigned char))
 {
+    fpr_cache_begin(false);
     gencheck_cop1_unusable();
     ccond_setjump_body_s(jset);
+    fpr_cache_end();
 }
 static void gen_ccond_clearjump_s(void (*jclear2)(unsigned char))
 {
+    fpr_cache_begin(false);
     gencheck_cop1_unusable();
     ccond_clearjump_body_s(jclear2);
+    fpr_cache_end();
 }
 // Signaling ordered compares (LT/NGE=jae, LE/NGT=ja, SEQ/NGL=jne): NaN fail (toggle-gated) + ordered predicate.
 static void gen_ccond_sig_clearjump_s(void (*jclear2)(unsigned char))
 {
+    fpr_cache_begin(false);
     gencheck_cop1_unusable();
     if (g_core->cfg->float_exception_emulation) ccond_signaling_nan_s();
     ccond_clearjump_body_s(jclear2);
+    fpr_cache_end();
 }
 // Signaling SF/NGLE: NaN fail (toggle-gated) + always clear.
 static void gen_ccond_sig_clear_s()
 {
+    fpr_cache_begin(false);
     gencheck_cop1_unusable();
     if (g_core->cfg->float_exception_emulation) ccond_signaling_nan_s();
     gen_fcr31_clear_c();
+    fpr_cache_end();
+}
+
+#define ARITH_TMP 0
+
+static void emit_binop_s(void (*op)(int32_t, int32_t), int32_t d, int32_t s, int32_t t)
+{
+    if (d == s)
+    {
+        op(d, t);
+    }
+    else if (d == t)
+    {
+        movaps_xmm_xmm(ARITH_TMP, t);
+        movaps_xmm_xmm(d, s);
+        op(d, ARITH_TMP);
+    }
+    else
+    {
+        movaps_xmm_xmm(d, s);
+        op(d, t);
+    }
+}
+
+static uint32_t neg_abs_mask_s = 0x7FFFFFFF;
+static uint32_t neg_sign_mask_s = 0x80000000;
+
+static void apply_mask_s(int32_t d, void *mask, void (*op)(int32_t, int32_t))
+{
+    mov_reg64_imm64(EBX, (uintptr_t)mask);
+    movss_xmm_preg64(ARITH_TMP, EBX);
+    op(d, ARITH_TMP);
+}
+
+static void gen_unop_s(int32_t *s_out, int32_t *d_out, bool check_input)
+{
+    fpr_cache_begin(false);
+    gencheck_cop1_unusable();
+
+    const int32_t s = fpr_cache_read(dst->f.cf.fs);
+    fpr_cache_lock(s);
+    if (check_input) gencheck_input_s_xmm(s);
+    const int32_t d = fpr_cache_write(dst->f.cf.fd);
+    fpr_cache_unlock_all();
+
+    *s_out = s;
+    *d_out = d;
+}
+
+static void gen_arith_s(void (*op)(int32_t, int32_t))
+{
+    fpr_cache_begin(false);
+    gencheck_cop1_unusable();
+
+    const int32_t s = fpr_cache_read(dst->f.cf.fs);
+    fpr_cache_lock(s);
+    const int32_t t = fpr_cache_read(dst->f.cf.ft);
+    fpr_cache_lock(t);
+    gencheck_input_s_xmm(s);
+    gencheck_input_s_xmm(t);
+
+    const int32_t d = fpr_cache_write(dst->f.cf.fd);
+    fpr_cache_unlock_all();
+    emit_binop_s(op, d, s, t);
+    gencheck_output_s_xmm(d);
+
+    fpr_cache_end();
 }
 
 void genadd_s()
@@ -123,16 +199,7 @@ void genadd_s()
     // SSE port: bit-exact with the interpreter (same SSE add + same MXCSR rounding,
     // maintained by the interpreted CTC1 -> fesetround). Denormal/NaN handled by the
     // SSE gencheck_input_s/gencheck_output_s (mirror CHECK_INPUT/CHECK_OUTPUT).
-    gencheck_cop1_unusable();
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.ft]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    movss_xmm_preg64(0, EAX); // xmm0 = fs
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.ft]));
-    addss_xmm_preg64(0, EAX); // xmm0 += ft
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fd]));
-    movss_preg64_xmm(EAX, 0); // fd = xmm0
-    gencheck_output_s((void *)(&reg_cop1_simple[dst->f.cf.fd]));
+    gen_arith_s(addss_xmm_xmm);
 #endif
 }
 
@@ -141,16 +208,7 @@ void gensub_s()
 #ifdef INTERPRET_SUB_S
     gencallinterp((uintptr_t)SUB_S, 0);
 #else
-    gencheck_cop1_unusable();
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.ft]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    movss_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.ft]));
-    subss_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fd]));
-    movss_preg64_xmm(EAX, 0);
-    gencheck_output_s((void *)(&reg_cop1_simple[dst->f.cf.fd]));
+    gen_arith_s(subss_xmm_xmm);
 #endif
 }
 
@@ -159,16 +217,7 @@ void genmul_s()
 #ifdef INTERPRET_MUL_S
     gencallinterp((uintptr_t)MUL_S, 0);
 #else
-    gencheck_cop1_unusable();
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.ft]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    movss_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.ft]));
-    mulss_xmm_preg64(0, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fd]));
-    movss_preg64_xmm(EAX, 0);
-    gencheck_output_s((void *)(&reg_cop1_simple[dst->f.cf.fd]));
+    gen_arith_s(mulss_xmm_xmm);
 #endif
 }
 
@@ -177,16 +226,7 @@ void gendiv_s()
 #ifdef INTERPRET_DIV_S
     gencallinterp((uintptr_t)DIV_S, 0);
 #else
-    gencheck_cop1_unusable();
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.ft]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    movss_xmm_preg64(0, EAX); // xmm0 = fs
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.ft]));
-    divss_xmm_preg64(0, EAX); // xmm0 /= ft
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fd]));
-    movss_preg64_xmm(EAX, 0); // fd = xmm0
-    gencheck_output_s((void *)(&reg_cop1_simple[dst->f.cf.fd]));
+    gen_arith_s(divss_xmm_xmm);
 #endif
 }
 
@@ -196,15 +236,13 @@ void gensqrt_s()
     gencallinterp((uintptr_t)SQRT_S, 0);
 #else
     // sqrt in DOUBLE then narrow: interpreter does (float)sqrt((double)fs), not sqrtf.
-    gencheck_cop1_unusable();
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    cvtss2sd_xmm_preg64(0, EAX); // xmm0 = (double)fs
-    sqrtsd_xmm_xmm(0, 0);        // xmm0 = sqrt(xmm0)
-    cvtsd2ss_xmm_xmm(0, 0);      // xmm0 = (float)xmm0
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fd]));
-    movss_preg64_xmm(EAX, 0); // fd = xmm0
-    gencheck_output_s((void *)(&reg_cop1_simple[dst->f.cf.fd]));
+    int32_t s, d;
+    gen_unop_s(&s, &d, true);
+    cvtss2sd_xmm_xmm(d, s);
+    sqrtsd_xmm_xmm(d, d);
+    cvtsd2ss_xmm_xmm(d, d);
+    gencheck_output_s_xmm(d);
+    fpr_cache_end();
 #endif
 }
 
@@ -214,13 +252,11 @@ void genabs_s()
     gencallinterp((uintptr_t)ABS_S, 0);
 #else
     // fabs = clear the sign bit (bit-exact; ABS cannot fail, no output check).
-    gencheck_cop1_unusable();
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    mov_reg32_preg32(EBX, EAX);
-    and_reg32_imm32(EBX, 0x7FFFFFFF);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fd]));
-    mov_preg32_reg32(EAX, EBX);
+    int32_t s, d;
+    gen_unop_s(&s, &d, true);
+    if (d != s) movaps_xmm_xmm(d, s);
+    apply_mask_s(d, &neg_abs_mask_s, andps_xmm_xmm);
+    fpr_cache_end();
 #endif
 }
 
@@ -229,13 +265,10 @@ void genmov_s()
 #ifdef INTERPRET_MOV_S
     gencallinterp((uintptr_t)MOV_S, 0);
 #else
-    // Raw 32-bit copy (no check). 64-bit pointer loads (the old mov_eax_memoffs32
-    // truncated the FPR pointer on x64).
-    gencheck_cop1_unusable();
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    mov_reg32_preg32(EBX, EAX);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fd]));
-    mov_preg32_reg32(EAX, EBX);
+    int32_t s, d;
+    gen_unop_s(&s, &d, false);
+    if (d != s) movaps_xmm_xmm(d, s);
+    fpr_cache_end();
 #endif
 }
 
@@ -245,13 +278,11 @@ void genneg_s()
     gencallinterp((uintptr_t)NEG_S, 0);
 #else
     // Negate = flip the sign bit (bit-exact; NEG cannot fail, no output check).
-    gencheck_cop1_unusable();
-    gencheck_input_s((void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fs]));
-    mov_reg32_preg32(EBX, EAX);
-    xor_reg32_imm32(EBX, 0x80000000);
-    mov_reg64_m64(EAX, (void *)(&reg_cop1_simple[dst->f.cf.fd]));
-    mov_preg32_reg32(EAX, EBX);
+    int32_t s, d;
+    gen_unop_s(&s, &d, true);
+    if (d != s) movaps_xmm_xmm(d, s);
+    apply_mask_s(d, &neg_sign_mask_s, xorps_xmm_xmm);
+    fpr_cache_end();
 #endif
 }
 

--- a/src/Core/R4300/x86_64/GR4300.cpp
+++ b/src/Core/R4300/x86_64/GR4300.cpp
@@ -13,6 +13,7 @@
 #include <R4300/R4300.hpp>
 #include <R4300/Recomph.hpp>
 #include <R4300/x86_64/Assemble.hpp>
+#include <R4300/x86_64/FprCache.hpp>
 #include <R4300/x86_64/RegCache.hpp>
 #include <Alloc.hpp>
 
@@ -108,6 +109,7 @@ void gendelayslot()
     mov_m32_imm32((void *)(&delay_slot), 1);
     recompile_opcode();
 
+    fpr_cache_flush();
     free_all_registers();
     genupdate_count(dst->addr + 4);
 
@@ -1831,19 +1833,18 @@ inline void put8gr(unsigned char octet)
 
 void gencheck_cop1_unusable()
 {
-    uint32_t temp, temp2;
     free_all_registers();
     simplify_access();
+    fpr_cache_mark_live();
     test_m32_imm32((uint32_t *)&core_Status, 0x20000000);
-    jne_rj(0);
-    temp = code_length;
+    jne_near_rj(0);
+    const int32_t jfast = code_length - 4;
 
+    fpr_cache_spill_live();
     gencallinterp((uintptr_t)check_cop1_unusable, 0);
+    fpr_cache_reload_live();
 
-    temp2 = code_length;
-    code_length = temp - 1;
-    put8gr(temp2 - temp);
-    code_length = temp2;
+    rj_patch_near(jfast);
 }
 
 void genlwc1()

--- a/src/Core/R4300/x86_64/Gcop1Helpers.hpp
+++ b/src/Core/R4300/x86_64/Gcop1Helpers.hpp
@@ -12,6 +12,11 @@ void gencheck_output_s(void *fpr_slot);
 void gencheck_input_d(void *fpr_slot);
 void gencheck_output_d(void *fpr_slot);
 
+void gencheck_input_s_xmm(int32_t xmm);
+void gencheck_output_s_xmm(int32_t xmm);
+void gencheck_input_d_xmm(int32_t xmm);
+void gencheck_output_d_xmm(int32_t xmm);
+
 // ROUND/CEIL/FLOOR SSE rounding-mode swap (MXCSR). rc_bits: nearest=0, floor=0x2000, ceil=0x4000.
 void gen_mxcsr_set_round(uint32_t rc_bits);
 void gen_mxcsr_restore();

--- a/src/Core/R4300/x86_64/RegCache.cpp
+++ b/src/Core/R4300/x86_64/RegCache.cpp
@@ -772,6 +772,9 @@ void build_wrapper(precomp_instr *instr, unsigned char *code, precomp_block *blo
     int32_t i;
     int32_t j = 0;
 
+    static_assert(8 * 13 + FPR_CACHE_SLOTS * 18 + 27 <= sizeof(reg_cache_struct::jump_wrapper),
+                  "jump_wrapper is too small for the reloads build_wrapper emits");
+
     // Reload needed registers, then jump to block->code + local_addr (R10 scratch, R11 target).
     // Must NOT touch RSP: always entered via `jmp` at the block's canonical RSP%16==8 (passe2 stub,
     // genjr/jalr fast paths, and the dyna_jump thunk which already did `add rsp,8`). A `sub rsp,8`
@@ -792,6 +795,26 @@ void build_wrapper(precomp_instr *instr, unsigned char *code, precomp_block *blo
             code[j++] = 0x8B;
             code[j++] = (i << 3) | 0x02;
         }
+    }
+
+    for (i = 0; i < FPR_CACHE_SLOTS; i++)
+    {
+        if (instr->reg_cache_infos.needed_xmm[i] == NULL) continue;
+
+        code[j++] = 0x49;
+        code[j++] = 0xBA;
+        *((uintptr_t *)&code[j]) = (uintptr_t)instr->reg_cache_infos.needed_xmm[i];
+        j += 8;
+
+        code[j++] = 0x4D;
+        code[j++] = 0x8B;
+        code[j++] = 0x12;
+
+        code[j++] = instr->reg_cache_infos.needed_xmm_double[i] ? 0xF2 : 0xF3;
+        code[j++] = 0x41;
+        code[j++] = 0x0F;
+        code[j++] = 0x10;
+        code[j++] = (unsigned char)(((FPR_CACHE_XMM_BASE + i) << 3) | 0x02);
     }
 
     // Compute the target at RUNTIME from the live fields, not a baked absolute: block->code moves
@@ -838,10 +861,18 @@ void build_wrappers(precomp_instr *instr, int32_t start, int32_t end, precomp_bl
             if (instr[i].reg_cache_infos.needed_registers[reg] != NULL)
             {
                 instr[i].reg_cache_infos.need_map = 1;
-                build_wrapper(&instr[i], instr[i].reg_cache_infos.jump_wrapper, block);
                 break;
             }
         }
+        for (reg = 0; reg < FPR_CACHE_SLOTS; reg++)
+        {
+            if (instr[i].reg_cache_infos.needed_xmm[reg] != NULL)
+            {
+                instr[i].reg_cache_infos.need_map = 1;
+                break;
+            }
+        }
+        if (instr[i].reg_cache_infos.need_map) build_wrapper(&instr[i], instr[i].reg_cache_infos.jump_wrapper, block);
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #854. COP1 codegen reloaded every operand through the FPR pointer tables and stored the result back on every instruction. This keeps FPR values in xmm registers across consecutive COP1 instructions instead.

Answers to the open questions on the issue:

- **Keyed by FGR index, no flush on FR change.** Within one width, distinct indices never alias whatever FR is: FR=1 maps `i` to `&fgr[i]`, FR=0 to `&fgr[i>>1] + (i&1)`, and `i>>1` with `i&1` recover `i`. The pointer is still read at run time, so emitted code stays FR-agnostic.
- **No per-slot width.** Aliasing *between* widths does depend on FR (`simple[3]` is the high half of `double[2]` when FR=0), so the cache holds one width at a time and writes back when it changes. Free in practice `CVT.D.S` / `CVT.S.D` are not on the cache.

## Changes

- `FprCache.{hpp,cpp}`: 3 slots in `xmm3`-`xmm5` (ABI-volatile on both Win64 and System V, so neither the entry trampoline nor `dyna_stop` has to preserve them), LRU with pinning, spill/fill through the pointer table.
- `reg_cache_struct` gains `needed_xmm`; `build_wrapper` reloads live slots on block re-entry.
- `fpr_cache_gate()` flushes ahead of any instruction not explicitly on the cache, so an unaccounted-for opcode loses the optimisation instead of reading a stale FPR.
- `gendelayslot()` flushes, for the same reason `free_all_registers()` is already called there.
- `gencheck_cop1_unusable()` spills before the interpreter call and reloads after; its guard jump becomes near since the cold path now scales with live slot count.
- `.S` and `.D` arithmetic, `SQRT`, `ABS`, `MOV`, `NEG` and all compares run on the cache. Conversions and load/stores are untouched.

## Testing

Built and run at each of the five steps this was developed in, the next only written once the previous ran. SM64 boots and plays with `float_exception_emulation` both off and on.

**Draft because none of the validation that matters is done yet:** no bit-exactness comparison against the interpreter, none against x86, and no perf measurement so there is currently no evidence for the premise of the issue. I will post all three before marking this ready.

## Known limitations

- `ABS` / `NEG` move from integer `and`/`xor` through a GPR to `andps`/`xorps` against the same mask same bit operation, different encoding.
- 3 slots, limited by staying in the volatile xmm range. Wider means saving `xmm6`-`xmm15` in the trampoline and handling `dyna_stop`; separate change, only if measurements justify it.
- `FPR_CACHE_PERSIST` switches cross-instruction caching off, falling back to a per-instruction cache. Kept as a bisection handle, happy to drop it.

## Checklist

- [ ] Tests pass `src/Core.Tests` does not cover the dynarec; the validation this needs is the comparison above.
- [ ] Documentation updated no user-facing change.
- [ ] No breaking changes behavioural equivalence is exactly what is not yet proven.
