### PR TITLE
fix(FFmpegEncoder): space in output path causing capture failure

### DIFF
--- a/src/Views.Win32/capture/encoders/FFmpegEncoder.cpp
+++ b/src/Views.Win32/capture/encoders/FFmpegEncoder.cpp
@@ -10,7 +10,7 @@
 #include <Config.hpp>
 
 const std::wstring NUT_PIPE_NAME = L"\\\\.\\pipe\\mupennut";
-const std::wstring FFMPEG_OPTIONS = L"-y -i {} {} {}";
+const std::wstring FFMPEG_OPTIONS = L"-y -i {} {} \"{}\"";
 
 struct PipeIO
 {


### PR DESCRIPTION
Closes #941