### PR TITLE
fix(LuaDialog): rare crash when closing dialog

### DIFF
--- a/src/Views.Win32/lua/LuaDialog.cpp
+++ b/src/Views.Win32/lua/LuaDialog.cpp
@@ -308,17 +308,28 @@ static void add_and_start(const std::filesystem::path &path)
     start(*ctx, path);
 }
 
+static bool instance_context_alive(const t_instance_context *ctx)
+{
+    return ctx && std::ranges::any_of(g_lua_instance_wnd_ctxs, [&](const auto &c) { return c.get() == ctx; });
+}
+
 static INT_PTR CALLBACK lua_instance_dialog_proc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
+    if (msg == WM_INITDIALOG)
+    {
+        SetWindowLongPtr(hwnd, GWLP_USERDATA, lparam);
+    }
+
     auto ctx = (t_instance_context *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+
+    if (!instance_context_alive(ctx))
+    {
+        return FALSE;
+    }
 
     switch (msg)
     {
     case WM_INITDIALOG:
-        SetWindowLongPtr(hwnd, GWLP_USERDATA, lparam);
-
-        ctx = (t_instance_context *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
-
         ctx->hwnd = hwnd;
 
         Edit_SetText(GetDlgItem(hwnd, IDC_PATH), ctx->typed_path.string().c_str());
@@ -364,7 +375,7 @@ static INT_PTR CALLBACK lua_instance_dialog_proc(HWND hwnd, UINT msg, WPARAM wpa
             break;
         }
         case IDC_START: {
-            const auto path = get_window_text(GetDlgItem(ctx->hwnd, IDC_PATH)).value();
+            const auto path = get_window_text(GetDlgItem(hwnd, IDC_PATH)).value_or(ctx->typed_path.string());
             start(*ctx, path);
             break;
         }


### PR DESCRIPTION
This pull request improves the stability and robustness of the Lua dialog window in the Win32 UI by adding context validation and enhancing input handling. The main changes focus on ensuring that dialog operations only proceed when the instance context is valid, and making the dialog more resilient to user input errors.

**Dialog context validation and input handling improvements:**

* Added the `instance_context_alive` function to check if a given `t_instance_context` pointer is still valid and associated with an active dialog, preventing operations on destroyed or invalid contexts.
* Updated `lua_instance_dialog_proc` to use `instance_context_alive` for early exit if the dialog context is no longer alive, reducing the risk of crashes or undefined behavior.
* Changed the handling of the `IDC_START` button so that if the path field is empty, it falls back to the context's stored path (`ctx->typed_path.string()`), improving robustness against missing or invalid user input.…log proc