### PR TITLE
fix: rename plugin t_config types to avoid collisions

### DIFF
--- a/src/Plugins.TASRSP/Config.cpp
+++ b/src/Plugins.TASRSP/Config.cpp
@@ -9,9 +9,9 @@
 
 #define CONFIG_FILE_NAME "TASRSP.json"
 
-t_config config = {};
-t_config default_config = {};
-t_config prev_config = {};
+t_rsp_config config = {};
+t_rsp_config default_config = {};
+t_rsp_config prev_config = {};
 
 static std::filesystem::path get_config_path()
 {

--- a/src/Plugins.TASRSP/Config.hpp
+++ b/src/Plugins.TASRSP/Config.hpp
@@ -8,11 +8,11 @@
 
 #include <nlohmann/json.hpp>
 
-struct t_config
+struct t_rsp_config
 {
     int32_t version = 2;
 
-    friend void to_json(nlohmann::json &j, const t_config &self)
+    friend void to_json(nlohmann::json &j, const t_rsp_config &self)
     {
 #define TASRSP_FIELD(field) {#field, self.field}
         j = nlohmann::json::object({
@@ -21,16 +21,16 @@ struct t_config
 #undef TASRSP_FIELD
     }
 
-    friend void from_json(const nlohmann::json &j, t_config &self)
+    friend void from_json(const nlohmann::json &j, t_rsp_config &self)
     {
-        if (!j.is_object()) throw std::domain_error("t_config expected JSON object");
+        if (!j.is_object()) throw std::domain_error("t_rsp_config expected JSON object");
 #define TASRSP_FIELD(field) nlohmann::from_json(j.at(#field), self.field)
         TASRSP_FIELD(version);
 #undef TASRSP_FIELD
     }
 };
 
-extern t_config config;
+extern t_rsp_config config;
 
 /**
  * \brief Saves the config

--- a/src/Plugins.Win32.TASInput/ConfigDialog.cpp
+++ b/src/Plugins.Win32.TASInput/ConfigDialog.cpp
@@ -22,7 +22,7 @@ struct config_dialog_context
 {
     HWND hwnd{};
     HWND devices_hwnd{};
-    t_config prev_config{};
+    t_input_config prev_config{};
     size_t selected_controller{};
     std::variant<std::monostate, t_button_mapping *, t_axis_mapping *> target_value{};
     bool positive_target_axis{};
@@ -412,7 +412,7 @@ static LRESULT CALLBACK dlgproc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lpara
             EndDialog(hwnd, IDCANCEL);
             break;
         case IDC_B_CLEAR:
-            new_config = t_config{};
+            new_config = t_input_config{};
             update_visuals();
             break;
         case IDC_COMBOCONT: {

--- a/src/Plugins.Win32.TASInput/NewConfig.cpp
+++ b/src/Plugins.Win32.TASInput/NewConfig.cpp
@@ -10,8 +10,8 @@
 #include <Main.hpp>
 #include <GamepadManager.hpp>
 
-const t_config default_config{};
-t_config new_config{};
+const t_input_config default_config{};
+t_input_config new_config{};
 
 static std::filesystem::path get_config_path()
 {

--- a/src/Plugins.Win32.TASInput/NewConfig.hpp
+++ b/src/Plugins.Win32.TASInput/NewConfig.hpp
@@ -205,7 +205,7 @@ struct t_controller_config
     }
 };
 
-struct t_config
+struct t_input_config
 {
     int32_t version = 7;
     int32_t always_on_top = false;
@@ -223,7 +223,7 @@ struct t_config
     t_controller_config controller_config[4] = {t_controller_config::keyboard_config(), {}, {}, {}};
     std::optional<SDL_GUID> preferred_device_guid;
 
-    friend void to_json(nlohmann::json &j, const t_config &self)
+    friend void to_json(nlohmann::json &j, const t_input_config &self)
     {
 #define TASINPUT_FIELD(field) {#field, self.field}
 #define TASINPUT_ARRAY_FIELD(field) nlohmann::to_json(j[#field], self.field)
@@ -247,9 +247,9 @@ struct t_config
 #undef TASINPUT_ARRAY_FIELD
     }
 
-    friend void from_json(const nlohmann::json &j, t_config &self)
+    friend void from_json(const nlohmann::json &j, t_input_config &self)
     {
-        if (!j.is_object()) throw std::domain_error("t_config expected JSON object");
+        if (!j.is_object()) throw std::domain_error("t_input_config expected JSON object");
 #define TASINPUT_FIELD(field) nlohmann::from_json(j.at(#field), self.field)
         self = {};
         TASINPUT_FIELD(version);
@@ -273,7 +273,7 @@ struct t_config
     }
 };
 
-extern t_config new_config;
+extern t_input_config new_config;
 
 /**
  * \brief Saves the current config to a file

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -1068,7 +1068,7 @@ bool Status::show_context_menu(int x, int y)
 
     // HACK: disable topmost so menu doesnt appear under tasinput
     hmenu = CreatePopupMenu();
-#define ADD_ITEM(hmenu, x, y) AppendMenu(hmenu, new_config.x ? MF_CHECKED : 0, offsetof(t_config, x), y)
+#define ADD_ITEM(hmenu, x, y) AppendMenu(hmenu, new_config.x ? MF_CHECKED : 0, offsetof(t_input_config, x), y)
     ADD_ITEM(hmenu, relative_mode, "Relative");
     ADD_ITEM(hmenu, approach_mode, "Approach");
     AppendMenu(hmenu, MF_SEPARATOR, 0, NULL);


### PR DESCRIPTION
TASRSP and TASInput both call their config type `t_config`. Now that the plugins are statically linked, the names overlap and TASInput's settings no longer save.

This PR renames them to `t_rsp_config` and `t_input_config`.

Closes #982.

changelog: skip