### PR TITLE
fix(TASVideo): fix broken shaders after ROM reset

### DIFF
--- a/src/Plugins.Win32.TASVideo/RSP.cpp
+++ b/src/Plugins.Win32.TASVideo/RSP.cpp
@@ -58,6 +58,7 @@ DWORD WINAPI RSP_ThreadProc(LPVOID)
         {
         case WAIT_OBJECT_0 + RSPMSG_CLOSE:
             OGL_Stop();
+            OGL_DestroyContext();
             SetEvent(RSP.threadFinished);
             return 0;
         case WAIT_OBJECT_0 + RSPMSG_START:


### PR DESCRIPTION
This pull request addresses a critical issue with OpenGL context management during ROM resets in the RSP thread. The main change ensures that the OpenGL context is properly destroyed when the thread is closed, preventing failures when the context is re-initialized on a new thread.

**OpenGL context management:**

* Added a call to `OGL_DestroyContext()` in the `RSP_ThreadProc` function (in `src/Plugins.Win32.TASVideo/RSP.cpp`) when handling the `RSPMSG_CLOSE` message, ensuring the GL context is torn down before the thread exits. This prevents initialization issues when restarting the ROM, as the context will be correctly re-created for the new thread.

changelog: skip