### PR TITLE
feat(TASInput): make wraparound behavior optional 

### DIFF
--- a/src/Common.Win32/include/JoystickControl.hpp
+++ b/src/Common.Win32/include/JoystickControl.hpp
@@ -94,8 +94,8 @@ inline void update_joystick_position(HWND hwnd, Context *ctx)
     RECT rc{};
     GetClientRect(hwnd, &rc);
 
-    if (std::abs(ctx->x) <= 8) ctx->x = 0;
-    if (std::abs(ctx->y) <= 8) ctx->y = 0;
+    if (std::abs(ctx->x) < 8) ctx->x = 0;
+    if (std::abs(ctx->y) < 8) ctx->y = 0;
 
     ctx->x = std::clamp(ctx->x, -128, 127);
     ctx->y = std::clamp(ctx->y, -128, 127);

--- a/src/Plugins.Win32.TASInput/NewConfig.hpp
+++ b/src/Plugins.Win32.TASInput/NewConfig.hpp
@@ -220,6 +220,7 @@ struct t_config
     // Increments joystick position by the value of the magnitude slider when moving via keyboard or gamepad
     int32_t relative_mode = false;
     int32_t approach_mode = false;
+    int32_t wrap_joystick = false;
     t_controller_config controller_config[4] = {t_controller_config::keyboard_config(), {}, {}, {}};
     std::optional<SDL_GUID> preferred_device_guid;
 
@@ -236,6 +237,7 @@ struct t_config
             TASINPUT_FIELD(loop_combo),
             TASINPUT_FIELD(relative_mode),
             TASINPUT_FIELD(approach_mode),
+            TASINPUT_FIELD(wrap_joystick),
             TASINPUT_FIELD(preferred_device_guid),
         });
         TASINPUT_ARRAY_FIELD(dialog_expanded);
@@ -262,6 +264,7 @@ struct t_config
             TASINPUT_FIELD(loop_combo);
             TASINPUT_FIELD(relative_mode);
             TASINPUT_FIELD(approach_mode);
+            TASINPUT_FIELD(wrap_joystick);
             TASINPUT_FIELD(dialog_expanded);
             TASINPUT_FIELD(controller_active);
             TASINPUT_FIELD(controller_mempak);

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -878,14 +878,28 @@ INT_PTR CALLBACK wndproc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
         case IDC_X_DOWN:
         case IDC_X_UP: {
             int increment = get_joystick_increment(LOWORD(wparam) == IDC_X_UP);
-            ctx->current_input.x = MiscHelpers::wrapping_clamp(ctx->current_input.x + increment, -128, 127);
+            if (new_config.wrap_joystick)
+            {
+                ctx->current_input.x = MiscHelpers::wrapping_clamp(ctx->current_input.x + increment, -128, 127);
+            }
+            else
+            {
+                ctx->current_input.x = std::clamp(ctx->current_input.x + increment, -128, 127);
+            }
             ctx->set_visuals(ctx->current_input);
         }
         break;
         case IDC_Y_DOWN:
         case IDC_Y_UP: {
             int increment = get_joystick_increment(LOWORD(wparam) == IDC_Y_UP);
-            ctx->current_input.y = MiscHelpers::wrapping_clamp(ctx->current_input.y + increment, -128, 127);
+            if (new_config.wrap_joystick)
+            {
+                ctx->current_input.y = MiscHelpers::wrapping_clamp(ctx->current_input.y + increment, -128, 127);
+            }
+            else
+            {
+                ctx->current_input.y = std::clamp(ctx->current_input.y + increment, -128, 127);
+            }
             ctx->set_visuals(ctx->current_input);
         }
         break;
@@ -1071,6 +1085,7 @@ bool Status::show_context_menu(int x, int y)
 #define ADD_ITEM(hmenu, x, y) AppendMenu(hmenu, new_config.x ? MF_CHECKED : 0, offsetof(t_config, x), y)
     ADD_ITEM(hmenu, relative_mode, "Relative");
     ADD_ITEM(hmenu, approach_mode, "Approach");
+    ADD_ITEM(hmenu, wrap_joystick, "Wrap joystick");
     AppendMenu(hmenu, MF_SEPARATOR, 0, NULL);
     ADD_ITEM(hmenu, always_on_top, "Always on top");
     ADD_ITEM(hmenu, float_from_parent, "Float from parent");


### PR DESCRIPTION
This PR adds a toggle in the right click menu, allowing the incrementing of joystick values to either clamp to maximum, or wrap around if at maximum. It also fixes a bug which did not allow 8 to be a value which could be achieved by dragging the joystick. 