### PR TITLE
fix(CLI): failure to start ROMs due to them being treated like movies

### DIFF
--- a/src/Views.Win32/components/CLI.cpp
+++ b/src/Views.Win32/components/CLI.cpp
@@ -286,7 +286,7 @@ void CLI::init()
         cli_state.is_movie_from_start = hdr.startFlags & MOVIE_START_FROM_NOTHING;
     }
 
-    cli_state.rom_is_movie = cli_params.rom.extension().compare(L".m64");
+    cli_state.rom_is_movie = cli_params.rom.extension().compare(L".m64") == 0;
 
     log_cli_params(cli_params);
 }


### PR DESCRIPTION
This pull request makes a small but important fix to the logic that determines if the loaded ROM is a movie file. The comparison now correctly checks for equality, ensuring that `cli_state.rom_is_movie` is set only when the file extension is exactly `.m64`.